### PR TITLE
Enable frontend auto reload in Docker

### DIFF
--- a/Frontend/nutrition-frontend/Dockerfile
+++ b/Frontend/nutrition-frontend/Dockerfile
@@ -1,3 +1,11 @@
+# Development stage
+FROM node:23-slim AS dev
+WORKDIR /app
+COPY Frontend/nutrition-frontend/package*.json ./
+RUN npm install
+COPY Frontend/nutrition-frontend/ .
+CMD ["npm", "start"]
+
 # Build stage
 FROM node:23-slim AS build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,16 @@ services:
     build:
       context: .
       dockerfile: Frontend/nutrition-frontend/Dockerfile
+      target: dev
     depends_on:
       - backend
+    volumes:
+      - ./Frontend/nutrition-frontend:/app
+      - /app/node_modules
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
     ports:
-      - "3000:80"
+      - "3000:3000"
     networks:
       - nutrition-net
 


### PR DESCRIPTION
## Summary
- add development stage to frontend Dockerfile to run React dev server
- mount frontend source and enable polling for hot reload via docker-compose

## Testing
- `CI=true npm test`
- `docker-compose config` *(fails: command not found; apt-get update fails with 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899489df1a88322bc529499a6a47c55