### PR TITLE
Fix unit selection crash in ingredient table

### DIFF
--- a/Frontend/nutrition-frontend/src/contexts/DataContext.js
+++ b/Frontend/nutrition-frontend/src/contexts/DataContext.js
@@ -107,6 +107,7 @@ export const DataProvider = ({ children }) => {
 
   const value = {
     ingredients,
+    setIngredients,
     ingredientProcessingTags,
     ingredientGroupTags,
     ingredientOtherTags,


### PR DESCRIPTION
## Summary
- expose `setIngredients` in `DataContext` so IngredientTable can update ingredient state when switching units

## Testing
- `cd Frontend/nutrition-frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6897f4c74ca48322bb8052aee309c9fb