### PR TITLE
Add Pydantic models mirroring database schema

### DIFF
--- a/Backend/models/__init__.py
+++ b/Backend/models/__init__.py
@@ -1,0 +1,17 @@
+from .nutrition import NutritionModel
+from .ingredient_unit import IngredientUnitModel
+from .possible_ingredient_tag import PossibleIngredientTagModel
+from .possible_meal_tag import PossibleMealTagModel
+from .ingredient import IngredientModel
+from .meal_ingredient import MealIngredientModel
+from .meal import MealModel
+
+__all__ = [
+    "NutritionModel",
+    "IngredientUnitModel",
+    "PossibleIngredientTagModel",
+    "PossibleMealTagModel",
+    "IngredientModel",
+    "MealIngredientModel",
+    "MealModel",
+]

--- a/Backend/models/ingredient.py
+++ b/Backend/models/ingredient.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Annotated, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .ingredient_unit import IngredientUnitModel
+from .nutrition import NutritionModel
+from .possible_ingredient_tag import PossibleIngredientTagModel
+
+PositiveInt = Annotated[int, Field(gt=0)]
+Name100 = Annotated[str, Field(min_length=1, max_length=100)]
+
+
+class IngredientModel(BaseModel):
+    """Core ingredient information."""
+
+    id: Optional[PositiveInt] = None
+    name: Name100
+    nutrition: Optional[NutritionModel] = None
+    units: List[IngredientUnitModel] = Field(default_factory=list)
+    tags: List[PossibleIngredientTagModel] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)

--- a/Backend/models/ingredient_unit.py
+++ b/Backend/models/ingredient_unit.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PositiveInt = Annotated[int, Field(gt=0)]
+Name50 = Annotated[str, Field(min_length=1, max_length=50)]
+Decimal4 = Annotated[Decimal, Field(ge=0, max_digits=10, decimal_places=4)]
+
+
+class IngredientUnitModel(BaseModel):
+    """Measurement unit for an ingredient."""
+
+    id: Optional[PositiveInt] = None
+    ingredient_id: PositiveInt
+    name: Name50
+    grams: Decimal4
+
+    model_config = ConfigDict(from_attributes=True)

--- a/Backend/models/meal.py
+++ b/Backend/models/meal.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Annotated, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .meal_ingredient import MealIngredientModel
+from .possible_meal_tag import PossibleMealTagModel
+
+PositiveInt = Annotated[int, Field(gt=0)]
+Name100 = Annotated[str, Field(min_length=1, max_length=100)]
+
+
+class MealModel(BaseModel):
+    """Meal with associated ingredients and tags."""
+
+    id: Optional[PositiveInt] = None
+    name: Name100
+    ingredients: List[MealIngredientModel] = Field(default_factory=list)
+    tags: List[PossibleMealTagModel] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)

--- a/Backend/models/meal_ingredient.py
+++ b/Backend/models/meal_ingredient.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .ingredient import IngredientModel
+from .ingredient_unit import IngredientUnitModel
+
+PositiveInt = Annotated[int, Field(gt=0)]
+Decimal4 = Annotated[Decimal, Field(ge=0, max_digits=10, decimal_places=4)]
+
+
+class MealIngredientModel(BaseModel):
+    """Link between a meal and an ingredient with quantity information."""
+
+    ingredient_id: PositiveInt
+    meal_id: PositiveInt
+    unit_id: Optional[PositiveInt] = None
+    unit_quantity: Optional[Decimal4] = None
+    ingredient: IngredientModel
+    unit: Optional[IngredientUnitModel] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/Backend/models/nutrition.py
+++ b/Backend/models/nutrition.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PositiveInt = Annotated[int, Field(gt=0)]
+Decimal4 = Annotated[Decimal, Field(ge=0, max_digits=10, decimal_places=4)]
+
+
+class NutritionModel(BaseModel):
+    """Nutritional information for a single ingredient."""
+
+    id: Optional[PositiveInt] = None
+    ingredient_id: PositiveInt
+    calories: Decimal4
+    fat: Decimal4
+    carbohydrates: Decimal4
+    protein: Decimal4
+    fiber: Decimal4
+
+    model_config = ConfigDict(from_attributes=True)

--- a/Backend/models/possible_ingredient_tag.py
+++ b/Backend/models/possible_ingredient_tag.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PositiveInt = Annotated[int, Field(gt=0)]
+Name50 = Annotated[str, Field(min_length=1, max_length=50)]
+
+
+class PossibleIngredientTagModel(BaseModel):
+    """Tag that can be associated with an ingredient."""
+
+    id: Optional[PositiveInt] = None
+    tag: Name50
+
+    model_config = ConfigDict(from_attributes=True)

--- a/Backend/models/possible_meal_tag.py
+++ b/Backend/models/possible_meal_tag.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Annotated, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+PositiveInt = Annotated[int, Field(gt=0)]
+Name50 = Annotated[str, Field(min_length=1, max_length=50)]
+
+
+class PossibleMealTagModel(BaseModel):
+    """Tag that can be associated with a meal."""
+
+    id: Optional[PositiveInt] = None
+    tag: Name50
+
+    model_config = ConfigDict(from_attributes=True)

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -4,4 +4,5 @@ Flask-SQLAlchemy==3.1.1
 psycopg2-binary==2.9.10
 marshmallow==3.21.2
 marshmallow-sqlalchemy==0.29.0
+pydantic==2.7.1
 


### PR DESCRIPTION
## Summary
- introduce `Backend/models` with Pydantic classes that mirror the SQLAlchemy tables
- express relations such as ingredients→nutrition and meals→ingredients via nested models
- add `pydantic` dependency for the backend

## Testing
- `python -m pytest`
- `pip install pydantic==2.7.1` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8992a0524832284f78f5aa2d1339d