### PR TITLE
Fix main panel offset with explicit pixel margin

### DIFF
--- a/Frontend/nutrition-frontend/src/App.js
+++ b/Frontend/nutrition-frontend/src/App.js
@@ -70,7 +70,7 @@ function App() {
             </Tabs>
           </Box>
 
-          <Box sx={{ marginLeft: 200, flexGrow: 1 }}>
+          <Box sx={{ marginLeft: "200px", flexGrow: 1 }}>
             {activityTab === 0 && (
               <Box
                 role="tabpanel"


### PR DESCRIPTION
## Summary
- Correct main panel positioning by using an explicit 200px left margin

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68981729861c8322b888bcd492e4e628