### PR TITLE
Add data seeding option to compose script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ git clone <your-repo-url>
 cd Nutrition
 
 # Start all services for the current Git branch
-pwsh ./scripts/compose-up-branch.ps1 --build
+# Choose one of -production, -test, or -empty to control database seeding
+pwsh ./scripts/compose-up-branch.ps1 -test --build
 
 # When you're done, remove containers and volumes for this branch
 BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]' | sed 's#[^a-z0-9]#-#g')

--- a/scripts/compose-up-branch.ps1
+++ b/scripts/compose-up-branch.ps1
@@ -1,6 +1,15 @@
 # scripts/compose-up-branch.ps1
-[CmdletBinding()]
+[CmdletBinding(DefaultParameterSetName='Empty')]
 param(
+  [Parameter(ParameterSetName='Production', Mandatory=$true)]
+  [switch]$production,
+
+  [Parameter(ParameterSetName='Test', Mandatory=$true)]
+  [switch]$test,
+
+  [Parameter(ParameterSetName='Empty', Mandatory=$true)]
+  [switch]$empty,
+
   [Parameter(ValueFromRemainingArguments=$true)]
   [string[]]$Services
 )
@@ -10,6 +19,7 @@ Set-Location $repoRoot
 
 $branch = (git rev-parse --abbrev-ref HEAD).Trim()
 $sanitized = ($branch.ToLower() -replace '[^a-z0-9]', '-').Trim('-')
+$project = "nutrition-$sanitized"
 
 $offset = [math]::Abs($branch.GetHashCode()) % 100
 $env:DB_PORT = 5432 + $offset
@@ -18,4 +28,22 @@ $env:FRONTEND_PORT = 3000 + $offset
 
 Write-Host "Starting '$branch' with ports:`n  DB: $env:DB_PORT`n  Backend: $env:BACKEND_PORT`n  Frontend: $env:FRONTEND_PORT"
 
-docker compose -p "nutrition-$sanitized" up -d @Services
+docker compose -p $project up -d @Services
+
+if (-not $empty) {
+  Write-Host "Waiting for database to be ready..."
+  do {
+    Start-Sleep -Seconds 1
+    docker compose -p $project exec -T db pg_isready -U nutrition_user -d nutrition | Out-Null
+  } until ($LASTEXITCODE -eq 0)
+
+  if ($production) {
+    Write-Host "Importing production data..."
+    python Database/import_from_csv.py --production
+  } elseif ($test) {
+    Write-Host "Importing test data..."
+    python Database/import_from_csv.py --test
+  }
+} else {
+  Write-Host "Starting with empty database."
+}


### PR DESCRIPTION
## Summary
- require a data set flag (-production, -test, or -empty) when starting containers
- automatically import production or test CSV data after `docker compose up`
- document new usage in README

## Testing
- `pytest`
- `npm test` *(no tests found)*
- `pwsh -NoLogo -NoProfile -Command "Get-Help ./scripts/compose-up-branch.ps1"` *(missing: pwsh)


------
https://chatgpt.com/codex/tasks/task_e_689be443ea748322816c61d219ace579