### PR TITLE
fix: prevent meal table width expansion

### DIFF
--- a/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
@@ -172,8 +172,8 @@ function MealTable({ onMealDoubleClick = () => {}, onMealCtrlClick = () => {} })
         label="Filter tags"
       />
 
-      <TableContainer component={Paper}>
-        <Table>
+      <TableContainer component={Paper} sx={{ width: "100%" }}>
+        <Table sx={{ tableLayout: "fixed", width: "100%" }}>
           <TableHead>
             <TableRow>
               <TableCell></TableCell>
@@ -215,7 +215,8 @@ function MealTable({ onMealDoubleClick = () => {}, onMealCtrlClick = () => {} })
                         </Typography>
                         <Table
                           size="small"
-                          aria-label="purchases">
+                          aria-label="purchases"
+                          sx={{ tableLayout: "fixed", width: "100%" }}>
                           <TableHead>
                             <TableRow>
                               <TableCell>Name</TableCell>


### PR DESCRIPTION
## Summary
- ensure meal table spans full width and uses fixed layout so nested ingredients don't widen the table
- apply fixed layout to ingredient table to maintain consistent width when expanded

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install react-scripts` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a514d0083c832290c570a59f556ed1