### PR TITLE
feat: compute per day macros for plans

### DIFF
--- a/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
+++ b/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
@@ -5,7 +5,7 @@ import { Paper, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/ma
 
 import { formatCellNumber } from "./utils";
 
-const MacrosTable = ({ meals, targets = {} }) => {
+const MacrosTable = ({ meals, targets = {}, duration = 1 }) => {
   const [totalMacros, setTotalMacros] = useState({
     calories: 0,
     protein: 0,
@@ -35,12 +35,20 @@ const MacrosTable = ({ meals, targets = {} }) => {
     calculateTotalMacros();
   }, [meals]);
 
+  const perDayMacros = {
+    calories: totalMacros.calories / duration,
+    protein: totalMacros.protein / duration,
+    carbohydrates: totalMacros.carbohydrates / duration,
+    fat: totalMacros.fat / duration,
+    fiber: totalMacros.fiber / duration,
+  };
+
   const remaining = {
-    calories: (targets.calories || 0) - totalMacros.calories,
-    protein: (targets.protein || 0) - totalMacros.protein,
-    carbohydrates: (targets.carbohydrates || 0) - totalMacros.carbohydrates,
-    fat: (targets.fat || 0) - totalMacros.fat,
-    fiber: (targets.fiber || 0) - totalMacros.fiber,
+    calories: (targets.calories || 0) - perDayMacros.calories,
+    protein: (targets.protein || 0) - perDayMacros.protein,
+    carbohydrates: (targets.carbohydrates || 0) - perDayMacros.carbohydrates,
+    fat: (targets.fat || 0) - perDayMacros.fat,
+    fiber: (targets.fiber || 0) - perDayMacros.fiber,
   };
 
   return (
@@ -67,12 +75,12 @@ const MacrosTable = ({ meals, targets = {} }) => {
             <TableCell>{formatCellNumber(targets.fiber || 0)}</TableCell>
           </TableRow>
           <TableRow>
-            <TableCell>Total</TableCell>
-            <TableCell>{formatCellNumber(totalMacros.calories)}</TableCell>
-            <TableCell>{formatCellNumber(totalMacros.protein)}</TableCell>
-            <TableCell>{formatCellNumber(totalMacros.carbohydrates)}</TableCell>
-            <TableCell>{formatCellNumber(totalMacros.fat)}</TableCell>
-            <TableCell>{formatCellNumber(totalMacros.fiber)}</TableCell>
+            <TableCell>Per Day</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.calories)}</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.protein)}</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.carbohydrates)}</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.fat)}</TableCell>
+            <TableCell>{formatCellNumber(perDayMacros.fiber)}</TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Remaining</TableCell>

--- a/Frontend/nutrition-frontend/src/components/planning/Planning.js
+++ b/Frontend/nutrition-frontend/src/components/planning/Planning.js
@@ -182,9 +182,9 @@ function Planning() {
             Add Meal
           </Button>
           <PlanningTable meals={dayMeals} onPlanChange={(data) => handleDayPlanChange(dayIndex, data)} />
-          <MacrosTable meals={dayMeals} targets={targets} />
         </div>
       ))}
+      <MacrosTable meals={plan.flat()} targets={targets} duration={duration} />
       <div style={{ marginTop: "20px" }}>
         <TextField label="Plan ID" value={planId} onChange={(e) => setPlanId(e.target.value)} />
         <Button variant="contained" style={{ marginLeft: "10px" }} onClick={handleSavePlan}>


### PR DESCRIPTION
## Summary
- compute per-day macro totals by dividing plan macros by duration
- aggregate all meals and display a single MacrosTable for the plan

## Testing
- `cd Frontend/nutrition-frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68993f3834e8832287d40ae31b088716