### PR TITLE
Switch to FastAPI backend

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -20,4 +20,4 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # Copy backend source
 COPY Backend/ /app
 
-CMD ["python", "backend.py"]
+CMD ["uvicorn", "backend:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,7 +1,7 @@
-SQLAlchemy==2.0.30
+sqlalchemy==2.0.30
 psycopg2-binary==2.9.10
 marshmallow==3.21.2
 marshmallow-sqlalchemy==0.29.0
 pydantic==2.11.7
 fastapi==0.111.0
-uvicorn==0.29.0
+uvicorn[standard]==0.29.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,18 +25,18 @@ services:
       context: .
       dockerfile: Backend/Dockerfile
     environment:
-      FLASK_ENV: development
       DATABASE_URL: postgresql://nutrition_user:nutrition_pass@db:5432/nutrition
+      DB_AUTO_CREATE: "true"
     depends_on:
       db:
         condition: service_healthy
     volumes:
       - ./Backend:/app
-    command: flask --app backend.py --debug run --host=0.0.0.0
+    command: uvicorn backend:app --host 0.0.0.0 --port 8000
     networks:
       - nutrition-net
     ports:
-      - "${BACKEND_PORT:-5000}:5000"
+      - "${BACKEND_PORT:-8000}:8000"
 
   frontend:
     build:


### PR DESCRIPTION
## Summary
- Adopt FastAPI stack by adding sqlalchemy, uvicorn[standard], and fastapi dependencies
- Run backend with uvicorn instead of Flask in Dockerfile
- Update docker-compose to run uvicorn on port 8000 and pass DATABASE_URL and DB_AUTO_CREATE variables

## Testing
- `pytest`
- `docker compose config` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b741047c8322885cdc7cff73e03a