### PR TITLE
Simplify planning to single meal list

### DIFF
--- a/Frontend/nutrition-frontend/src/components/planning/Planning.js
+++ b/Frontend/nutrition-frontend/src/components/planning/Planning.js
@@ -17,35 +17,13 @@ function Planning() {
     fat: 0,
     fiber: 0,
   });
-  const [plan, setPlan] = useState([[]]);
-  const [mealSelections, setMealSelections] = useState([{ mealId: "", servings: 1 }]);
+  const [plan, setPlan] = useState([]);
+  const [mealSelection, setMealSelection] = useState({ mealId: "", servings: 1 });
   const [planId, setPlanId] = useState("");
 
   const handleDurationChange = (event) => {
     const newDuration = parseInt(event.target.value, 10) || 1;
     setDuration(newDuration);
-    setPlan((prev) => {
-      const updated = [...prev];
-      if (newDuration > prev.length) {
-        for (let i = prev.length; i < newDuration; i++) {
-          updated.push([]);
-        }
-      } else {
-        updated.length = newDuration;
-      }
-      return updated;
-    });
-    setMealSelections((prev) => {
-      const updated = [...prev];
-      if (newDuration > prev.length) {
-        for (let i = prev.length; i < newDuration; i++) {
-          updated.push({ mealId: "", servings: 1 });
-        }
-      } else {
-        updated.length = newDuration;
-      }
-      return updated;
-    });
   };
 
   const handleTargetChange = (event) => {
@@ -53,12 +31,8 @@ function Planning() {
     setTargets({ ...targets, [name]: parseFloat(value) });
   };
 
-  const handleMealSelectionChange = (index, field, value) => {
-    setMealSelections((prev) => {
-      const updated = [...prev];
-      updated[index] = { ...updated[index], [field]: value };
-      return updated;
-    });
+  const handleMealSelectionChange = (field, value) => {
+    setMealSelection((prev) => ({ ...prev, [field]: value }));
   };
 
   const calculateMealMacros = (meal) => {
@@ -78,38 +52,26 @@ function Planning() {
     return totals;
   };
 
-  const handleAddMeal = (dayIndex) => {
-    const selection = mealSelections[dayIndex];
-    if (!selection.mealId) return;
-    const meal = meals.find((m) => m.id === selection.mealId);
+  const handleAddMeal = () => {
+    if (!mealSelection.mealId) return;
+    const meal = meals.find((m) => m.id === mealSelection.mealId);
     const macros = calculateMealMacros(meal);
     const ingredient = {
       mealId: meal.id,
       name: meal.name,
-      quantity: parseFloat(selection.servings) || 1,
+      quantity: parseFloat(mealSelection.servings) || 1,
       nutrition: macros,
     };
-    setPlan((prev) => {
-      const updated = [...prev];
-      updated[dayIndex] = [...updated[dayIndex], ingredient];
-      return updated;
-    });
-    setMealSelections((prev) => {
-      const updated = [...prev];
-      updated[dayIndex] = { mealId: "", servings: 1 };
-      return updated;
-    });
+    setPlan((prev) => [...prev, ingredient]);
+    setMealSelection({ mealId: "", servings: 1 });
   };
 
-  const handleDayPlanChange = (dayIndex, data) => {
+  const handlePlanChange = (data) => {
     setPlan((prev) => {
-      const updated = [...prev];
       if (Array.isArray(data)) {
-        updated[dayIndex] = data;
-      } else {
-        updated[dayIndex] = updated[dayIndex].filter((item) => item !== data);
+        return data;
       }
-      return updated;
+      return prev.filter((item) => item !== data);
     });
   };
 
@@ -117,10 +79,7 @@ function Planning() {
     return {
       duration,
       targets,
-      days: plan.map((dayMeals, idx) => ({
-        day: idx + 1,
-        meals: dayMeals.map((m) => ({ meal_id: m.mealId, servings: m.quantity })),
-      })),
+      meals: plan.map((m) => ({ meal_id: m.mealId, servings: m.quantity })),
     };
   };
 
@@ -154,41 +113,38 @@ function Planning() {
         <TextField name="fat" label="Fat Target" type="number" value={targets.fat} onChange={handleTargetChange} />
         <TextField name="fiber" label="Fiber Target" type="number" value={targets.fiber} onChange={handleTargetChange} />
       </div>
-      {plan.map((dayMeals, dayIndex) => (
-        <div key={dayIndex} style={{ marginTop: "20px" }}>
-          <h2>Day {dayIndex + 1}</h2>
-          <FormControl style={{ minWidth: 200 }}>
-            <InputLabel id={`meal-select-label-${dayIndex}`}>Meal</InputLabel>
-            <Select
-              labelId={`meal-select-label-${dayIndex}`}
-              value={mealSelections[dayIndex].mealId}
-              label="Meal"
-              onChange={(e) => handleMealSelectionChange(dayIndex, "mealId", e.target.value)}>
-              <MenuItem value="">
-                <em>None</em>
+      <div style={{ marginTop: "20px" }}>
+        <FormControl style={{ minWidth: 200 }}>
+          <InputLabel id="meal-select-label">Meal</InputLabel>
+          <Select
+            labelId="meal-select-label"
+            value={mealSelection.mealId}
+            label="Meal"
+            onChange={(e) => handleMealSelectionChange("mealId", e.target.value)}>
+            <MenuItem value="">
+              <em>None</em>
+            </MenuItem>
+            {meals.map((meal) => (
+              <MenuItem key={meal.id} value={meal.id}>
+                {meal.name}
               </MenuItem>
-              {meals.map((meal) => (
-                <MenuItem key={meal.id} value={meal.id}>
-                  {meal.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-          <TextField
-            type="number"
-            label="Servings"
-            value={mealSelections[dayIndex].servings}
-            onChange={(e) => handleMealSelectionChange(dayIndex, "servings", e.target.value)}
-            InputProps={{ inputProps: { min: 1 } }}
-            style={{ marginLeft: "10px" }}
-          />
-          <Button style={{ marginLeft: "10px" }} variant="contained" onClick={() => handleAddMeal(dayIndex)}>
-            Add Meal
-          </Button>
-          <PlanningTable ingredients={dayMeals} onIngredientRemove={(data) => handleDayPlanChange(dayIndex, data)} />
-          <MacrosTable ingredients={dayMeals} targets={targets} />
-        </div>
-      ))}
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          type="number"
+          label="Servings"
+          value={mealSelection.servings}
+          onChange={(e) => handleMealSelectionChange("servings", e.target.value)}
+          InputProps={{ inputProps: { min: 1 } }}
+          style={{ marginLeft: "10px" }}
+        />
+        <Button style={{ marginLeft: "10px" }} variant="contained" onClick={handleAddMeal}>
+          Add Meal
+        </Button>
+      </div>
+      <PlanningTable ingredients={plan} onIngredientRemove={handlePlanChange} />
+      <MacrosTable ingredients={plan} targets={targets} />
       <div style={{ marginTop: "20px" }}>
         <TextField label="Plan ID" value={planId} onChange={(e) => setPlanId(e.target.value)} />
         <Button variant="contained" style={{ marginLeft: "10px" }} onClick={handleSavePlan}>


### PR DESCRIPTION
## Summary
- refactor planning state to a single meal list with global meal selection
- add global helpers for meal add/update/remove and simplified duration handling
- generate API payload as {duration, targets, meals}

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689934f351588322bb9c82501d6b29ac