### PR TITLE
fix: ensure frontend routes requests to backend API

### DIFF
--- a/Frontend/nutrition-frontend/package.json
+++ b/Frontend/nutrition-frontend/package.json
@@ -2,6 +2,7 @@
   "name": "nutrition-frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://backend:5000",
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",

--- a/Frontend/nutrition-frontend/src/components/data/ingredient/form/IngredientForm.js
+++ b/Frontend/nutrition-frontend/src/components/data/ingredient/form/IngredientForm.js
@@ -90,7 +90,7 @@ function IngredientForm({ ingredientToEditData }) {
     };
 
     if (isEditMode) {
-      const url = `http://localhost:5000/ingredients/${toDatabaseIngredient.id}`;
+      const url = `/api/ingredients/${toDatabaseIngredient.id}`;
       const method = "PUT";
       const data = toDatabaseIngredient;
 
@@ -99,7 +99,7 @@ function IngredientForm({ ingredientToEditData }) {
         setFetching(false);
       });
     } else {
-      const url = "http://localhost:5000/ingredients";
+      const url = "/api/ingredients";
       const method = "POST";
       const data = toDatabaseIngredient;
 
@@ -114,7 +114,7 @@ function IngredientForm({ ingredientToEditData }) {
 
   const handleIngredientDelete = () => {
     if (ingredientToEdit) {
-      fetch(`http://localhost:5000/ingredients/${ingredientToEdit.id}`, {
+      fetch(`/api/ingredients/${ingredientToEdit.id}`, {
         method: "DELETE",
       })
         .then((response) => {

--- a/Frontend/nutrition-frontend/src/temp/IngredientsContext.js
+++ b/Frontend/nutrition-frontend/src/temp/IngredientsContext.js
@@ -10,7 +10,7 @@ export const IngredientsProvider = ({ children }) => {
   const [needsRefetch, setNeedsRefetch] = useState(false);
 
   const fetchData = () => {
-    fetch("http://localhost:5000/ingredients")
+    fetch("/api/ingredients")
       .then((response) => response.json())
       .then((data) => {
         const ingredientsWith1gUnit = data.map((ingredient) => {

--- a/Frontend/nutrition-frontend/src/temp/MealsContext.js
+++ b/Frontend/nutrition-frontend/src/temp/MealsContext.js
@@ -12,7 +12,7 @@ export const MealsProvider = ({ children }) => {
   const [needsRefetch, setNeedsRefetch] = useState(false);
 
   const fetchData = () => {
-    fetch("http://localhost:5000/meals")
+    fetch("/api/meals")
       .then((response) => response.json())
       .then((data) => {
         const formattedData = data.map((meal) => ({


### PR DESCRIPTION
## Summary
- proxy React dev server requests to backend container
- replace hard-coded localhost URLs with `/api` paths for ingredient fetches
- clean up temporary context fetches

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689beecb030083228af6f70e54d441bc