### PR TITLE
Expose routers via package and document uvicorn run

### DIFF
--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -6,8 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from db import Base, engine
-from routes.ingredients import router as ingredient_router
-from routes.meals import router as meal_router
+from routes import ingredients_router, meals_router
 
 app = FastAPI()
 
@@ -22,8 +21,8 @@ app.add_middleware(
 )
 
 # Prefix all API routes with /api so the frontend can proxy requests.
-app.include_router(ingredient_router, prefix="/api")
-app.include_router(meal_router, prefix="/api")
+app.include_router(ingredients_router, prefix="/api")
+app.include_router(meals_router, prefix="/api")
 
 
 @app.on_event("startup")

--- a/Backend/routes/__init__.py
+++ b/Backend/routes/__init__.py
@@ -1,0 +1,6 @@
+"""Router exports for the Backend routes package."""
+
+from .ingredients import router as ingredients_router
+from .meals import router as meals_router
+
+__all__ = ["ingredients_router", "meals_router"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ pwsh ./scripts/activate-venv.ps1
 
 The script creates the `.venv` directory if needed and installs required dependencies.
 
+## ▶️ Run the Backend
+
+Start the FastAPI application locally with [uvicorn](https://www.uvicorn.org/):
+
+```bash
+uvicorn Backend.backend:app --reload
+```
+
+The server will be available at <http://localhost:8000> by default.
+
 ---
 
 ## 🗂️ Project Structure


### PR DESCRIPTION
## Summary
- export ingredient and meal routers from Backend.routes package
- import routers from package in FastAPI backend
- document starting backend with uvicorn

## Testing
- `python -m py_compile Backend/backend.py Backend/routes/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8bbe62e388322bf53fdba77194593