### PR TITLE
feat: make API proxy configurable

### DIFF
--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const apiUrl = process.env.VITE_API_URL || "http://localhost:5000";
+
 export default defineConfig({
   plugins: [react()],
   test: {
@@ -12,7 +14,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       "/api": {
-        target: "http://backend:5000",
+        target: apiUrl,
         changeOrigin: true,
       },
     },

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ POSTGRES_PASSWORD: nutrition_pass
 POSTGRES_DB: nutrition
 ```
 
+The frontend development server proxies API requests to the backend. Set `VITE_API_URL` to override the default target (falls back to `http://localhost:5000`).
+
 Backend connects using:
 
 ```


### PR DESCRIPTION
## Summary
- allow frontend dev server to use VITE_API_URL for API proxy
- document VITE_API_URL environment variable

## Testing
- `npm test -- --run` *(fails: Failed to parse source for import analysis, Expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_689c099f33a883229cd0e8057a9fa419