### PR TITLE
Make DB configuration configurable

### DIFF
--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from flask_cors import CORS
 
@@ -13,11 +15,15 @@ app.register_blueprint(ingredient_blueprint)
 app.register_blueprint(meal_blueprint)
 
 CORS(app)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://nutrition_user:nutrition_pass@nutrition-db:5432/nutrition'
+app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv(
+    'SQLALCHEMY_DATABASE_URI',
+    'postgresql://nutrition_user:nutrition_pass@nutrition-db:5432/nutrition'
+)
 db.init_app(app)
 
-with app.app_context():
-    db.create_all()
+if os.getenv('DB_AUTO_CREATE', '').lower() in ('1', 'true', 't'):
+    with app.app_context():
+        db.create_all()
 
 if __name__ == '__main__':
     app.run(debug = True, host='0.0.0.0')


### PR DESCRIPTION
## Summary
- load SQLAlchemy database URI from environment with default fallback
- gate `db.create_all()` behind `DB_AUTO_CREATE` env flag

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898203d9c64832283c05a5c1031dc7d