### PR TITLE
Center main panel layout

### DIFF
--- a/Frontend/nutrition-frontend/src/App.js
+++ b/Frontend/nutrition-frontend/src/App.js
@@ -76,9 +76,10 @@ function App() {
               flexGrow: 1,
               display: "flex",
               justifyContent: "center",
+              alignItems: "flex-start",
             }}
           >
-            <Box sx={{ width: "100%", maxWidth: 800 }}>
+            <Box sx={{ width: "100%", maxWidth: 800, mx: "auto" }}>
               {activityTab === 0 && (
                 <Box
                   role="tabpanel"

--- a/Frontend/nutrition-frontend/src/styles/App.css
+++ b/Frontend/nutrition-frontend/src/styles/App.css
@@ -1,7 +1,8 @@
 .App {
-  text-align: center;
   display: flex;
-  height: 100vh;
+  justify-content: center;
+  align-items: flex-start;
+  width: 100%;
 }
 
 .App-logo {


### PR DESCRIPTION
## Summary
- Align main app container to center content at top
- Allow inner content box to center horizontally with auto margins

## Testing
- `CI=true npm test -- --watchAll=false | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68991c2a47f08322ae84f0a7a42e79ec