### PR TITLE
refactor: migrate tests to vitest

### DIFF
--- a/Frontend/src/tests/App.test.jsx
+++ b/Frontend/src/tests/App.test.jsx
@@ -1,26 +1,27 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { vi, beforeEach } from "vitest";
 import App from "../App";
 
 var mockIngredientData;
 var mockMealData;
 
-jest.mock("../components/data/ingredient/IngredientData", () => ({
+vi.mock("../components/data/ingredient/IngredientData", () => ({
   __esModule: true,
   default: (...args) => mockIngredientData(...args),
 }));
 
-jest.mock("../components/data/meal/MealData", () => ({
+vi.mock("../components/data/meal/MealData", () => ({
   __esModule: true,
   default: (...args) => mockMealData(...args),
 }));
 
-mockIngredientData = jest.fn(() => <div>IngredientDataComponent</div>);
-mockMealData = jest.fn(() => <div>MealDataComponent</div>);
+mockIngredientData = vi.fn(() => <div>IngredientDataComponent</div>);
+mockMealData = vi.fn(() => <div>MealDataComponent</div>);
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  vi.clearAllMocks();
 });
 
 test("renders tabs and switches between Meals and Ingredients views", () => {

--- a/Frontend/src/tests/MealTable.test.jsx
+++ b/Frontend/src/tests/MealTable.test.jsx
@@ -1,10 +1,11 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+import { vi, beforeEach } from "vitest";
 import MealTable from "../components/data/meal/MealTable";
 import { useData } from "../contexts/DataContext";
 
-jest.mock("../contexts/DataContext");
+vi.mock("../contexts/DataContext");
 
 const mockMeals = [
   {
@@ -51,7 +52,7 @@ const renderWithData = () => {
 
 describe("MealTable tag filtering", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   test("shows all meals when no tags are selected", () => {


### PR DESCRIPTION
## Summary
- swap jest utilities for vi in frontend tests
- add vitest helpers to App and MealTable tests

## Testing
- `npm test -- --run` *(fails: Failed to parse source for import analysis)*

------
https://chatgpt.com/codex/tasks/task_e_689c09e444cc8322a1726adbca52a28f