### PR TITLE
fix: expose Vite dev server

### DIFF
--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
     setupFiles: "./src/tests/setupTests.js",
   },
   server: {
+    host: "0.0.0.0",
     port: 3000,
     proxy: {
       "/api": {


### PR DESCRIPTION
## Summary
- bind Vite dev server to `0.0.0.0` for reliable access from Docker

## Testing
- `npm test -- --run` *(fails: Failed to parse source for import analysis because the content contains invalid JS syntax)*

------
https://chatgpt.com/codex/tasks/task_e_689c0f23f89483228b184ff2350cbcf3