### PR TITLE
Add branch-aware CSV import helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,18 +22,20 @@ Data will persist as long as you do not also delete the Docker volume
 
 ## Database management
 
-The Python script import_from_csv.py will remove all existing data from the database and import the specified data.
+The `import_from_csv.py` script will remove all existing data from the database
+and import the specified data. Use the wrapper script so it targets the
+containers for your current branch.
 
 To import production data
 
-```python
-python .\\Database\\import_from_csv.py
+```bash
+./scripts/import-from-csv.sh -production
 ```
 
 To import test data
 
-```python
-python .\\Database\\import_from_csv.py --test
+```bash
+./scripts/import-from-csv.sh -test
 ```
 
 To drop and recreate the tables before importing:

--- a/Database/db_config.py
+++ b/Database/db_config.py
@@ -11,6 +11,8 @@ DB_CONFIG = {
     "user": "nutrition_user",
     "password": "nutrition_pass",
     "host": "localhost",
-    "port": 5432,
+    # Allow the database port to be overridden so scripts can connect to
+    # branch-specific containers that map Postgres to a unique host port.
+    "port": int(os.environ.get("DB_PORT", 5432)),
 }
 

--- a/Database/import_from_csv.py
+++ b/Database/import_from_csv.py
@@ -79,12 +79,14 @@ def import_csv(cur, folder, ordered_tables):
 
 def main():
     parser = argparse.ArgumentParser(description="Import CSVs into PostgreSQL.")
-    parser.add_argument("--test", action="store_true", help="Use test CSV files (e.g., table_test.csv)")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--production", action="store_true", help="Use production CSV files")
+    group.add_argument("--test", action="store_true", help="Use test CSV files (e.g., table_test.csv)")
     args = parser.parse_args()
 
-    data_dir = os.path.join(BASE_DIR, "test_data" if args.test else "production_data")
+    data_dir = os.path.join(BASE_DIR, "production_data" if args.production else "test_data")
 
-    mode = "TEST" if args.test else "PRODUCTION"
+    mode = "PRODUCTION" if args.production else "TEST"
     print(f"Running in {mode} mode — reading from: {data_dir}")
 
     if not os.path.exists(data_dir):

--- a/scripts/import-from-csv.sh
+++ b/scripts/import-from-csv.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Wrapper to run import_from_csv.py against the containers for the current branch.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") -production|-test" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+case "$1" in
+  -production|--production)
+    flag="--production"
+    ;;
+  -test|--test)
+    flag="--test"
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+# Determine repo root
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# Determine branch-specific project name
+branch="$(git rev-parse --abbrev-ref HEAD)"
+san=$(echo "$branch" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^[-]*//;s/[-]*$//')
+project="nutrition-$san"
+
+# Ensure containers are running for this branch
+if [[ -z $(docker compose -p "$project" ps -q 2>/dev/null) ]]; then
+  echo "Warning: no containers running for branch '$branch'. Run the compose script first." >&2
+  exit 1
+fi
+
+# Get mapped database port
+port_line=$(docker compose -p "$project" port db 5432 2>/dev/null || true)
+if [[ -z "$port_line" ]]; then
+  echo "Warning: unable to determine database port for project '$project'." >&2
+  exit 1
+fi
+DB_PORT=${port_line##*:}
+
+export DB_PORT
+python Database/import_from_csv.py "$flag"


### PR DESCRIPTION
## Summary
- allow database port override via `DB_PORT` env variable
- require explicit `--production` or `--test` flag in CSV import script
- add `scripts/import-from-csv.sh` to target containers for current branch

## Testing
- `python -m py_compile Database/db_config.py Database/import_from_csv.py`
- `./scripts/import-from-csv.sh -test` *(fails: no containers running)*

------
https://chatgpt.com/codex/tasks/task_e_689be0c3a8148322ab40c562be6be4d2