### PR TITLE
docs: move database access instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+## Database access
+
+### 🛠️ Database Access with DBeaver
+
+DBeaver is a free and powerful GUI for inspecting your PostgreSQL database. You can use it to explore tables, run queries, and debug data directly.
+
+#### 🔽 Step 1: Install DBeaver
+
+* Download and install the Community Edition from:
+  👉 [https://dbeaver.io/download/](https://dbeaver.io/download/)
+
+#### ⚙️ Step 2: Connect to the Dockerized Database
+
+1. **Open DBeaver** and click `Database → New Database Connection`
+2. Choose **PostgreSQL** and click **Next**
+3. Enter the following connection info:
+
+| Field        | Value            |
+| ------------ | ---------------- |
+| **Host**     | `localhost`      |
+| **Port**     | `5432`           |
+| **Database** | `nutrition`      |
+| **Username** | `nutrition_user` |
+| **Password** | `nutrition_pass` |
+
+4. Click **Test Connection**.
+   If prompted to download the PostgreSQL driver, allow it.
+5. Click **Finish** to connect.
+
+> 📝 If the connection fails, make sure the Docker containers are running with:
+>
+> ```bash
+> docker-compose up
+> ```

--- a/README.md
+++ b/README.md
@@ -85,38 +85,9 @@ postgresql://nutrition_user:nutrition_pass@db:5432/nutrition
 
 ---
 
-### 🛠️ Database Access with DBeaver
+### 🛠️ Database access
 
-DBeaver is a free and powerful GUI for inspecting your PostgreSQL database. You can use it to explore tables, run queries, and debug data directly.
-
-#### 🔽 Step 1: Install DBeaver
-
-* Download and install the Community Edition from:
-  👉 [https://dbeaver.io/download/](https://dbeaver.io/download/)
-
-#### ⚙️ Step 2: Connect to the Dockerized Database
-
-1. **Open DBeaver** and click `Database → New Database Connection`
-2. Choose **PostgreSQL** and click **Next**
-3. Enter the following connection info:
-
-| Field        | Value            |
-| ------------ | ---------------- |
-| **Host**     | `localhost`      |
-| **Port**     | `5432`           |
-| **Database** | `nutrition`      |
-| **Username** | `nutrition_user` |
-| **Password** | `nutrition_pass` |
-
-4. Click **Test Connection**.
-   If prompted to download the PostgreSQL driver, allow it.
-5. Click **Finish** to connect.
-
-> 📝 If the connection fails, make sure the Docker containers are running with:
->
-> ```bash
-> docker-compose up
-> ```
+For detailed instructions on connecting to the development database with DBeaver, see the [Database access section](CONTRIBUTING.md#database-access) in the contributing guide.
 
 ---
 


### PR DESCRIPTION
## Summary
- create contributing guide with database access instructions
- reference contributing guide from README

## Testing
- `CI=true npm test --prefix Frontend/nutrition-frontend -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689950ba77b0832291c0bc5d24e3825a