### PR TITLE
Parse meal ingredient quantities

### DIFF
--- a/Frontend/nutrition-frontend/src/contexts/DataContext.js
+++ b/Frontend/nutrition-frontend/src/contexts/DataContext.js
@@ -75,7 +75,26 @@ export const DataProvider = ({ children }) => {
 
   const fetchMeals = () => {
     const url = "/api/meals";
-    fetchData(url, setMeals, setFetching, () => setMealsNeedsRefetch(true));
+    const processData = (data) =>
+      data.map((meal) => ({
+        ...meal,
+        ingredients: meal.ingredients
+          ? meal.ingredients.map((mi) => ({
+              ...mi,
+              unit_quantity: mi.unit_quantity
+                ? parseFloat(mi.unit_quantity)
+                : 0,
+            }))
+          : [],
+      }));
+
+    fetchData(
+      url,
+      setMeals,
+      setFetching,
+      () => setMealsNeedsRefetch(true),
+      processData
+    );
   };
 
   const fetchPossibleMealTags = () => {


### PR DESCRIPTION
## Summary
- ensure meal ingredient quantities are numeric by parsing `unit_quantity` and defaulting to 0
- pass meal-processing callback to `fetchData`

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden fetching @babel/plugin-proposal-private-property-in-object)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c52eda5c832283a77ecb35ed9ccb