### PR TITLE
feat: add tabs for meals and ingredients

### DIFF
--- a/Frontend/nutrition-frontend/src/App.js
+++ b/Frontend/nutrition-frontend/src/App.js
@@ -1,5 +1,8 @@
 import React, { useState } from "react";
 // import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
 
 import { DataProvider } from "./contexts/DataContext";
 
@@ -15,9 +18,14 @@ import "./styles/App.css";
 
 function App() {
   const [selectedIngredients, setSelectedIngredients] = useState([]);
+  const [tabIndex, setTabIndex] = useState(0);
 
   const handleAddIngredientToPlan = (ingredient) => {
     setSelectedIngredients([...selectedIngredients, { ...ingredient, quantity: 1 }]);
+  };
+
+  const handleTabChange = (event, newValue) => {
+    setTabIndex(newValue);
   };
 
   // const handleRemoveIngredientFromPlan = (ingredientToRemove) => {
@@ -32,8 +40,20 @@ function App() {
   return (
     <div className="App">
       <DataProvider>
-        <MealData />
-        <IngredientData handleAddIngredientToPlan={handleAddIngredientToPlan} />
+        <Tabs value={tabIndex} onChange={handleTabChange} aria-label="data tabs">
+          <Tab label="Meals" id="tab-0" aria-controls="tabpanel-0" />
+          <Tab label="Ingredients" id="tab-1" aria-controls="tabpanel-1" />
+        </Tabs>
+        {tabIndex === 0 && (
+          <Box role="tabpanel" id="tabpanel-0" aria-labelledby="tab-0">
+            <MealData />
+          </Box>
+        )}
+        {tabIndex === 1 && (
+          <Box role="tabpanel" id="tabpanel-1" aria-labelledby="tab-1">
+            <IngredientData handleAddIngredientToPlan={handleAddIngredientToPlan} />
+          </Box>
+        )}
       </DataProvider>
 
       {/* <MacrosTable ingredients={selectedIngredients} />

--- a/Frontend/nutrition-frontend/src/tests/App.test.js
+++ b/Frontend/nutrition-frontend/src/tests/App.test.js
@@ -1,8 +1,62 @@
-import { render, screen } from "@testing-library/react";
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+var mockIngredientData;
+var mockMealData;
+
+jest.mock("../components/data/ingredient/IngredientData", () => ({
+  __esModule: true,
+  default: (...args) => mockIngredientData(...args),
+}));
+
+jest.mock("../components/data/meal/MealData", () => ({
+  __esModule: true,
+  default: (...args) => mockMealData(...args),
+}));
+
+mockIngredientData = jest.fn(() => <div>IngredientDataComponent</div>);
+mockMealData = jest.fn(() => <div>MealDataComponent</div>);
+
 import App from "../App";
 
-test("renders Add Meal button", () => {
-  render(<App />);
-  const buttonElement = screen.getByText(/Add Meal/i);
-  expect(buttonElement).toBeTruthy();
+beforeEach(() => {
+  jest.clearAllMocks();
 });
+
+test("renders tabs and switches between Meals and Ingredients views", () => {
+  render(<App />);
+
+  const mealsTab = screen.getByRole("tab", { name: /Meals/i });
+  const ingredientsTab = screen.getByRole("tab", { name: /Ingredients/i });
+
+  expect(mealsTab).toBeInTheDocument();
+  expect(ingredientsTab).toBeInTheDocument();
+
+  expect(mockMealData).toHaveBeenCalledTimes(1);
+  expect(mockIngredientData).not.toHaveBeenCalled();
+
+  fireEvent.click(ingredientsTab);
+  expect(mockIngredientData).toHaveBeenCalledTimes(1);
+  expect(mockMealData).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(mealsTab);
+  expect(mockMealData).toHaveBeenCalledTimes(2);
+  expect(mockIngredientData).toHaveBeenCalledTimes(1);
+});
+
+test("provides handleAddIngredientToPlan only to IngredientData", () => {
+  render(<App />);
+
+  // initial render shows MealData without the prop
+  expect(mockIngredientData).not.toHaveBeenCalled();
+  expect(mockMealData).toHaveBeenCalled();
+  expect(mockMealData.mock.calls[0][0].handleAddIngredientToPlan).toBeUndefined();
+
+  fireEvent.click(screen.getByRole("tab", { name: /Ingredients/i }));
+
+  expect(mockIngredientData).toHaveBeenCalled();
+  const props = mockIngredientData.mock.calls[0][0];
+  expect(props.handleAddIngredientToPlan).toBeInstanceOf(Function);
+});
+


### PR DESCRIPTION
## Summary
- add Material UI Tabs to switch between Meals and Ingredients tables

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897fa299cbc83228a16fe0900290bd9