### PR TITLE
Simplify compose tooling and avoid branch port collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ git clone <your-repo-url>
 cd Nutrition
 
 # Start all services for the current Git branch
-./scripts/compose-up-branch.sh --build
+pwsh ./scripts/compose-up-branch.ps1 --build
 
 # When you're done, remove containers and volumes for this branch
 BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]' | sed 's#[^a-z0-9]#-#g')
 docker compose -p nutrition-$BRANCH down -v
 ```
 
-* Frontend: [http://localhost:3000](http://localhost:3000)
-* Backend API: [http://localhost:5000](http://localhost:5000)
+* Frontend: `http://localhost:<FRONTEND_PORT>` (prints on startup, default 3000)
+* Backend API: `http://localhost:<BACKEND_PORT>` (default 5000)
+* PostgreSQL: `localhost:<DB_PORT>` (default 5432)
 
 > 📝 The database is seeded automatically on first run using `Database/createtables.sql`, `addingredients.sql`, and `addnutrition.sql`.
 
@@ -56,6 +57,7 @@ Nutrition/
 │
 ├── docker-compose.yml          # Orchestration config
 └── scripts/
+    ├── compose-up-branch.ps1   # Start stack with branch-specific ports
     └── print-tree.ps1          # Dev tooling
 ```
 
@@ -63,11 +65,11 @@ Nutrition/
 
 ## ⚙️ Environment and Configuration
 
-| Service    | Port | Description                    |
-| ---------- | ---- | ------------------------------ |
-| Frontend   | 3000 | React app served via Nginx     |
-| Backend    | 5000 | Flask API                      |
-| PostgreSQL | 5432 | Nutrition DB with initial data |
+| Service    | Base Port | Description                                   |
+| ---------- | ---------- | ---------------------------------------------- |
+| Frontend   | 3000       | React app served via Nginx (offset per branch) |
+| Backend    | 5000       | Flask API (offset per branch)                  |
+| PostgreSQL | 5432       | Nutrition DB with initial data (offset per branch) |
 
 Environment variables are defined in `docker-compose.yml`:
 
@@ -103,7 +105,7 @@ DBeaver is a free and powerful GUI for inspecting your PostgreSQL database. You 
 | Field        | Value            |
 | ------------ | ---------------- |
 | **Host**     | `localhost`      |
-| **Port**     | `5432`           |
+| **Port**     | `<DB_PORT>` (see compose script output) |
 | **Database** | `nutrition`      |
 | **Username** | `nutrition_user` |
 | **Password** | `nutrition_pass` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - dbdata:/var/lib/postgresql/data
       - ./Database:/docker-entrypoint-initdb.d
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
     networks:
       - nutrition-net
 
@@ -35,8 +35,8 @@ services:
     command: flask --app backend.py --debug run --host=0.0.0.0
     networks:
       - nutrition-net
-    expose:
-      - "5000"
+    ports:
+      - "${BACKEND_PORT:-5000}:5000"
 
   frontend:
     build:
@@ -51,7 +51,7 @@ services:
     environment:
       CHOKIDAR_USEPOLLING: "true"
     ports:
-      - "3000:3000"
+      - "${FRONTEND_PORT:-3000}:3000"
     networks:
       - nutrition-net
 

--- a/scripts/compose-up-branch.ps1
+++ b/scripts/compose-up-branch.ps1
@@ -1,43 +1,21 @@
 # scripts/compose-up-branch.ps1
 [CmdletBinding()]
 param(
-  # Optional: restrict to specific services, e.g. "backend frontend"
   [Parameter(ValueFromRemainingArguments=$true)]
   [string[]]$Services
 )
 
-Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
-
-# Ensure git is available
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-  throw "git not found in PATH."
-}
-
-# Resolve repo root (folder that contains docker-compose.yml)
 $repoRoot = Split-Path -Parent $PSScriptRoot
-if (-not (Test-Path (Join-Path $repoRoot 'docker-compose.yml'))) {
-  throw "docker-compose.yml not found at $repoRoot"
-}
+Set-Location $repoRoot
 
-# Get current branch and sanitize for docker compose project name
-$branch = (git -C $repoRoot rev-parse --abbrev-ref HEAD).Trim()
-if ([string]::IsNullOrWhiteSpace($branch)) { throw "Could not determine git branch." }
-
+$branch = (git rev-parse --abbrev-ref HEAD).Trim()
 $sanitized = ($branch.ToLower() -replace '[^a-z0-9]', '-').Trim('-')
-if ([string]::IsNullOrWhiteSpace($sanitized)) { $sanitized = 'default' }
 
-Write-Host "Starting containers for branch: $branch (sanitized: $sanitized)"
+$offset = [math]::Abs($branch.GetHashCode()) % 100
+$env:DB_PORT = 5432 + $offset
+$env:BACKEND_PORT = 5000 + $offset
+$env:FRONTEND_PORT = 3000 + $offset
 
-# Run docker compose
-Push-Location $repoRoot
-try {
-  if ($Services -and $Services.Count -gt 0) {
-    docker compose -p "nutrition-$sanitized" up -d @Services
-  } else {
-    docker compose -p "nutrition-$sanitized" up -d
-  }
-}
-finally {
-  Pop-Location
-}
+Write-Host "Starting '$branch' with ports:`n  DB: $env:DB_PORT`n  Backend: $env:BACKEND_PORT`n  Frontend: $env:FRONTEND_PORT"
+
+docker compose -p "nutrition-$sanitized" up -d @Services


### PR DESCRIPTION
## Summary
- parameterize service ports in docker-compose
- add short compose-up script with branch-based port offsets
- document dynamic ports and new script usage

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68994f5aa7f88322b9e62ef1842bd299