### PR TITLE
Add meal planning interface with macro tracking

### DIFF
--- a/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
+++ b/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
@@ -5,7 +5,7 @@ import { Paper, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/ma
 
 import { formatCellNumber } from "./utils";
 
-const MacrosTable = ({ ingredients }) => {
+const MacrosTable = ({ ingredients, goals = {} }) => {
   const [totalMacros, setTotalMacros] = useState({
     calories: 0,
     protein: 0,
@@ -15,7 +15,6 @@ const MacrosTable = ({ ingredients }) => {
   });
 
   useEffect(() => {
-    // Calculate total macros when ingredients change
     const calculateTotalMacros = () => {
       let calories = 0,
         protein = 0,
@@ -36,12 +35,21 @@ const MacrosTable = ({ ingredients }) => {
     calculateTotalMacros();
   }, [ingredients]);
 
+  const remaining = {
+    calories: (goals.calories || 0) - totalMacros.calories,
+    protein: (goals.protein || 0) - totalMacros.protein,
+    carbohydrates: (goals.carbohydrates || 0) - totalMacros.carbohydrates,
+    fat: (goals.fat || 0) - totalMacros.fat,
+    fiber: (goals.fiber || 0) - totalMacros.fiber,
+  };
+
   return (
     <div>
-      <h1>Total Macros</h1>
+      <h1>Macros</h1>
       <Table component={Paper}>
         <TableHead>
           <TableRow>
+            <TableCell></TableCell>
             <TableCell>Calories</TableCell>
             <TableCell>Protein</TableCell>
             <TableCell>Carbs</TableCell>
@@ -50,11 +58,30 @@ const MacrosTable = ({ ingredients }) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          <TableCell>{formatCellNumber(totalMacros.calories)}</TableCell>
-          <TableCell>{formatCellNumber(totalMacros.protein)}</TableCell>
-          <TableCell>{formatCellNumber(totalMacros.carbohydrates)}</TableCell>
-          <TableCell>{formatCellNumber(totalMacros.fat)}</TableCell>
-          <TableCell>{formatCellNumber(totalMacros.fiber)}</TableCell>
+          <TableRow>
+            <TableCell>Goal</TableCell>
+            <TableCell>{formatCellNumber(goals.calories || 0)}</TableCell>
+            <TableCell>{formatCellNumber(goals.protein || 0)}</TableCell>
+            <TableCell>{formatCellNumber(goals.carbohydrates || 0)}</TableCell>
+            <TableCell>{formatCellNumber(goals.fat || 0)}</TableCell>
+            <TableCell>{formatCellNumber(goals.fiber || 0)}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Total</TableCell>
+            <TableCell>{formatCellNumber(totalMacros.calories)}</TableCell>
+            <TableCell>{formatCellNumber(totalMacros.protein)}</TableCell>
+            <TableCell>{formatCellNumber(totalMacros.carbohydrates)}</TableCell>
+            <TableCell>{formatCellNumber(totalMacros.fat)}</TableCell>
+            <TableCell>{formatCellNumber(totalMacros.fiber)}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Remaining</TableCell>
+            <TableCell>{formatCellNumber(remaining.calories)}</TableCell>
+            <TableCell>{formatCellNumber(remaining.protein)}</TableCell>
+            <TableCell>{formatCellNumber(remaining.carbohydrates)}</TableCell>
+            <TableCell>{formatCellNumber(remaining.fat)}</TableCell>
+            <TableCell>{formatCellNumber(remaining.fiber)}</TableCell>
+          </TableRow>
         </TableBody>
       </Table>
     </div>

--- a/Frontend/nutrition-frontend/src/components/planning/Planning.js
+++ b/Frontend/nutrition-frontend/src/components/planning/Planning.js
@@ -1,7 +1,205 @@
-import React from "react";
+import React, { useState } from "react";
+import { Button, TextField, Select, MenuItem, FormControl, InputLabel } from "@mui/material";
+
+import { useData } from "../../contexts/DataContext";
+import PlanningTable from "./PlanningTable";
+import MacrosTable from "./MacrosTable";
+import { handleFetchRequest } from "../../utils/utils";
 
 function Planning() {
-  return <div>Planning coming soon...</div>;
+  const { meals, ingredients } = useData();
+
+  const [duration, setDuration] = useState(1);
+  const [goals, setGoals] = useState({
+    calories: 0,
+    protein: 0,
+    carbohydrates: 0,
+    fat: 0,
+    fiber: 0,
+  });
+  const [plan, setPlan] = useState([[]]);
+  const [mealSelections, setMealSelections] = useState([{ mealId: "", servings: 1 }]);
+  const [planId, setPlanId] = useState("");
+
+  const handleDurationChange = (event) => {
+    const newDuration = parseInt(event.target.value, 10) || 1;
+    setDuration(newDuration);
+    setPlan((prev) => {
+      const updated = [...prev];
+      if (newDuration > prev.length) {
+        for (let i = prev.length; i < newDuration; i++) {
+          updated.push([]);
+        }
+      } else {
+        updated.length = newDuration;
+      }
+      return updated;
+    });
+    setMealSelections((prev) => {
+      const updated = [...prev];
+      if (newDuration > prev.length) {
+        for (let i = prev.length; i < newDuration; i++) {
+          updated.push({ mealId: "", servings: 1 });
+        }
+      } else {
+        updated.length = newDuration;
+      }
+      return updated;
+    });
+  };
+
+  const handleGoalChange = (event) => {
+    const { name, value } = event.target;
+    setGoals({ ...goals, [name]: parseFloat(value) });
+  };
+
+  const handleMealSelectionChange = (index, field, value) => {
+    setMealSelections((prev) => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
+  const calculateMealMacros = (meal) => {
+    if (!meal) return { calories: 0, protein: 0, carbohydrates: 0, fat: 0, fiber: 0 };
+
+    const totals = { calories: 0, protein: 0, carbohydrates: 0, fat: 0, fiber: 0 };
+    meal.ingredients.forEach((ing) => {
+      const dataIngredient = ingredients.find((i) => i.id === ing.ingredient_id);
+      if (!dataIngredient) return;
+      const unit = dataIngredient.units.find((u) => u.id === ing.unit_id) || dataIngredient.units[0];
+      totals.calories += (dataIngredient.nutrition.calories || 0) * unit.grams * ing.amount;
+      totals.protein += (dataIngredient.nutrition.protein || 0) * unit.grams * ing.amount;
+      totals.carbohydrates += (dataIngredient.nutrition.carbohydrates || 0) * unit.grams * ing.amount;
+      totals.fat += (dataIngredient.nutrition.fat || 0) * unit.grams * ing.amount;
+      totals.fiber += (dataIngredient.nutrition.fiber || 0) * unit.grams * ing.amount;
+    });
+    return totals;
+  };
+
+  const handleAddMeal = (dayIndex) => {
+    const selection = mealSelections[dayIndex];
+    if (!selection.mealId) return;
+    const meal = meals.find((m) => m.id === selection.mealId);
+    const macros = calculateMealMacros(meal);
+    const ingredient = {
+      mealId: meal.id,
+      name: meal.name,
+      quantity: parseFloat(selection.servings) || 1,
+      nutrition: macros,
+    };
+    setPlan((prev) => {
+      const updated = [...prev];
+      updated[dayIndex] = [...updated[dayIndex], ingredient];
+      return updated;
+    });
+    setMealSelections((prev) => {
+      const updated = [...prev];
+      updated[dayIndex] = { mealId: "", servings: 1 };
+      return updated;
+    });
+  };
+
+  const handleDayPlanChange = (dayIndex, data) => {
+    setPlan((prev) => {
+      const updated = [...prev];
+      if (Array.isArray(data)) {
+        updated[dayIndex] = data;
+      } else {
+        updated[dayIndex] = updated[dayIndex].filter((item) => item !== data);
+      }
+      return updated;
+    });
+  };
+
+  const buildPlanForApi = () => {
+    return {
+      duration,
+      goals,
+      days: plan.map((dayMeals, idx) => ({
+        day: idx + 1,
+        meals: dayMeals.map((m) => ({ meal_id: m.mealId, servings: m.quantity })),
+      })),
+    };
+  };
+
+  const handleSavePlan = () => {
+    const url = "http://localhost:5000/planning";
+    handleFetchRequest(url, "POST", buildPlanForApi());
+  };
+
+  const handleUpdatePlan = () => {
+    if (!planId) return;
+    const url = `http://localhost:5000/planning/${planId}`;
+    handleFetchRequest(url, "PUT", buildPlanForApi());
+  };
+
+  return (
+    <div>
+      <h1>Planning</h1>
+      <div>
+        <TextField
+          label="Plan Duration (days)"
+          type="number"
+          value={duration}
+          onChange={handleDurationChange}
+          InputProps={{ inputProps: { min: 1 } }}
+        />
+      </div>
+      <div>
+        <TextField name="calories" label="Calories Goal" type="number" value={goals.calories} onChange={handleGoalChange} />
+        <TextField name="protein" label="Protein Goal" type="number" value={goals.protein} onChange={handleGoalChange} />
+        <TextField name="carbohydrates" label="Carbs Goal" type="number" value={goals.carbohydrates} onChange={handleGoalChange} />
+        <TextField name="fat" label="Fat Goal" type="number" value={goals.fat} onChange={handleGoalChange} />
+        <TextField name="fiber" label="Fiber Goal" type="number" value={goals.fiber} onChange={handleGoalChange} />
+      </div>
+      {plan.map((dayMeals, dayIndex) => (
+        <div key={dayIndex} style={{ marginTop: "20px" }}>
+          <h2>Day {dayIndex + 1}</h2>
+          <FormControl style={{ minWidth: 200 }}>
+            <InputLabel id={`meal-select-label-${dayIndex}`}>Meal</InputLabel>
+            <Select
+              labelId={`meal-select-label-${dayIndex}`}
+              value={mealSelections[dayIndex].mealId}
+              label="Meal"
+              onChange={(e) => handleMealSelectionChange(dayIndex, "mealId", e.target.value)}>
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {meals.map((meal) => (
+                <MenuItem key={meal.id} value={meal.id}>
+                  {meal.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            type="number"
+            label="Servings"
+            value={mealSelections[dayIndex].servings}
+            onChange={(e) => handleMealSelectionChange(dayIndex, "servings", e.target.value)}
+            InputProps={{ inputProps: { min: 1 } }}
+            style={{ marginLeft: "10px" }}
+          />
+          <Button style={{ marginLeft: "10px" }} variant="contained" onClick={() => handleAddMeal(dayIndex)}>
+            Add Meal
+          </Button>
+          <PlanningTable ingredients={dayMeals} onIngredientRemove={(data) => handleDayPlanChange(dayIndex, data)} />
+          <MacrosTable ingredients={dayMeals} goals={goals} />
+        </div>
+      ))}
+      <div style={{ marginTop: "20px" }}>
+        <TextField label="Plan ID" value={planId} onChange={(e) => setPlanId(e.target.value)} />
+        <Button variant="contained" style={{ marginLeft: "10px" }} onClick={handleSavePlan}>
+          Save Plan
+        </Button>
+        <Button variant="contained" style={{ marginLeft: "10px" }} onClick={handleUpdatePlan} disabled={!planId}>
+          Update Plan
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export default Planning;

--- a/Frontend/nutrition-frontend/src/components/planning/utils.js
+++ b/Frontend/nutrition-frontend/src/components/planning/utils.js
@@ -1,0 +1,3 @@
+import { formatCellNumber } from "../../utils/utils";
+
+export { formatCellNumber };


### PR DESCRIPTION
## Summary
- Implement planning page with plan duration, macro goals, meal selectors per day, and save/update actions
- Add macros table displaying goals, totals, and remaining macros
- Provide shared planning utilities for formatting numbers

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68992983f05c8322ba3c6bc13a580fe9