### PR TITLE
refactor: replace uuid library with crypto.randomUUID

### DIFF
--- a/Frontend/src/components/data/ingredient/form/IngredientForm.js
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useCallback, useReducer } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { Button, Collapse, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Box } from "@mui/material";
 
 import { useData } from "../../../../contexts/DataContext";
@@ -17,8 +16,8 @@ const initialState = {
   isEditMode: false,
   ingredientToEdit: {
     name: "",
-    id: uuidv4(),
-    units: [{ id: "0", ingredient_id: uuidv4(), name: "1g", grams: "1" }],
+    id: crypto.randomUUID(),
+    units: [{ id: "0", ingredient_id: crypto.randomUUID(), name: "1g", grams: "1" }],
     nutrition: {
       calories: 0,
       protein: 0,
@@ -61,8 +60,8 @@ function IngredientForm({ ingredientToEditData }) {
 
   const initializeEmptyIngredient = () => ({
     name: "",
-    id: uuidv4(),
-    units: [{ id: "0", ingredient_id: uuidv4(), name: "1g", grams: "1" }],
+    id: crypto.randomUUID(),
+    units: [{ id: "0", ingredient_id: crypto.randomUUID(), name: "1g", grams: "1" }],
     nutrition: {
       calories: 0,
       protein: 0,

--- a/Frontend/src/components/data/ingredient/form/UnitEdit.js
+++ b/Frontend/src/components/data/ingredient/form/UnitEdit.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { Button, Select, MenuItem, TextField, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
 
 function AddUnitDialog({ open, onClose, onAddUnit }) {
@@ -71,7 +70,7 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }) {
 
   const handleAddUnit = useCallback(
     (name, grams) => {
-      const tempId = uuidv4();
+      const tempId = crypto.randomUUID();
       const newUnit = {
         id: tempId,
         ingredient_id: ingredient.id,

--- a/Frontend/src/components/data/meal/form/MealForm.js
+++ b/Frontend/src/components/data/meal/form/MealForm.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useCallback, useReducer } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { Button, Collapse, Paper, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
 
 import { useData } from "../../../../contexts/DataContext";
@@ -13,7 +12,7 @@ const intitalState = {
   isEditMode: false,
   mealToEdit: {
     name: "",
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     ingredients: [],
     tags: [],
   },
@@ -53,7 +52,7 @@ function MealForm({ mealToEditData }) {
 
   const initializeEmptyMeal = () => ({
     name: "",
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     ingredients: [],
     tags: [],
   });


### PR DESCRIPTION
## Summary
- remove uuid imports from data forms
- use built-in crypto.randomUUID for id generation

## Testing
- `npm test`
- `npm run lint` *(fails: prop-types and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c15eb0f5c83229647c3a2d7f9f1f3