### PR TITLE
Enable backend live reload via bind mount

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -14,10 +14,10 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies
-COPY Backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY Backend/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Copy backend source
-COPY Backend/ .
+COPY Backend/ /app
 
 CMD ["python", "backend.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - ./Backend:/app
+    command: flask --app backend.py --debug run --host=0.0.0.0
     networks:
       - nutrition-net
     expose:


### PR DESCRIPTION
## Summary
- Mount local Backend directory into backend container for live development
- Install backend dependencies separately from source in Docker build
- Run backend with Flask's debug reloader

## Testing
- `python -m py_compile Backend/backend.py`
- `docker compose config` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899434b372c83228eabd5395b780bea