### PR TITLE
feat: add grouped tag filtering

### DIFF
--- a/Frontend/nutrition-frontend/src/components/common/TagFilter.js
+++ b/Frontend/nutrition-frontend/src/components/common/TagFilter.js
@@ -1,10 +1,21 @@
 import { Autocomplete, TextField, Chip } from "@mui/material";
 
+/**
+ * TagFilter renders a chip selector for tag objects.
+ *
+ * Tags can optionally contain a `group` field. When provided, options are
+ * grouped in the dropdown using MUI's `groupBy` prop.
+ *
+ * Example tag object: `{ id: 1, name: "Vegan", group: "Diet" }`
+ */
 function TagFilter({ tags = [], selectedTags = [], onChange = () => {}, label = "Tags" }) {
+  const hasGroups = tags.some((tag) => tag.group);
+
   return (
     <Autocomplete
       multiple
       options={tags}
+      groupBy={hasGroups ? (option) => option.group : undefined}
       value={selectedTags}
       onChange={(event, newValue) => onChange(newValue)}
       getOptionLabel={(option) => option.name}

--- a/Frontend/nutrition-frontend/src/components/data/ingredient/IngredientTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/ingredient/IngredientTable.js
@@ -80,9 +80,9 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
   const currentIngredients = filteredIngredients.slice(indexOfFirstItem, indexOfLastItem);
 
   const allIngredientTags = [
-    ...ingredientProcessingTags,
-    ...ingredientGroupTags,
-    ...ingredientOtherTags,
+    ...ingredientProcessingTags.map((tag) => ({ ...tag, group: "Processing" })),
+    ...ingredientGroupTags.map((tag) => ({ ...tag, group: "Group" })),
+    ...ingredientOtherTags.map((tag) => ({ ...tag, group: "Other" })),
   ];
 
   return (

--- a/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
@@ -71,7 +71,11 @@ function MealTable({ onMealDoubleClick = () => {}, onMealCtrlClick = () => {} })
     .filter(handleTagFilter);
   const currentMeals = filteredMeals.slice(indexOfFirstItem, indexOfLastItem);
 
-  const allMealTags = [...mealDietTags, ...mealTypeTags, ...mealOtherTags];
+  const allMealTags = [
+    ...mealDietTags.map((tag) => ({ ...tag, group: "Diet" })),
+    ...mealTypeTags.map((tag) => ({ ...tag, group: "Type" })),
+    ...mealOtherTags.map((tag) => ({ ...tag, group: "Other" })),
+  ];
 
   const calculateIngredientMacros = (ingredient) => {
     const dataIngredient = ingredients.find(

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ DBeaver is a free and powerful GUI for inspecting your PostgreSQL database. You 
     * All ingredients and meals
     * All possible tags
   * Categorizes tags into `group`, `processing`, `type`, and `diet`
+  * Tag filtering components accept `{ group: "Category", ...tag }` objects to
+    show grouped options via MUI's Autocomplete
 
 ---
 


### PR DESCRIPTION
## Summary
- allow TagFilter to group options by tag category
- pass grouped tags in meal and ingredient tables
- document grouped tag usage

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689926944b1083229aa8e5abb96744aa