### PR TITLE
docs: align Docker config with fastapi backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Options:
 
 Each branch gets **unique host ports**, calculated as:
 
-* Base ports → Frontend `3000`, Backend `5000`, DB `5432`
+* Base ports → Frontend `3000`, Backend `8000`, DB `5432`
 * Plus branch-specific offset (hash of branch name)
 
 The startup script prints exact values.
@@ -71,9 +71,9 @@ The startup script prints exact values.
 
 | Branch      | Frontend | Backend | DB   |
 | ----------- | -------- | ------- | ---- |
-| `main`      | 3000     | 5000    | 5432 |
-| `feature/x` | 3004     | 5006    | 5438 |
-| `bugfix/y`  | 3012     | 5012    | 5444 |
+| `main`      | 3000     | 8000    | 5432 |
+| `feature/x` | 3004     | 8006    | 5438 |
+| `bugfix/y`  | 3012     | 8012    | 5444 |
 
 In Docker Desktop, ports show as `HOST:CONTAINER` (e.g. `3099:3000`).
 Click the **host port** (3099) to open the frontend in your browser.
@@ -139,7 +139,7 @@ In Docker Desktop, shown as `PORT:5432`.
 
 You can also run backend/frontend directly on your machine.
 
-### Backend (Flask)
+### Backend (FastAPI)
 
 Virtual Environment Setup
 ```powershell
@@ -147,7 +147,7 @@ pwsh ./scripts/activate-venv.ps1
 ```
 
 # Run backend
-python Backend/backend.py
+uvicorn Backend.backend:app --reload
 ```
 
 ### Frontend (React)
@@ -163,9 +163,9 @@ npm start
 ## 🧩 Project Structure (Developer View)
 
 ```
-Backend/                  # Flask app
+Backend/                  # FastAPI app
   ├── db_models/          # SQLAlchemy ORM models
-  ├── schemas/            # Marshmallow schemas
+  ├── models/             # Pydantic models
   ├── routes/             # API routes
   ├── backend.py          # Entrypoint
   └── db.py               # SQLAlchemy setup
@@ -184,7 +184,7 @@ scripts/                  # Helper scripts (compose up/down, tooling)
 ## 📚 Reference
 
 * **Frontend ports** → base `3000` + offset
-* **Backend ports** → base `5000` + offset
+* **Backend ports** → base `8000` + offset
 * **DB ports** → base `5432` + offset
 * **Credentials** → `nutrition_user` / `nutrition_pass` / `nutrition`
 

--- a/Frontend/nutrition-frontend/nginx.conf
+++ b/Frontend/nutrition-frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://nutrition-backend:5000/;
+    proxy_pass http://nutrition-backend:8000/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';

--- a/Frontend/nutrition-frontend/package.json
+++ b/Frontend/nutrition-frontend/package.json
@@ -2,7 +2,7 @@
   "name": "nutrition-frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://backend:5000",
+  "proxy": "http://backend:8000",
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A full-stack nutrition planning and tracking app built with:
 
 * 🖥️ **React** frontend (Material UI + Context API)
-* 🐍 **Flask** backend (SQLAlchemy + Marshmallow)
+* 🐍 **FastAPI** backend (SQLAlchemy + Pydantic)
 * 🐘 **PostgreSQL** database (seeded with food and nutrition data)
 * 🐳 **Docker** for development and deployment
 
@@ -35,7 +35,7 @@ Multiple branches can run in parallel without conflict.
 ### 3. Access services
 
 * Frontend: [http://localhost:\<FRONTEND\_PORT>](http://localhost:3000)
-* Backend API: [http://localhost:\<BACKEND\_PORT>](http://localhost:5000)
+* Backend API: [http://localhost:\<BACKEND\_PORT>](http://localhost:8000)
 * PostgreSQL: `localhost:<DB_PORT>`
 
 ## 🐍 Virtual Environment
@@ -64,11 +64,11 @@ The server will be available at <http://localhost:8000> by default.
 
 ```
 Nutrition/
-├── Backend/                     # Flask app
+├── Backend/                     # FastAPI app
 │   ├── db_models/              # SQLAlchemy ORM models
-│   ├── schemas/                # Marshmallow schemas
+│   ├── models/                 # Pydantic models
 │   ├── routes/                 # Ingredient and meal routes
-│   ├── backend.py              # Main Flask entrypoint
+│   ├── backend.py              # FastAPI entrypoint
 │   ├── db.py                   # SQLAlchemy setup
 │   └── Dockerfile              # Backend build config
 │

--- a/scripts/activate-venv.ps1
+++ b/scripts/activate-venv.ps1
@@ -15,7 +15,7 @@ if (-Not (Test-Path $VenvPath)) {
 & "$VenvPath\Scripts\Activate.ps1"
 
 # Install dependencies if the venv was just created or requirements are missing
-pip show Flask > $null 2>&1
+pip show fastapi > $null 2>&1
 if ($venvCreated -or -not $?) {
     pip install -r $RequirementsPath
 }

--- a/scripts/activate_venv.ps1
+++ b/scripts/activate_venv.ps1
@@ -15,7 +15,7 @@ if (-Not (Test-Path $VenvPath)) {
 & "$VenvPath\Scripts\Activate.ps1"
 
 # Install dependencies if the venv was just created or requirements are missing
-pip show Flask > $null 2>&1
+pip show fastapi > $null 2>&1
 if ($venvCreated -or -not $?) {
     pip install -r $RequirementsPath
 }

--- a/scripts/compose-up-branch.ps1
+++ b/scripts/compose-up-branch.ps1
@@ -41,7 +41,7 @@ $project    = "nutrition-$sanitized"
 # Stable, per-branch port offsets (0–99)
 $offset              = [math]::Abs($branch.GetHashCode()) % 100
 $env:DB_PORT        = 5432 + $offset
-$env:BACKEND_PORT   = 5000 + $offset
+$env:BACKEND_PORT   = 8000 + $offset
 $env:FRONTEND_PORT  = 3000 + $offset
 
 Write-Host "Starting '$branch' with ports:`n  DB: $env:DB_PORT`n  Backend: $env:BACKEND_PORT`n  Frontend: $env:FRONTEND_PORT"


### PR DESCRIPTION
## Summary
- adjust branch compose script to expose FastAPI on 8000+offset
- proxy frontend to FastAPI service on 8000
- update venv helper and docs to refer to FastAPI and new ports

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `pwsh ./scripts/compose-up-branch.ps1 -empty db backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8be862cf48322bc2c4139c4ab292e