### PR TITLE
Add MainLayout with drawer navigation and routing

### DIFF
--- a/Frontend/nutrition-frontend/package.json
+++ b/Frontend/nutrition-frontend/package.json
@@ -13,6 +13,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.2",
     "react-scripts": "^5.0.1",
     "react-virtuoso": "^4.7.1",
     "react-window": "^1.8.10",
@@ -44,3 +45,4 @@
     ]
   }
 }
+

--- a/Frontend/nutrition-frontend/src/App.js
+++ b/Frontend/nutrition-frontend/src/App.js
@@ -1,12 +1,9 @@
-import React, { useState } from "react";
-import Box from "@mui/material/Box";
-import Tabs from "@mui/material/Tabs";
-import Tab from "@mui/material/Tab";
+import React from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 import { DataProvider } from "./contexts/DataContext";
-
-import IngredientData from "./components/data/ingredient/IngredientData";
-import MealData from "./components/data/meal/MealData";
+import MainLayout from "./components/layout/MainLayout";
+import DataPage from "./components/data/DataPage";
 import Planning from "./components/planning/Planning";
 import Shopping from "./components/shopping/Shopping";
 import Cooking from "./components/cooking/Cooking";
@@ -15,159 +12,23 @@ import Logging from "./components/logging/Logging";
 import "./styles/App.css";
 
 function App() {
-  const [selectedIngredients, setSelectedIngredients] = useState([]);
-  const [activityTab, setActivityTab] = useState(0);
-  const [dataTab, setDataTab] = useState(0);
-
-  const handleAddIngredientToPlan = (ingredient) => {
-    setSelectedIngredients([...selectedIngredients, { ...ingredient, quantity: 1 }]);
-  };
-
-  const handleActivityTabChange = (event, newValue) => {
-    setActivityTab(newValue);
-  };
-
-  const handleDataTabChange = (event, newValue) => {
-    setDataTab(newValue);
-  };
-
-  // const handleRemoveIngredientFromPlan = (ingredientToRemove) => {
-  //   const updatedIngredients = selectedIngredients.filter((ingredient) => ingredient !== ingredientToRemove);
-  //   setSelectedIngredients(updatedIngredients);
-  // };
-
-  // const handleAddMeal = (newMeal) => {
-  //   console.log(newMeal);
-  // };
-
   return (
-    <div className="App">
+    <Router>
       <DataProvider>
-        <Box sx={{ display: "flex" }}>
-          <Box
-            sx={{
-              width: 200,
-              flexShrink: 0,
-              borderRight: 1,
-              borderColor: "divider",
-              position: "fixed",
-              top: 0,
-              bottom: 0,
-              left: 0,
-            }}
-          >
-            <Tabs
-              orientation="vertical"
-              value={activityTab}
-              onChange={handleActivityTabChange}
-              aria-label="activity tabs"
-            >
-              <Tab label="Data" id="activity-tab-0" aria-controls="activity-panel-0" />
-              <Tab label="Planning" id="activity-tab-1" aria-controls="activity-panel-1" />
-              <Tab label="Shopping" id="activity-tab-2" aria-controls="activity-panel-2" />
-              <Tab label="Cooking" id="activity-tab-3" aria-controls="activity-panel-3" />
-              <Tab label="Logging" id="activity-tab-4" aria-controls="activity-panel-4" />
-            </Tabs>
-          </Box>
-
-          <Box
-            sx={{
-              marginLeft: "200px",
-              flexGrow: 1,
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "flex-start",
-            }}
-          >
-            <Box sx={{ width: "100%", maxWidth: 800, mx: "auto" }}>
-              {activityTab === 0 && (
-                <Box
-                  role="tabpanel"
-                  id="activity-panel-0"
-                  aria-labelledby="activity-tab-0"
-                  sx={{ p: 3, display: "flex", flexDirection: "column", alignItems: "center" }}
-                >
-                  <Tabs
-                    value={dataTab}
-                    onChange={handleDataTabChange}
-                    aria-label="data tabs"
-                    centered
-                  >
-                    <Tab label="Meals" id="data-tab-0" aria-controls="data-panel-0" />
-                    <Tab label="Ingredients" id="data-tab-1" aria-controls="data-panel-1" />
-                  </Tabs>
-                  {dataTab === 0 && (
-                    <Box
-                      role="tabpanel"
-                      id="data-panel-0"
-                      aria-labelledby="data-tab-0"
-                      sx={{ width: "100%", display: "flex", flexDirection: "column", alignItems: "center" }}
-                    >
-                      <MealData />
-                    </Box>
-                  )}
-                  {dataTab === 1 && (
-                    <Box
-                      role="tabpanel"
-                      id="data-panel-1"
-                      aria-labelledby="data-tab-1"
-                      sx={{ width: "100%", display: "flex", flexDirection: "column", alignItems: "center" }}
-                    >
-                      <IngredientData handleAddIngredientToPlan={handleAddIngredientToPlan} />
-                    </Box>
-                  )}
-                </Box>
-              )}
-
-              {activityTab === 1 && (
-                <Box
-                  role="tabpanel"
-                  id="activity-panel-1"
-                  aria-labelledby="activity-tab-1"
-                  sx={{ p: 3 }}
-                >
-                  <Planning />
-                </Box>
-              )}
-
-              {activityTab === 2 && (
-                <Box
-                  role="tabpanel"
-                  id="activity-panel-2"
-                  aria-labelledby="activity-tab-2"
-                  sx={{ p: 3 }}
-                >
-                  <Shopping />
-                </Box>
-              )}
-
-              {activityTab === 3 && (
-                <Box
-                  role="tabpanel"
-                  id="activity-panel-3"
-                  aria-labelledby="activity-tab-3"
-                  sx={{ p: 3 }}
-                >
-                  <Cooking />
-                </Box>
-              )}
-
-              {activityTab === 4 && (
-                <Box
-                  role="tabpanel"
-                  id="activity-panel-4"
-                  aria-labelledby="activity-tab-4"
-                  sx={{ p: 3 }}
-                >
-                  <Logging />
-                </Box>
-              )}
-            </Box>
-          </Box>
-        </Box>
+        <MainLayout>
+          <Routes>
+            <Route path="/" element={<DataPage />} />
+            <Route path="/data" element={<DataPage />} />
+            <Route path="/planning" element={<Planning />} />
+            <Route path="/shopping" element={<Shopping />} />
+            <Route path="/cooking" element={<Cooking />} />
+            <Route path="/logging" element={<Logging />} />
+          </Routes>
+        </MainLayout>
       </DataProvider>
-    </div>
+    </Router>
   );
 }
 
 export default App;
+

--- a/Frontend/nutrition-frontend/src/components/data/DataPage.js
+++ b/Frontend/nutrition-frontend/src/components/data/DataPage.js
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import Box from "@mui/material/Box";
+import Tabs from "@mui/material/Tabs";
+import Tab from "@mui/material/Tab";
+
+import MealData from "./meal/MealData";
+import IngredientData from "./ingredient/IngredientData";
+
+function DataPage() {
+  const [dataTab, setDataTab] = useState(0);
+  const handleDataTabChange = (event, newValue) => {
+    setDataTab(newValue);
+  };
+
+  return (
+    <Box sx={{ width: "100%", display: "flex", flexDirection: "column", alignItems: "center" }}>
+      <Tabs value={dataTab} onChange={handleDataTabChange} aria-label="data tabs" centered>
+        <Tab label="Meals" />
+        <Tab label="Ingredients" />
+      </Tabs>
+      {dataTab === 0 && <MealData />}
+      {dataTab === 1 && <IngredientData handleAddIngredientToPlan={() => {}} />}
+    </Box>
+  );
+}
+
+export default DataPage;
+

--- a/Frontend/nutrition-frontend/src/components/layout/MainLayout.js
+++ b/Frontend/nutrition-frontend/src/components/layout/MainLayout.js
@@ -1,0 +1,174 @@
+import React, { useState } from "react";
+import { styled, useTheme } from "@mui/material/styles";
+import Box from "@mui/material/Box";
+import MuiDrawer from "@mui/material/Drawer";
+import MuiAppBar from "@mui/material/AppBar";
+import Toolbar from "@mui/material/Toolbar";
+import List from "@mui/material/List";
+import CssBaseline from "@mui/material/CssBaseline";
+import Typography from "@mui/material/Typography";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import MenuIcon from "@mui/icons-material/Menu";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import StorageIcon from "@mui/icons-material/Storage";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
+import ShoppingCartIcon from "@mui/icons-material/ShoppingCart";
+import RestaurantMenuIcon from "@mui/icons-material/RestaurantMenu";
+import NoteAltIcon from "@mui/icons-material/NoteAlt";
+import { Link } from "react-router-dom";
+
+const drawerWidth = 240;
+
+const openedMixin = (theme) => ({
+  width: drawerWidth,
+  transition: theme.transitions.create("width", {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.enteringScreen,
+  }),
+  overflowX: "hidden",
+});
+
+const closedMixin = (theme) => ({
+  transition: theme.transitions.create("width", {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+  overflowX: "hidden",
+  width: `calc(${theme.spacing(7)} + 1px)`,
+  [theme.breakpoints.up("sm")]: {
+    width: `calc(${theme.spacing(8)} + 1px)`,
+  },
+});
+
+const DrawerHeader = styled("div")(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-end",
+  padding: theme.spacing(0, 1),
+  ...theme.mixins.toolbar,
+}));
+
+const AppBar = styled(MuiAppBar, {
+  shouldForwardProp: (prop) => prop !== "open",
+})(({ theme, open }) => ({
+  zIndex: theme.zIndex.drawer + 1,
+  transition: theme.transitions.create(["width", "margin"], {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+  ...(open && {
+    marginLeft: drawerWidth,
+    width: `calc(100% - ${drawerWidth}px)`,
+    transition: theme.transitions.create(["width", "margin"], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  }),
+}));
+
+const Drawer = styled(MuiDrawer, {
+  shouldForwardProp: (prop) => prop !== "open",
+})(({ theme, open }) => ({
+  width: drawerWidth,
+  flexShrink: 0,
+  whiteSpace: "nowrap",
+  boxSizing: "border-box",
+  ...(open && {
+    ...openedMixin(theme),
+    "& .MuiDrawer-paper": openedMixin(theme),
+  }),
+  ...(!open && {
+    ...closedMixin(theme),
+    "& .MuiDrawer-paper": closedMixin(theme),
+  }),
+}));
+
+function MainLayout({ children }) {
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
+
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+
+  const menuItems = [
+    { text: "Data", icon: <StorageIcon />, path: "/data" },
+    { text: "Planning", icon: <CalendarMonthIcon />, path: "/planning" },
+    { text: "Shopping", icon: <ShoppingCartIcon />, path: "/shopping" },
+    { text: "Cooking", icon: <RestaurantMenuIcon />, path: "/cooking" },
+    { text: "Logging", icon: <NoteAltIcon />, path: "/logging" },
+  ];
+
+  return (
+    <Box sx={{ display: "flex" }}>
+      <CssBaseline />
+      <AppBar position="fixed" open={open}>
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            onClick={handleDrawerOpen}
+            edge="start"
+            sx={{ marginRight: "36px", ...(open && { display: "none" }) }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" noWrap component="div">
+            Nutrition App
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Drawer variant="permanent" open={open}>
+        <DrawerHeader>
+          <IconButton onClick={handleDrawerClose}>
+            {theme.direction === "rtl" ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+          </IconButton>
+        </DrawerHeader>
+        <Divider />
+        <List>
+          {menuItems.map((item) => (
+            <ListItem key={item.text} disablePadding sx={{ display: "block" }}>
+              <ListItemButton
+                component={Link}
+                to={item.path}
+                sx={{
+                  minHeight: 48,
+                  justifyContent: open ? "initial" : "center",
+                  px: 2.5,
+                }}
+              >
+                <ListItemIcon
+                  sx={{
+                    minWidth: 0,
+                    mr: open ? 3 : "auto",
+                    justifyContent: "center",
+                  }}
+                >
+                  {item.icon}
+                </ListItemIcon>
+                <ListItemText primary={item.text} sx={{ opacity: open ? 1 : 0 }} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+        <DrawerHeader />
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+export default MainLayout;
+


### PR DESCRIPTION
## Summary
- add MainLayout with mini variant drawer and navigation items
- scaffold DataPage and wire up React Router
- remove placeholder Dashboard and Settings pages

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_6899263785f48322a62d0349b984a771