### PR TITLE
Fix marshmallow fields import for ingredient and meal schemas

### DIFF
--- a/Backend/schemas/ingredient.py
+++ b/Backend/schemas/ingredient.py
@@ -1,4 +1,5 @@
-from marshmallow_sqlalchemy import SQLAlchemyAutoSchema, auto_field, fields
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema, auto_field
+from marshmallow import fields
 
 from db import db
 from db_models.ingredient import Ingredient

--- a/Backend/schemas/meal.py
+++ b/Backend/schemas/meal.py
@@ -1,4 +1,5 @@
-from marshmallow_sqlalchemy import SQLAlchemyAutoSchema, auto_field, fields
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema, auto_field
+from marshmallow import fields
 
 from db import db
 from db_models.meal import Meal


### PR DESCRIPTION
## Summary
- import field classes from `marshmallow` instead of `marshmallow_sqlalchemy`

## Testing
- `pytest`
- `python -m py_compile Backend/schemas/ingredient.py Backend/schemas/meal.py`
- `python Backend/backend.py` (fails: could not translate host name "nutrition-db" to address)

------
https://chatgpt.com/codex/tasks/task_e_6898200727f08322a38cee80540ee967