### PR TITLE
Fix planning utilities import path

### DIFF
--- a/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
+++ b/Frontend/nutrition-frontend/src/components/planning/MacrosTable.js
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from "react";
 import { Paper, Table, TableBody, TableCell, TableHead, TableRow } from "@mui/material";
 
-import { formatCellNumber } from "./utils";
+import { formatCellNumber } from "../../utils/utils";
 
 const MacrosTable = ({ ingredients }) => {
   const [totalMacros, setTotalMacros] = useState({

--- a/Frontend/nutrition-frontend/src/components/planning/PlanningTable.js
+++ b/Frontend/nutrition-frontend/src/components/planning/PlanningTable.js
@@ -3,7 +3,7 @@
 import React from "react";
 import { Paper, Table, TableBody, TableCell, TableHead, TableRow, Button } from "@mui/material";
 
-import { formatCellNumber } from "./utils";
+import { formatCellNumber } from "../../utils/utils";
 
 // Function to format the cell content
 

--- a/Frontend/nutrition-frontend/src/components/planning/utils.js
+++ b/Frontend/nutrition-frontend/src/components/planning/utils.js
@@ -1,0 +1,1 @@
+export { formatCellNumber } from "../../utils/utils";


### PR DESCRIPTION
## Summary
- import `formatCellNumber` from shared utils in planning tables
- add optional utils re-export in planning components folder

## Testing
- `cd Frontend/nutrition-frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689945d1b7bc8322bfa49f8d3b3e955a