### PR TITLE
Add duration-based per-day macros to MacrosTable

### DIFF
--- a/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
+++ b/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
@@ -5,7 +5,7 @@ import { Paper, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/ma
 
 import { formatCellNumber } from "./utils";
 
-const MacrosTable = ({ ingredients, targets = {} }) => {
+const MacrosTable = ({ ingredients, targets = {}, duration = 1 }) => {
   const [totalMacros, setTotalMacros] = useState({
     calories: 0,
     protein: 0,
@@ -35,12 +35,20 @@ const MacrosTable = ({ ingredients, targets = {} }) => {
     calculateTotalMacros();
   }, [ingredients]);
 
+  const perDayMacros = {
+    calories: totalMacros.calories / duration,
+    protein: totalMacros.protein / duration,
+    carbohydrates: totalMacros.carbohydrates / duration,
+    fat: totalMacros.fat / duration,
+    fiber: totalMacros.fiber / duration,
+  };
+
   const remaining = {
-    calories: (targets.calories || 0) - totalMacros.calories,
-    protein: (targets.protein || 0) - totalMacros.protein,
-    carbohydrates: (targets.carbohydrates || 0) - totalMacros.carbohydrates,
-    fat: (targets.fat || 0) - totalMacros.fat,
-    fiber: (targets.fiber || 0) - totalMacros.fiber,
+    calories: (targets.calories || 0) - perDayMacros.calories,
+    protein: (targets.protein || 0) - perDayMacros.protein,
+    carbohydrates: (targets.carbohydrates || 0) - perDayMacros.carbohydrates,
+    fat: (targets.fat || 0) - perDayMacros.fat,
+    fiber: (targets.fiber || 0) - perDayMacros.fiber,
   };
 
   return (
@@ -73,6 +81,14 @@ const MacrosTable = ({ ingredients, targets = {} }) => {
             <TableCell>{formatCellNumber(totalMacros.carbohydrates)}</TableCell>
             <TableCell>{formatCellNumber(totalMacros.fat)}</TableCell>
             <TableCell>{formatCellNumber(totalMacros.fiber)}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Per Day</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.calories)}</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.protein)}</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.carbohydrates)}</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.fat)}</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.fiber)}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Remaining</TableCell>

--- a/Frontend/nutrition-frontend/src/components/planning/Planning.js
+++ b/Frontend/nutrition-frontend/src/components/planning/Planning.js
@@ -186,7 +186,7 @@ function Planning() {
             Add Meal
           </Button>
           <PlanningTable ingredients={dayMeals} onIngredientRemove={(data) => handleDayPlanChange(dayIndex, data)} />
-          <MacrosTable ingredients={dayMeals} targets={targets} />
+          <MacrosTable ingredients={dayMeals} targets={targets} duration={duration} />
         </div>
       ))}
       <div style={{ marginTop: "20px" }}>


### PR DESCRIPTION
## Summary
- calculate per-day macros by dividing totals by duration
- show total and per-day macro rows and compute remaining against targets
- pass plan duration into MacrosTable from Planning

## Testing
- `cd Frontend/nutrition-frontend && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_689934f573c883228f2b537aa1f0a411