### PR TITLE
Refactor backend to use SQLAlchemy core session

### DIFF
--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -4,30 +4,10 @@ import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from flask import Flask
 
-from db import db
+from db import Base, engine
 from routes.ingredients import router as ingredient_router
 from routes.meals import router as meal_router
-
-# Configure the database connection string. Historically the application looked
-# for `SQLALCHEMY_DATABASE_URI`, but docker-compose provides the URL via the
-# more conventional `DATABASE_URL`. Attempt to read either environment variable
-# and fall back to the default connection string used by the development stack.
-DATABASE_URL = (
-    os.getenv("SQLALCHEMY_DATABASE_URI")
-    or os.getenv(
-        "DATABASE_URL", "postgresql://nutrition_user:nutrition_pass@db:5432/nutrition"
-    )
-)
-
-# ``flask_sqlalchemy`` expects a Flask application context. Create a minimal
-# Flask app solely for managing the SQLAlchemy session used by the existing
-# models.
-_flask_app = Flask(__name__)
-_flask_app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URL
-db.init_app(_flask_app)
-_flask_app.app_context().push()
 
 app = FastAPI()
 
@@ -50,7 +30,7 @@ app.include_router(meal_router, prefix="/api")
 def _create_tables() -> None:
     """Create database tables if DB_AUTO_CREATE is set."""
     if os.getenv("DB_AUTO_CREATE", "").lower() in {"1", "true", "t"}:
-        db.create_all()
+        Base.metadata.create_all(bind=engine)
 
 
 __all__ = ["app"]

--- a/Backend/db.py
+++ b/Backend/db.py
@@ -1,3 +1,40 @@
-from flask_sqlalchemy import SQLAlchemy
+"""SQLAlchemy database configuration."""
 
-db = SQLAlchemy()
+import os
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+# Configure the database connection string. Historically the application looked
+# for ``SQLALCHEMY_DATABASE_URI``, but docker-compose provides the URL via the
+# more conventional ``DATABASE_URL``. Attempt to read either environment
+# variable and fall back to the default connection string used by the
+# development stack.
+DATABASE_URL = (
+    os.getenv("SQLALCHEMY_DATABASE_URI")
+    or os.getenv(
+        "DATABASE_URL", "postgresql://nutrition_user:nutrition_pass@db:5432/nutrition"
+    )
+)
+
+# Create the engine and configured ``SessionLocal`` class used throughout the
+# application. ``autocommit`` and ``autoflush`` are disabled so changes are only
+# persisted when explicitly committed.
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Base class for declarative models.
+Base = declarative_base()
+
+
+def get_db() -> Generator:
+    """Provide a transactional scope around a series of operations."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+__all__ = ["Base", "engine", "SessionLocal", "get_db"]

--- a/Backend/db_models/ingredient.py
+++ b/Backend/db_models/ingredient.py
@@ -1,19 +1,23 @@
 # models/ingredient.py
-from db import db
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+
+from db import Base
 from .ingredient_tag import ingredient_tags
 
-class Ingredient(db.Model):
-    __tablename__ = 'ingredients'
 
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), nullable=False)
-    nutrition = db.relationship(
-        'Nutrition', backref='ingredient', uselist=False, cascade='all, delete-orphan'
+class Ingredient(Base):
+    __tablename__ = "ingredients"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), nullable=False)
+    nutrition = relationship(
+        "Nutrition", backref="ingredient", uselist=False, cascade="all, delete-orphan"
     )
-    units = db.relationship(
-        'IngredientUnit', backref='ingredient', cascade='all, delete-orphan'
+    units = relationship(
+        "IngredientUnit", backref="ingredient", cascade="all, delete-orphan"
     )
-    tags = db.relationship(
-        'PossibleIngredientTag', secondary=ingredient_tags, backref='ingredients'
+    tags = relationship(
+        "PossibleIngredientTag", secondary=ingredient_tags, backref="ingredients"
     )
 

--- a/Backend/db_models/ingredient_tag.py
+++ b/Backend/db_models/ingredient_tag.py
@@ -1,10 +1,13 @@
 # db_models/ingredient_tag.py
-from db import db
+from sqlalchemy import Column, ForeignKey, Integer, Table
+
+from db import Base
 
 
-ingredient_tags = db.Table(
-    'ingredient_tags',
-    db.Column('ingredient_id', db.Integer, db.ForeignKey('ingredients.id'), primary_key=True),
-    db.Column('tag_id', db.Integer, db.ForeignKey('possible_ingredient_tags.id'), primary_key=True),
+ingredient_tags = Table(
+    "ingredient_tags",
+    Base.metadata,
+    Column("ingredient_id", Integer, ForeignKey("ingredients.id"), primary_key=True),
+    Column("tag_id", Integer, ForeignKey("possible_ingredient_tags.id"), primary_key=True),
 )
 

--- a/Backend/db_models/ingredient_unit.py
+++ b/Backend/db_models/ingredient_unit.py
@@ -1,10 +1,13 @@
 # db_models/meal_ingredients.py
-from db import db
+from sqlalchemy import Column, ForeignKey, Integer, Numeric, String
 
-class IngredientUnit(db.Model):
-    __tablename__ = 'ingredient_units'
-    
-    id = db.Column(db.Integer, primary_key=True)
-    ingredient_id = db.Column(db.Integer, db.ForeignKey('ingredients.id'), nullable=False)
-    name = db.Column(db.String(50), nullable=False)
-    grams = db.Column(db.Numeric(10, 4), nullable=False)
+from db import Base
+
+
+class IngredientUnit(Base):
+    __tablename__ = "ingredient_units"
+
+    id = Column(Integer, primary_key=True)
+    ingredient_id = Column(Integer, ForeignKey("ingredients.id"), nullable=False)
+    name = Column(String(50), nullable=False)
+    grams = Column(Numeric(10, 4), nullable=False)

--- a/Backend/db_models/meal.py
+++ b/Backend/db_models/meal.py
@@ -1,15 +1,17 @@
 # models/meal.py
-from db import db
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+
+from db import Base
 from .meal_tag import meal_tags
 
-class Meal(db.Model):
-    __tablename__ = 'meals'
 
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), nullable=False)
-    ingredients = db.relationship(
-        'MealIngredient', backref='meal', cascade='all, delete-orphan'
+class Meal(Base):
+    __tablename__ = "meals"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), nullable=False)
+    ingredients = relationship(
+        "MealIngredient", backref="meal", cascade="all, delete-orphan"
     )
-    tags = db.relationship(
-        'PossibleMealTag', secondary=meal_tags, backref='meals'
-    )
+    tags = relationship("PossibleMealTag", secondary=meal_tags, backref="meals")

--- a/Backend/db_models/meal_ingredient.py
+++ b/Backend/db_models/meal_ingredient.py
@@ -1,15 +1,25 @@
 # models/meal_ingredients.py
-from db import db
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    Numeric,
+)
+from sqlalchemy.orm import relationship
 
-class MealIngredient(db.Model):
-    __tablename__ = 'meal_ingredients'
+from db import Base
 
-    ingredient_id = db.Column(db.Integer, db.ForeignKey('ingredients.id'), primary_key=True)
-    meal_id = db.Column(db.Integer, db.ForeignKey('meals.id'), primary_key=True)
-    unit_id = db.Column(db.Integer, db.ForeignKey('ingredient_units.id'))
-    unit_quantity = db.Column(db.Numeric(10, 4))
-    
-    unit = db.relationship('IngredientUnit')
+
+class MealIngredient(Base):
+    __tablename__ = "meal_ingredients"
+
+    ingredient_id = Column(Integer, ForeignKey("ingredients.id"), primary_key=True)
+    meal_id = Column(Integer, ForeignKey("meals.id"), primary_key=True)
+    unit_id = Column(Integer, ForeignKey("ingredient_units.id"))
+    unit_quantity = Column(Numeric(10, 4))
+
+    unit = relationship("IngredientUnit")
     __table_args__ = (
-        db.ForeignKeyConstraint(['unit_id'], ['ingredient_units.id']),
+        ForeignKeyConstraint(["unit_id"], ["ingredient_units.id"]),
     )

--- a/Backend/db_models/meal_tag.py
+++ b/Backend/db_models/meal_tag.py
@@ -1,9 +1,12 @@
 # db_models/meal_tag.py
-from db import db
+from sqlalchemy import Column, ForeignKey, Integer, Table
+
+from db import Base
 
 
-meal_tags = db.Table(
-    'meal_tags',
-    db.Column('meal_id', db.Integer, db.ForeignKey('meals.id'), primary_key=True),
-    db.Column('tag_id', db.Integer, db.ForeignKey('possible_meal_tags.id'), primary_key=True),
+meal_tags = Table(
+    "meal_tags",
+    Base.metadata,
+    Column("meal_id", Integer, ForeignKey("meals.id"), primary_key=True),
+    Column("tag_id", Integer, ForeignKey("possible_meal_tags.id"), primary_key=True),
 )

--- a/Backend/db_models/nutrition.py
+++ b/Backend/db_models/nutrition.py
@@ -1,13 +1,17 @@
 # models/nutrition.py
-from db import db
+from sqlalchemy import Column, ForeignKey, Integer, Numeric
 
-class Nutrition(db.Model):
-    __tablename__ = 'nutrition'
-    id = db.Column(db.Integer, primary_key=True)
-    ingredient_id = db.Column(db.Integer, db.ForeignKey('ingredients.id'), nullable=False)
-    calories = db.Column(db.Numeric(10, 4), nullable=False)
-    fat = db.Column(db.Numeric(10, 4), nullable=False)
-    carbohydrates = db.Column(db.Numeric(10, 4), nullable=False)
-    protein = db.Column(db.Numeric(10, 4), nullable=False)
-    fiber = db.Column(db.Numeric(10, 4), nullable=False)
+from db import Base
+
+
+class Nutrition(Base):
+    __tablename__ = "nutrition"
+
+    id = Column(Integer, primary_key=True)
+    ingredient_id = Column(Integer, ForeignKey("ingredients.id"), nullable=False)
+    calories = Column(Numeric(10, 4), nullable=False)
+    fat = Column(Numeric(10, 4), nullable=False)
+    carbohydrates = Column(Numeric(10, 4), nullable=False)
+    protein = Column(Numeric(10, 4), nullable=False)
+    fiber = Column(Numeric(10, 4), nullable=False)
 

--- a/Backend/db_models/possible_ingredient_tag.py
+++ b/Backend/db_models/possible_ingredient_tag.py
@@ -1,8 +1,11 @@
 # models/possible_ingredient_tags.py
-from db import db
+from sqlalchemy import Column, Integer, String
 
-class PossibleIngredientTag(db.Model):
-    __tablename__ = 'possible_ingredient_tags'
+from db import Base
 
-    id = db.Column(db.Integer, primary_key=True)
-    tag = db.Column(db.String(50), nullable=False)
+
+class PossibleIngredientTag(Base):
+    __tablename__ = "possible_ingredient_tags"
+
+    id = Column(Integer, primary_key=True)
+    tag = Column(String(50), nullable=False)

--- a/Backend/db_models/possible_meal_tag.py
+++ b/Backend/db_models/possible_meal_tag.py
@@ -1,9 +1,12 @@
 # models/meal_ingredients.py
-from db import db
+from sqlalchemy import Column, Integer, String
 
-class PossibleMealTag(db.Model):
-    __tablename__ = 'possible_meal_tags'
-    
-    id = db.Column(db.Integer, primary_key=True)
-    tag = db.Column(db.String(50), nullable=False)
+from db import Base
+
+
+class PossibleMealTag(Base):
+    __tablename__ = "possible_meal_tags"
+
+    id = Column(Integer, primary_key=True)
+    tag = Column(String(50), nullable=False)
 

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,5 +1,4 @@
-Flask==3.1.1
-Flask-SQLAlchemy==3.1.1
+SQLAlchemy==2.0.30
 psycopg2-binary==2.9.10
 marshmallow==3.21.2
 marshmallow-sqlalchemy==0.29.0


### PR DESCRIPTION
## Summary
- replace Flask-SQLAlchemy with SQLAlchemy's engine, declarative base and sessionmaker
- convert ORM models and association tables to inherit from the new Base
- update API routes and backend startup to use session dependency

## Testing
- `python -m py_compile Backend/db.py Backend/backend.py Backend/db_models/*.py Backend/routes/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b1db879483229a9dedbba4a6b07a