### PR TITLE
Refactor database scripts and add venv setup

### DIFF
--- a/Database/activate_venv.ps1
+++ b/Database/activate_venv.ps1
@@ -1,0 +1,11 @@
+# Ensure the project's virtual environment exists and activate it
+
+param(
+    [string]$VenvPath = (Join-Path (Resolve-Path "$PSScriptRoot/..") ".venv")
+)
+
+if (-Not (Test-Path $VenvPath)) {
+    python -m venv $VenvPath
+}
+
+& "$VenvPath\Scripts\Activate.ps1"

--- a/Database/db_config.py
+++ b/Database/db_config.py
@@ -1,0 +1,16 @@
+"""Shared configuration for database scripts."""
+
+import os
+
+# Directory where the database scripts reside
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Default database connection settings
+DB_CONFIG = {
+    "dbname": "nutrition",
+    "user": "nutrition_user",
+    "password": "nutrition_pass",
+    "host": "localhost",
+    "port": 5432,
+}
+

--- a/Database/import_from_csv.py
+++ b/Database/import_from_csv.py
@@ -1,20 +1,17 @@
+"""Import CSV files into the PostgreSQL nutrition database.
+
+The script determines table dependency order using foreign key relationships,
+clears existing data, and loads table contents from CSV files located in either
+the ``production_data`` or ``test_data`` directory.
+"""
+
 import os
 import psycopg2
 import argparse
 import csv
 from collections import defaultdict, deque
 
-# Get the directory where this script lives
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
-# Database connection settings
-DB_CONFIG = {
-    "dbname": "nutrition",
-    "user": "nutrition_user",
-    "password": "nutrition_pass",
-    "host": "localhost",
-    "port": 5432
-}
+from db_config import DB_CONFIG, BASE_DIR
 
 def get_table_order(cur):
     # Get all public tables

--- a/Database/reset_database.py
+++ b/Database/reset_database.py
@@ -1,17 +1,17 @@
+"""Recreate the PostgreSQL nutrition database schema and import CSV data.
+
+This utility drops all existing tables, rebuilds them using the schema SQL file,
+and then populates the tables from CSV files in the ``production_data`` or
+``test_data`` directory.
+"""
+
 import os
 import argparse
 import psycopg2
 from import_from_csv import get_table_order, import_csv
+from db_config import DB_CONFIG, BASE_DIR
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 SQL_FILE = os.path.join(BASE_DIR, "01-createtables.sql")
-DB_CONFIG = {
-    "dbname": "nutrition",
-    "user": "nutrition_user",
-    "password": "nutrition_pass",
-    "host": "localhost",
-    "port": 5432,
-}
 
 def drop_all_tables(cur):
     ordered = get_table_order(cur)


### PR DESCRIPTION
## Summary
- document database scripts with module docstrings
- move shared database config to a dedicated module
- add PowerShell script to create (if needed) and activate the project’s virtual environment

## Testing
- `python -m py_compile Database/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6898111154d48322a7f6016bd9b87051