### PR TITLE
chore: support JSX in .js files

### DIFF
--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -5,6 +5,11 @@ const apiUrl = process.env.VITE_API_URL || "http://localhost:5000";
 
 export default defineConfig({
   plugins: [react()],
+  esbuild: {
+    loader: "jsx",
+    include: /src\/.*\.jsx?$/,
+    exclude: [],
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Summary
- configure Vite's esbuild to load `.js` files with JSX

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: missing prop-types and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c130df6948322ac51860ba88f002a