### PR TITLE
chore: add babel private property-in-object plugin

### DIFF
--- a/Frontend/nutrition-frontend/package-lock.json
+++ b/Frontend/nutrition-frontend/package-lock.json
@@ -23,6 +23,9 @@
         "react-window": "^1.8.10",
         "styled-components": "^6.1.8",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/Frontend/nutrition-frontend/package.json
+++ b/Frontend/nutrition-frontend/package.json
@@ -42,5 +42,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `@babel/plugin-proposal-private-property-in-object` to devDependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fplugin-proposal-private-property-in-object)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689932b7cc24832286fa3309eb6478d7