### PR TITLE
Refactor planning UI to meal terminology

### DIFF
--- a/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
+++ b/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
@@ -5,7 +5,7 @@ import { Paper, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/ma
 
 import { formatCellNumber } from "./utils";
 
-const MacrosTable = ({ ingredients, targets = {} }) => {
+const MacrosTable = ({ meals, targets = {} }) => {
   const [totalMacros, setTotalMacros] = useState({
     calories: 0,
     protein: 0,
@@ -21,19 +21,19 @@ const MacrosTable = ({ ingredients, targets = {} }) => {
         carbohydrates = 0,
         fat = 0,
         fiber = 0;
-      ingredients.forEach((ingredient) => {
-        const quantity = ingredient.quantity || 1;
-        calories += quantity * ingredient.nutrition.calories;
-        protein += quantity * ingredient.nutrition.protein;
-        carbohydrates += quantity * ingredient.nutrition.carbohydrates;
-        fat += quantity * ingredient.nutrition.fat;
-        fiber += quantity * ingredient.nutrition.fiber;
+      meals.forEach((meal) => {
+        const quantity = meal.quantity || 1;
+        calories += quantity * meal.nutrition.calories;
+        protein += quantity * meal.nutrition.protein;
+        carbohydrates += quantity * meal.nutrition.carbohydrates;
+        fat += quantity * meal.nutrition.fat;
+        fiber += quantity * meal.nutrition.fiber;
       });
       setTotalMacros({ calories, protein, carbohydrates, fat, fiber });
     };
 
     calculateTotalMacros();
-  }, [ingredients]);
+  }, [meals]);
 
   const remaining = {
     calories: (targets.calories || 0) - totalMacros.calories,

--- a/Frontend/nutrition-frontend/src/components/planning/Planning.js
+++ b/Frontend/nutrition-frontend/src/components/planning/Planning.js
@@ -83,7 +83,7 @@ function Planning() {
     if (!selection.mealId) return;
     const meal = meals.find((m) => m.id === selection.mealId);
     const macros = calculateMealMacros(meal);
-    const ingredient = {
+    const planMeal = {
       mealId: meal.id,
       name: meal.name,
       quantity: parseFloat(selection.servings) || 1,
@@ -91,7 +91,7 @@ function Planning() {
     };
     setPlan((prev) => {
       const updated = [...prev];
-      updated[dayIndex] = [...updated[dayIndex], ingredient];
+      updated[dayIndex] = [...updated[dayIndex], planMeal];
       return updated;
     });
     setMealSelections((prev) => {
@@ -101,14 +101,10 @@ function Planning() {
     });
   };
 
-  const handleDayPlanChange = (dayIndex, data) => {
+  const handleDayPlanChange = (dayIndex, updatedMeals) => {
     setPlan((prev) => {
       const updated = [...prev];
-      if (Array.isArray(data)) {
-        updated[dayIndex] = data;
-      } else {
-        updated[dayIndex] = updated[dayIndex].filter((item) => item !== data);
-      }
+      updated[dayIndex] = updatedMeals;
       return updated;
     });
   };
@@ -185,8 +181,8 @@ function Planning() {
           <Button style={{ marginLeft: "10px" }} variant="contained" onClick={() => handleAddMeal(dayIndex)}>
             Add Meal
           </Button>
-          <PlanningTable ingredients={dayMeals} onIngredientRemove={(data) => handleDayPlanChange(dayIndex, data)} />
-          <MacrosTable ingredients={dayMeals} targets={targets} />
+          <PlanningTable meals={dayMeals} onPlanChange={(data) => handleDayPlanChange(dayIndex, data)} />
+          <MacrosTable meals={dayMeals} targets={targets} />
         </div>
       ))}
       <div style={{ marginTop: "20px" }}>

--- a/Frontend/nutrition-frontend/src/components/planning/PlanningTable.js
+++ b/Frontend/nutrition-frontend/src/components/planning/PlanningTable.js
@@ -7,25 +7,26 @@ import { formatCellNumber } from "./utils";
 
 // Function to format the cell content
 
-const PlanningTable = ({ ingredients, onIngredientRemove }) => {
-  const handleIngredientRemove = (ingredient) => {
-    onIngredientRemove(ingredient);
+const PlanningTable = ({ meals, onPlanChange }) => {
+  const handleRemove = (meal) => {
+    const updatedMeals = meals.filter((m) => m !== meal);
+    onPlanChange(updatedMeals);
   };
 
   const handleQuantityChange = (index, quantity) => {
-    const updatedIngredients = [...ingredients];
-    updatedIngredients[index].quantity = quantity;
-    onIngredientRemove(updatedIngredients);
+    const updatedMeals = [...meals];
+    updatedMeals[index] = { ...updatedMeals[index], quantity };
+    onPlanChange(updatedMeals);
   };
 
   return (
     <div>
-      <h1>Planning Table</h1>
+      <h1>Meal Plan</h1>
       <Table component={Paper}>
         <TableHead>
           <TableRow>
             <TableCell></TableCell>
-            <TableCell>Name</TableCell>
+            <TableCell>Meal</TableCell>
             <TableCell>Quantity</TableCell>
             <TableCell>Calories</TableCell>
             <TableCell>Protein</TableCell>
@@ -35,22 +36,26 @@ const PlanningTable = ({ ingredients, onIngredientRemove }) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {ingredients.map((ingredient, index) => (
+          {meals.map((meal, index) => (
             <TableRow key={index}>
               <TableCell>
-                <Button variant="contained" color="error" onClick={() => handleIngredientRemove(ingredient)}>
+                <Button variant="contained" color="error" onClick={() => handleRemove(meal)}>
                   Remove
                 </Button>
               </TableCell>
-              <TableCell>{ingredient.name}</TableCell>
+              <TableCell>{meal.name}</TableCell>
               <TableCell>
-                <input type="number" value={ingredient.quantity || 1} onChange={(e) => handleQuantityChange(index, e.target.value)} />
+                <input
+                  type="number"
+                  value={meal.quantity || 1}
+                  onChange={(e) => handleQuantityChange(index, e.target.value)}
+                />
               </TableCell>
-              <TableCell>{formatCellNumber(ingredient.quantity * ingredient.nutrition.calories)}</TableCell>
-              <TableCell>{formatCellNumber(ingredient.quantity * ingredient.nutrition.protein)}</TableCell>
-              <TableCell>{formatCellNumber(ingredient.quantity * ingredient.nutrition.carbohydrates)}</TableCell>
-              <TableCell>{formatCellNumber(ingredient.quantity * ingredient.nutrition.fat)}</TableCell>
-              <TableCell>{formatCellNumber(ingredient.quantity * ingredient.nutrition.fiber)}</TableCell>
+              <TableCell>{formatCellNumber(meal.quantity * meal.nutrition.calories)}</TableCell>
+              <TableCell>{formatCellNumber(meal.quantity * meal.nutrition.protein)}</TableCell>
+              <TableCell>{formatCellNumber(meal.quantity * meal.nutrition.carbohydrates)}</TableCell>
+              <TableCell>{formatCellNumber(meal.quantity * meal.nutrition.fat)}</TableCell>
+              <TableCell>{formatCellNumber(meal.quantity * meal.nutrition.fiber)}</TableCell>
             </TableRow>
           ))}
         </TableBody>


### PR DESCRIPTION
## Summary
- rename planning table props from ingredients to meals
- replace onIngredientRemove with onPlanChange for updates and removals
- update macros table and planning component to new meal-based terminology

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_689934faaa98832281ed0fc658f38279