### PR TITLE
Fix meal tag filter comparison by tag name

### DIFF
--- a/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
@@ -37,7 +37,7 @@ function MealTable({ onMealDoubleClick = () => {}, onMealCtrlClick = () => {} })
       return true; // Show all meals if no tags are selected
     }
     return selectedTags.some((selectedTag) => {
-      return ingredient.tags.some((tag) => tag.name === selectedTag);
+      return ingredient.tags.some((tag) => tag.name === selectedTag.name);
     });
   };
 


### PR DESCRIPTION
## Summary
- Fix meal tag filtering to compare selected tags by name

## Testing
- `npm test -- --watchAll=false`
- `node - <<'NODE'\nconst toggleTag = (selectedTags, tag) => selectedTags.includes(tag) ? selectedTags.filter(t => t !== tag) : [...selectedTags, tag];\nconst handleTagFilter = (ingredient, selectedTags) => selectedTags.length === 0 || selectedTags.some(sel => ingredient.tags.some(tag => tag.name === sel.name));\nconst tagA = {name: 'Protein'};\nconst tagB = {name: 'Vegan'};\nlet selected = [];\nselected = toggleTag(selected, tagA);\nselected = toggleTag(selected, tagB);\nconsole.log('Selected after add:', selected.map(t=>t.name));\nselected = toggleTag(selected, tagA);\nconsole.log('Selected after remove:', selected.map(t=>t.name));\nconst ingredient = {tags: [{name: 'Vegan'}]};\nconsole.log('Passes filter?', handleTagFilter(ingredient, selected));\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_6897f69b90288322b4e4e0a9d114cd34