### PR TITLE
Center search fields with MUI Box

### DIFF
--- a/Frontend/nutrition-frontend/src/components/data/ingredient/IngredientTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/ingredient/IngredientTable.js
@@ -1,7 +1,7 @@
 // IngredientTable.js
 
 import React, { useState } from "react";
-import { TextField, TableContainer, Table, TableHead, TableBody, TableRow, TableCell, Paper, MenuItem, Select, TablePagination } from "@mui/material";
+import { Box, TextField, TableContainer, Table, TableHead, TableBody, TableRow, TableCell, Paper, MenuItem, Select, TablePagination } from "@mui/material";
 
 import { useData } from "../../../contexts/DataContext";
 import { formatCellNumber } from "../../../utils/utils";
@@ -89,13 +89,14 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
     <div>
       <h1>Ingredients</h1>
 
-      <TextField
-        type="text"
-        label="Search by name"
-        value={search}
-        onChange={handleSearch}
-        style={{ marginBottom: "10px" }}
-      />
+      <Box sx={{ display: "flex", justifyContent: "center", mb: 2 }}>
+        <TextField
+          type="text"
+          label="Search by name"
+          value={search}
+          onChange={handleSearch}
+        />
+      </Box>
 
       <TagFilter
         tags={allIngredientTags}

--- a/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
@@ -1,7 +1,7 @@
 // MealTable.js
 
 import React, { useState } from "react";
-import { TextField, TableContainer, Table, TableHead, TableBody, TableRow, TableCell, Paper, Collapse, Typography, TablePagination } from "@mui/material";
+import { Box, TextField, TableContainer, Table, TableHead, TableBody, TableRow, TableCell, Paper, Collapse, Typography, TablePagination } from "@mui/material";
 import { KeyboardArrowDown, KeyboardArrowRight } from "@mui/icons-material";
 
 import { useData } from "../../../contexts/DataContext";
@@ -152,13 +152,14 @@ function MealTable({ onMealDoubleClick = () => {}, onMealCtrlClick = () => {} })
     <div>
       <h1>Meals</h1>
 
-      <TextField
-        type="text"
-        label="Search by name"
-        value={search}
-        onChange={handleSearch}
-        style={{ marginBottom: "10px" }}
-      />
+      <Box sx={{ display: "flex", justifyContent: "center", mb: 2 }}>
+        <TextField
+          type="text"
+          label="Search by name"
+          value={search}
+          onChange={handleSearch}
+        />
+      </Box>
 
       <TagFilter
         tags={allMealTags}


### PR DESCRIPTION
## Summary
- Wrap MealTable and IngredientTable search fields in a centered MUI `Box`
- Use `sx` prop for spacing instead of inline styles

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68992659889c83228f7c612def2480bc