### PR TITLE
refactor: switch backend to FastAPI

### DIFF
--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -1,35 +1,57 @@
+"""FastAPI application entry point."""
+
 import os
 
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from flask import Flask
-from flask_cors import CORS
-
-from pprint import pprint
 
 from db import db
-from routes.ingredients import ingredient_blueprint
-from routes.meals import meal_blueprint
+from routes.ingredients import router as ingredient_router
+from routes.meals import router as meal_router
 
-app = Flask(__name__)
-
-# Prefix all API routes with /api so the frontend can proxy requests
-app.register_blueprint(ingredient_blueprint, url_prefix="/api")
-app.register_blueprint(meal_blueprint, url_prefix="/api")
-
-CORS(app)
-# Configure the database connection string. Historically the application
-# looked for `SQLALCHEMY_DATABASE_URI`, but docker-compose provides the
-# URL via the more conventional `DATABASE_URL`.  Attempt to read either
-# environment variable and fall back to the default connection string
-# used by the development stack.
-app.config['SQLALCHEMY_DATABASE_URI'] = (
-    os.getenv('SQLALCHEMY_DATABASE_URI')
-    or os.getenv('DATABASE_URL', 'postgresql://nutrition_user:nutrition_pass@db:5432/nutrition')
+# Configure the database connection string. Historically the application looked
+# for `SQLALCHEMY_DATABASE_URI`, but docker-compose provides the URL via the
+# more conventional `DATABASE_URL`. Attempt to read either environment variable
+# and fall back to the default connection string used by the development stack.
+DATABASE_URL = (
+    os.getenv("SQLALCHEMY_DATABASE_URI")
+    or os.getenv(
+        "DATABASE_URL", "postgresql://nutrition_user:nutrition_pass@db:5432/nutrition"
+    )
 )
-db.init_app(app)
 
-if os.getenv('DB_AUTO_CREATE', '').lower() in ('1', 'true', 't'):
-    with app.app_context():
+# ``flask_sqlalchemy`` expects a Flask application context. Create a minimal
+# Flask app solely for managing the SQLAlchemy session used by the existing
+# models.
+_flask_app = Flask(__name__)
+_flask_app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URL
+db.init_app(_flask_app)
+_flask_app.app_context().push()
+
+app = FastAPI()
+
+# Enable very permissive CORS so the frontend can communicate with the API
+# during development.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Prefix all API routes with /api so the frontend can proxy requests.
+app.include_router(ingredient_router, prefix="/api")
+app.include_router(meal_router, prefix="/api")
+
+
+@app.on_event("startup")
+def _create_tables() -> None:
+    """Create database tables if DB_AUTO_CREATE is set."""
+    if os.getenv("DB_AUTO_CREATE", "").lower() in {"1", "true", "t"}:
         db.create_all()
 
-if __name__ == '__main__':
-    app.run(debug = True, host='0.0.0.0')
+
+__all__ = ["app"]
+

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -3,6 +3,6 @@ Flask-SQLAlchemy==3.1.1
 psycopg2-binary==2.9.10
 marshmallow==3.21.2
 marshmallow-sqlalchemy==0.29.0
-pydantic==2.7.1
+pydantic==2.11.7
 fastapi==0.111.0
 uvicorn==0.29.0

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,8 +1,8 @@
 Flask==3.1.1
-Flask-Cors==6.0.1
 Flask-SQLAlchemy==3.1.1
 psycopg2-binary==2.9.10
 marshmallow==3.21.2
 marshmallow-sqlalchemy==0.29.0
 pydantic==2.7.1
-
+fastapi==0.111.0
+uvicorn==0.29.0


### PR DESCRIPTION
## Summary
- migrate backend entrypoint to FastAPI and expose ingredient and meal routers
- add CORS middleware and optional startup table creation
- convert ingredient and meal routes to FastAPI APIRouter modules
- add FastAPI runtime dependencies

## Testing
- `pip install -r Backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement pydantic==2.7.1)*
- `pytest`
- `python -m py_compile Backend/backend.py Backend/routes/ingredients.py Backend/routes/meals.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8ae48a9e083228d4d538091e209ee