### PR TITLE
Refactor meal ingredient quantity handling

### DIFF
--- a/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
@@ -107,19 +107,19 @@ function MealTable({ onMealDoubleClick = () => {}, onMealCtrlClick = () => {} })
 
     return {
       calories: dataIngredient.nutrition.calories
-        ? dataIngredient.nutrition.calories * dataUnit.grams * ingredient.amount
+        ? dataIngredient.nutrition.calories * dataUnit.grams * ingredient.unit_quantity
         : 0,
       protein: dataIngredient.nutrition.protein
-        ? dataIngredient.nutrition.protein * dataUnit.grams * ingredient.amount
+        ? dataIngredient.nutrition.protein * dataUnit.grams * ingredient.unit_quantity
         : 0,
       fat: dataIngredient.nutrition.fat
-        ? dataIngredient.nutrition.fat * dataUnit.grams * ingredient.amount
+        ? dataIngredient.nutrition.fat * dataUnit.grams * ingredient.unit_quantity
         : 0,
       carbs: dataIngredient.nutrition.carbohydrates
-        ? dataIngredient.nutrition.carbohydrates * dataUnit.grams * ingredient.amount
+        ? dataIngredient.nutrition.carbohydrates * dataUnit.grams * ingredient.unit_quantity
         : 0,
       fiber: dataIngredient.nutrition.fiber
-        ? dataIngredient.nutrition.fiber * dataUnit.grams * ingredient.amount
+        ? dataIngredient.nutrition.fiber * dataUnit.grams * ingredient.unit_quantity
         : 0,
     };
   };
@@ -248,7 +248,7 @@ function MealTable({ onMealDoubleClick = () => {}, onMealCtrlClick = () => {} })
                                   </TableCell>
                                   <TableCell>{unit ? unit.name : ""}</TableCell>
                                   <TableCell>
-                                    {formatCellNumber(ingredient.amount)}
+                                    {formatCellNumber(ingredient.unit_quantity)}
                                   </TableCell>
                                   <TableCell>
                                     {formatCellNumber(

--- a/Frontend/nutrition-frontend/src/components/data/meal/form/MealForm.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/form/MealForm.js
@@ -36,9 +36,9 @@ const reducer = (state, action) => {
       return { ...state, needsFillForm: action.payload };
     case "SET_CONFIRMATION_DIALOG":
       return { ...state, openConfirmationDialog: action.payload };
-    case "UPDATE_AMOUNT":
+    case "UPDATE_UNIT_QUANTITY":
       const updatedIngredients = [...state.mealToEdit.ingredients];
-      updatedIngredients[action.payload.index].amount = action.payload.amount;
+      updatedIngredients[action.payload.index].unit_quantity = action.payload.unit_quantity;
       return { ...state, mealToEdit: { ...state.mealToEdit, ingredients: updatedIngredients } };
     default:
       return state;
@@ -72,10 +72,10 @@ function MealForm({ mealToEditData }) {
 
     const toDatabaseMeal = {
       name: mealToEdit.name,
-      ingredients: mealToEdit.ingredients.map(({ ingredient_id, unit_id, amount }) => ({
+      ingredients: mealToEdit.ingredients.map(({ ingredient_id, unit_id, unit_quantity }) => ({
         ingredient_id,
         unit_id,
-        unit_quantity: amount,
+        unit_quantity,
       })),
       tags: mealToEdit.tags
         .filter((tag) => typeof tag.id === "number")

--- a/Frontend/nutrition-frontend/src/components/data/meal/form/MealIngredientsForm.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/form/MealIngredientsForm.js
@@ -10,7 +10,7 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
   //#region States
   const { ingredients } = useData();
   const [openIngredientsDialog, setOpenIngredientsDialog] = useState(false);
-  const [amounts, setAmounts] = useState({}); // Use an object to track amounts by ingredient index
+  const [unitQuantities, setUnitQuantities] = useState({}); // Use an object to track unit quantities by ingredient index
   const [totalMacros, setTotalMacros] = useState({
     calories: 0,
     protein: 0,
@@ -39,31 +39,31 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
       ingredient_id: ingredient.id,
       meal_id: meal.id,
       unit_id: ingredient.selectedUnitId ? ingredient.selectedUnitId : null,
-      amount: 1,
+      unit_quantity: 1,
     };
   };
 
-  const handleAmountChange = (event, index) => {
-    const newAmounts = { ...amounts, [index]: event.target.value };
-    setAmounts(newAmounts);
-    handleUpdateIngredientAmount(index, event.target.value);
+  const handleUnitQuantityChange = (event, index) => {
+    const newUnitQuantities = { ...unitQuantities, [index]: event.target.value };
+    setUnitQuantities(newUnitQuantities);
+    handleUpdateIngredientUnitQuantity(index, event.target.value);
   };
 
-  const handleAmountBlur = (index) => {
-    if (amounts[index] === "") {
-      const newAmounts = { ...amounts, [index]: "0" };
-      setAmounts(newAmounts);
-      handleUpdateIngredientAmount(index, "0");
+  const handleUnitQuantityBlur = (index) => {
+    if (unitQuantities[index] === "") {
+      const newUnitQuantities = { ...unitQuantities, [index]: "0" };
+      setUnitQuantities(newUnitQuantities);
+      handleUpdateIngredientUnitQuantity(index, "0");
     }
   };
 
-  const handleUpdateIngredientAmount = (index, value) => {
+  const handleUpdateIngredientUnitQuantity = (index, value) => {
     const updatedIngredients = [...meal.ingredients];
     updatedIngredients[index] = {
       ...updatedIngredients[index],
-      amount: parseFloat(value),
+      unit_quantity: parseFloat(value),
     };
-    if (!isNaN(updatedIngredients[index].amount)) {
+    if (!isNaN(updatedIngredients[index].unit_quantity)) {
       // Don't update if the field is empty
       dispatch({ type: "SET_MEAL", payload: { ...meal, ingredients: updatedIngredients } });
     }
@@ -79,11 +79,11 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
       const dataUnit = dataIngredient.units.find((unit) => unit.id === unitId) || dataIngredient.units[0]; // Fallback to the first unit if not found
 
       return {
-        calories: dataIngredient.nutrition.calories ? dataIngredient.nutrition.calories * dataUnit.grams * meal_ingredient.amount : 0,
-        protein: dataIngredient.nutrition.protein ? dataIngredient.nutrition.protein * dataUnit.grams * meal_ingredient.amount : 0,
-        fat: dataIngredient.nutrition.fat ? dataIngredient.nutrition.fat * dataUnit.grams * meal_ingredient.amount : 0,
-        carbs: dataIngredient.nutrition.carbohydrates ? dataIngredient.nutrition.carbohydrates * dataUnit.grams * meal_ingredient.amount : 0,
-        fiber: dataIngredient.nutrition.fiber ? dataIngredient.nutrition.fiber * dataUnit.grams * meal_ingredient.amount : 0,
+        calories: dataIngredient.nutrition.calories ? dataIngredient.nutrition.calories * dataUnit.grams * meal_ingredient.unit_quantity : 0,
+        protein: dataIngredient.nutrition.protein ? dataIngredient.nutrition.protein * dataUnit.grams * meal_ingredient.unit_quantity : 0,
+        fat: dataIngredient.nutrition.fat ? dataIngredient.nutrition.fat * dataUnit.grams * meal_ingredient.unit_quantity : 0,
+        carbs: dataIngredient.nutrition.carbohydrates ? dataIngredient.nutrition.carbohydrates * dataUnit.grams * meal_ingredient.unit_quantity : 0,
+        fiber: dataIngredient.nutrition.fiber ? dataIngredient.nutrition.fiber * dataUnit.grams * meal_ingredient.unit_quantity : 0,
       };
     },
     [ingredients]
@@ -108,12 +108,12 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
   }, [needsClearForm, dispatch, meal]); // Clear ingredients when needsClearForm is true
 
   useEffect(() => {
-    const initialAmounts = meal.ingredients.reduce((acc, ingredient, index) => {
-      acc[index] = ingredient.amount.toString();
+    const initialUnitQuantities = meal.ingredients.reduce((acc, ingredient, index) => {
+      acc[index] = ingredient.unit_quantity.toString();
       return acc;
     }, {});
-    setAmounts(initialAmounts);
-  }, [meal]); // Initialize or reset the amounts when meal changes, ensuring inputs are up-to-date
+    setUnitQuantities(initialUnitQuantities);
+  }, [meal]); // Initialize or reset the unit quantities when meal changes, ensuring inputs are up-to-date
 
   useEffect(() => {
     const totals = meal.ingredients.reduce(
@@ -187,9 +187,9 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
                   <TableCell>
                     <TextField
                       type="number"
-                      value={amounts[index] || ""}
-                      onChange={(event) => handleAmountChange(event, index)}
-                      onBlur={() => handleAmountBlur(index)}
+                      value={unitQuantities[index] || ""}
+                      onChange={(event) => handleUnitQuantityChange(event, index)}
+                      onBlur={() => handleUnitQuantityBlur(index)}
                       onKeyDown={(event) => {
                         if (event.key === "Enter") event.target.blur();
                       }}

--- a/Frontend/nutrition-frontend/src/components/planning/Planning.js
+++ b/Frontend/nutrition-frontend/src/components/planning/Planning.js
@@ -100,11 +100,11 @@ function Planning() {
       dataIngredient.units.find((u) => u.id === ingredient.unit_id) || dataIngredient.units[0];
     const grams = unit ? unit.grams : 0;
     return {
-      calories: (dataIngredient.nutrition.calories || 0) * grams * ingredient.amount,
-      protein: (dataIngredient.nutrition.protein || 0) * grams * ingredient.amount,
-      fat: (dataIngredient.nutrition.fat || 0) * grams * ingredient.amount,
-      carbs: (dataIngredient.nutrition.carbohydrates || 0) * grams * ingredient.amount,
-      fiber: (dataIngredient.nutrition.fiber || 0) * grams * ingredient.amount,
+      calories: (dataIngredient.nutrition.calories || 0) * grams * ingredient.unit_quantity,
+      protein: (dataIngredient.nutrition.protein || 0) * grams * ingredient.unit_quantity,
+      fat: (dataIngredient.nutrition.fat || 0) * grams * ingredient.unit_quantity,
+      carbs: (dataIngredient.nutrition.carbohydrates || 0) * grams * ingredient.unit_quantity,
+      fiber: (dataIngredient.nutrition.fiber || 0) * grams * ingredient.unit_quantity,
     };
   };
 
@@ -139,7 +139,7 @@ function Planning() {
     return calculateIngredientMacros({
       ingredient_id: item.ingredientId,
       unit_id: item.unitId,
-      amount: item.amount,
+      unit_quantity: item.amount,
     });
   };
 
@@ -414,7 +414,7 @@ function Planning() {
                                   </TableCell>
                                   <TableCell>{unit ? unit.name : ""}</TableCell>
                                   <TableCell>
-                                    {formatCellNumber(ingredient.amount * item.portions)}
+                                    {formatCellNumber(ingredient.unit_quantity * item.portions)}
                                   </TableCell>
                                   <TableCell>
                                     {formatCellNumber(ingMacros.calories * item.portions)}
@@ -449,7 +449,7 @@ function Planning() {
               const macros = calculateIngredientMacros({
                 ingredient_id: item.ingredientId,
                 unit_id: item.unitId,
-                amount: item.amount,
+                unit_quantity: item.amount,
               });
               return (
                 <TableRow key={`ingredient-${index}`}>


### PR DESCRIPTION
## Summary
- track meal ingredient quantities using `unit_quantity` instead of `amount`
- update meal and planning macros to use `unit_quantity`
- rename reducer action to `UPDATE_UNIT_QUANTITY`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a8c52833288322bfb0550c1642f969