### PR TITLE
Rename planning goals to targets

### DIFF
--- a/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
+++ b/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
@@ -5,7 +5,7 @@ import { Paper, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/ma
 
 import { formatCellNumber } from "./utils";
 
-const MacrosTable = ({ ingredients, goals = {} }) => {
+const MacrosTable = ({ ingredients, targets = {} }) => {
   const [totalMacros, setTotalMacros] = useState({
     calories: 0,
     protein: 0,
@@ -36,11 +36,11 @@ const MacrosTable = ({ ingredients, goals = {} }) => {
   }, [ingredients]);
 
   const remaining = {
-    calories: (goals.calories || 0) - totalMacros.calories,
-    protein: (goals.protein || 0) - totalMacros.protein,
-    carbohydrates: (goals.carbohydrates || 0) - totalMacros.carbohydrates,
-    fat: (goals.fat || 0) - totalMacros.fat,
-    fiber: (goals.fiber || 0) - totalMacros.fiber,
+    calories: (targets.calories || 0) - totalMacros.calories,
+    protein: (targets.protein || 0) - totalMacros.protein,
+    carbohydrates: (targets.carbohydrates || 0) - totalMacros.carbohydrates,
+    fat: (targets.fat || 0) - totalMacros.fat,
+    fiber: (targets.fiber || 0) - totalMacros.fiber,
   };
 
   return (
@@ -59,12 +59,12 @@ const MacrosTable = ({ ingredients, goals = {} }) => {
         </TableHead>
         <TableBody>
           <TableRow>
-            <TableCell>Goal</TableCell>
-            <TableCell>{formatCellNumber(goals.calories || 0)}</TableCell>
-            <TableCell>{formatCellNumber(goals.protein || 0)}</TableCell>
-            <TableCell>{formatCellNumber(goals.carbohydrates || 0)}</TableCell>
-            <TableCell>{formatCellNumber(goals.fat || 0)}</TableCell>
-            <TableCell>{formatCellNumber(goals.fiber || 0)}</TableCell>
+            <TableCell>Target</TableCell>
+            <TableCell>{formatCellNumber(targets.calories || 0)}</TableCell>
+            <TableCell>{formatCellNumber(targets.protein || 0)}</TableCell>
+            <TableCell>{formatCellNumber(targets.carbohydrates || 0)}</TableCell>
+            <TableCell>{formatCellNumber(targets.fat || 0)}</TableCell>
+            <TableCell>{formatCellNumber(targets.fiber || 0)}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Total</TableCell>

--- a/Frontend/nutrition-frontend/src/components/planning/Planning.js
+++ b/Frontend/nutrition-frontend/src/components/planning/Planning.js
@@ -10,7 +10,7 @@ function Planning() {
   const { meals, ingredients } = useData();
 
   const [duration, setDuration] = useState(1);
-  const [goals, setGoals] = useState({
+  const [targets, setTargets] = useState({
     calories: 0,
     protein: 0,
     carbohydrates: 0,
@@ -48,9 +48,9 @@ function Planning() {
     });
   };
 
-  const handleGoalChange = (event) => {
+  const handleTargetChange = (event) => {
     const { name, value } = event.target;
-    setGoals({ ...goals, [name]: parseFloat(value) });
+    setTargets({ ...targets, [name]: parseFloat(value) });
   };
 
   const handleMealSelectionChange = (index, field, value) => {
@@ -116,7 +116,7 @@ function Planning() {
   const buildPlanForApi = () => {
     return {
       duration,
-      goals,
+      targets,
       days: plan.map((dayMeals, idx) => ({
         day: idx + 1,
         meals: dayMeals.map((m) => ({ meal_id: m.mealId, servings: m.quantity })),
@@ -148,11 +148,11 @@ function Planning() {
         />
       </div>
       <div>
-        <TextField name="calories" label="Calories Goal" type="number" value={goals.calories} onChange={handleGoalChange} />
-        <TextField name="protein" label="Protein Goal" type="number" value={goals.protein} onChange={handleGoalChange} />
-        <TextField name="carbohydrates" label="Carbs Goal" type="number" value={goals.carbohydrates} onChange={handleGoalChange} />
-        <TextField name="fat" label="Fat Goal" type="number" value={goals.fat} onChange={handleGoalChange} />
-        <TextField name="fiber" label="Fiber Goal" type="number" value={goals.fiber} onChange={handleGoalChange} />
+        <TextField name="calories" label="Calories Target" type="number" value={targets.calories} onChange={handleTargetChange} />
+        <TextField name="protein" label="Protein Target" type="number" value={targets.protein} onChange={handleTargetChange} />
+        <TextField name="carbohydrates" label="Carbs Target" type="number" value={targets.carbohydrates} onChange={handleTargetChange} />
+        <TextField name="fat" label="Fat Target" type="number" value={targets.fat} onChange={handleTargetChange} />
+        <TextField name="fiber" label="Fiber Target" type="number" value={targets.fiber} onChange={handleTargetChange} />
       </div>
       {plan.map((dayMeals, dayIndex) => (
         <div key={dayIndex} style={{ marginTop: "20px" }}>
@@ -186,7 +186,7 @@ function Planning() {
             Add Meal
           </Button>
           <PlanningTable ingredients={dayMeals} onIngredientRemove={(data) => handleDayPlanChange(dayIndex, data)} />
-          <MacrosTable ingredients={dayMeals} goals={goals} />
+          <MacrosTable ingredients={dayMeals} targets={targets} />
         </div>
       ))}
       <div style={{ marginTop: "20px" }}>


### PR DESCRIPTION
## Summary
- rename state and handlers from goals to targets in planning flow
- adjust MacrosTable to accept targets and update labels

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6899335a49e88322bd1dca082f981473