### PR TITLE
feat: set Vite dev server port

### DIFF
--- a/Frontend/nutrition-frontend/vite.config.js
+++ b/Frontend/nutrition-frontend/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
     setupFiles: "./src/tests/setupTests.js",
   },
   server: {
+    port: 3000,
     proxy: {
       "/api": {
         target: "http://backend:5000",


### PR DESCRIPTION
## Summary
- configure Vite dev server to run on port 3000

## Testing
- `npm test` *(fails: Failed to parse source for import analysis because the content contains invalid JS syntax)*

------
https://chatgpt.com/codex/tasks/task_e_689c02f3eff4832281156f4f5e864a07