### PR TITLE
Use branch-specific project names for Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ A full-stack nutrition planning and tracking app built with:
 git clone <your-repo-url>
 cd Nutrition
 
-# Start all services
-docker-compose up --build
+# Start all services for the current Git branch
+./scripts/compose-up-branch.sh --build
+
+# When you're done, remove containers and volumes for this branch
+BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]' | sed 's#[^a-z0-9]#-#g')
+docker compose -p nutrition-$BRANCH down -v
 ```
 
 * Frontend: [http://localhost:3000](http://localhost:3000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.9"
 services:
   db:
     image: postgres:13
-    container_name: nutrition-db
     environment:
       POSTGRES_USER: nutrition_user
       POSTGRES_PASSWORD: nutrition_pass
@@ -25,7 +24,6 @@ services:
     build:
       context: .
       dockerfile: Backend/Dockerfile
-    container_name: nutrition-backend
     environment:
       FLASK_ENV: development
       DATABASE_URL: postgresql://nutrition_user:nutrition_pass@db:5432/nutrition
@@ -41,7 +39,6 @@ services:
     build:
       context: .
       dockerfile: Frontend/nutrition-frontend/Dockerfile
-    container_name: nutrition-frontend
     depends_on:
       - backend
     ports:

--- a/scripts/compose-up-branch.sh
+++ b/scripts/compose-up-branch.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SANITIZED=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's#[^a-z0-9]#-#g')
+
+echo "Starting containers for branch: $BRANCH (sanitized: $SANITIZED)"
+
+docker compose -p "nutrition-$SANITIZED" up -d "$@"


### PR DESCRIPTION
## Summary
- remove hardcoded `container_name` values so Compose uses project-scoped names
- add `scripts/compose-up-branch.sh` to launch containers with a branch-specific project name
- document branch-specific startup and cleanup in `README`

## Testing
- `CI=true npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6899434445f883228f5e5f8a711eaa67