### PR TITLE
Handle orphaned ingredient units on deletion

### DIFF
--- a/Backend/routes/ingredients.py
+++ b/Backend/routes/ingredients.py
@@ -124,6 +124,7 @@ def delete_ingredient(ingredient_id):
         return jsonify({'error': 'Ingredient not found'}), 404
 
     db_Nutrition.query.filter_by(ingredient_id=ingredient_id).delete()
+    db_IngredientUnit.query.filter_by(ingredient_id=ingredient_id).delete()
     db_IngredientTag.query.filter_by(ingredient_id=ingredient_id).delete()
     db.session.delete(ingredient)
     db.session.commit()


### PR DESCRIPTION
## Summary
- ensure ingredient deletion also removes associated units to avoid dangling records
- add trailing newline to ingredient routes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897f9593d788322a335530f4a8dff56