### PR TITLE
Add database reset and import script

### DIFF
--- a/Database/reset_database.py
+++ b/Database/reset_database.py
@@ -1,0 +1,61 @@
+import os
+import argparse
+import psycopg2
+from import_from_csv import get_table_order, import_csv
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+SQL_FILE = os.path.join(BASE_DIR, "01-createtables.sql")
+DB_CONFIG = {
+    "dbname": "nutrition",
+    "user": "nutrition_user",
+    "password": "nutrition_pass",
+    "host": "localhost",
+    "port": 5432,
+}
+
+def drop_all_tables(cur):
+    ordered = get_table_order(cur)
+    for table in reversed(ordered):
+        cur.execute(f"DROP TABLE IF EXISTS {table} CASCADE;")
+
+
+def create_schema(cur):
+    with open(SQL_FILE, "r", encoding="utf-8") as f:
+        cur.execute(f.read())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Recreate tables and import CSV data.")
+    parser.add_argument("--test", action="store_true", help="Use test CSV files")
+    args = parser.parse_args()
+
+    data_dir = os.path.join(BASE_DIR, "test_data" if args.test else "production_data")
+    mode = "TEST" if args.test else "PRODUCTION"
+    print(f"Running in {mode} mode — reading from: {data_dir}")
+
+    if not os.path.exists(data_dir):
+        print(f"Error: directory {data_dir} does not exist.")
+        return
+
+    try:
+        conn = psycopg2.connect(**DB_CONFIG)
+        cur = conn.cursor()
+
+        drop_all_tables(cur)
+        create_schema(cur)
+        conn.commit()
+
+        ordered_tables = get_table_order(cur)
+        print(f"Load order: {ordered_tables}")
+        import_csv(cur, data_dir, ordered_tables)
+
+        conn.commit()
+        cur.close()
+        conn.close()
+        print("Database reset and data imported successfully.")
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ To import test data
 python .\Database\import_from_csv.py --test
 ```
 
+To drop and recreate the tables before importing:
+
+```python
+python .\Database\reset_database.py
+```
+
+To reset with test data:
+
+```python
+python .\Database\reset_database.py --test
+```
+
 ### Local Development (non-Docker)
 
 **Backend:**


### PR DESCRIPTION
## Summary
- add reset_database.py to drop tables, recreate schema, and import CSV data
- document new reset workflow in README

## Testing
- `python -m py_compile Database/reset_database.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897f26c646483229bdee0f1ab61a56a