### PR TITLE
fix: use correct database url env

### DIFF
--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -15,9 +15,14 @@ app.register_blueprint(ingredient_blueprint)
 app.register_blueprint(meal_blueprint)
 
 CORS(app)
-app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv(
-    'SQLALCHEMY_DATABASE_URI',
-    'postgresql://nutrition_user:nutrition_pass@nutrition-db:5432/nutrition'
+# Configure the database connection string. Historically the application
+# looked for `SQLALCHEMY_DATABASE_URI`, but docker-compose provides the
+# URL via the more conventional `DATABASE_URL`.  Attempt to read either
+# environment variable and fall back to the default connection string
+# used by the development stack.
+app.config['SQLALCHEMY_DATABASE_URI'] = (
+    os.getenv('SQLALCHEMY_DATABASE_URI')
+    or os.getenv('DATABASE_URL', 'postgresql://nutrition_user:nutrition_pass@db:5432/nutrition')
 )
 db.init_app(app)
 


### PR DESCRIPTION
## Summary
- read DATABASE_URL or SQLALCHEMY_DATABASE_URI for backend DB connection
- default to Postgres service `db`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bea22c48083228358b0e411eda75b