### PR TITLE
feat(db): initialize Alembic and add unique constraints

### DIFF
--- a/Backend/db_models/ingredient.py
+++ b/Backend/db_models/ingredient.py
@@ -10,7 +10,7 @@ class Ingredient(Base):
     __tablename__ = "ingredients"
 
     id = Column(Integer, primary_key=True)
-    name = Column(String(100), nullable=False)
+    name = Column(String(100), nullable=False, unique=True)
     nutrition = relationship(
         "Nutrition", backref="ingredient", uselist=False, cascade="all, delete-orphan"
     )

--- a/Backend/db_models/meal.py
+++ b/Backend/db_models/meal.py
@@ -10,7 +10,7 @@ class Meal(Base):
     __tablename__ = "meals"
 
     id = Column(Integer, primary_key=True)
-    name = Column(String(100), nullable=False)
+    name = Column(String(100), nullable=False, unique=True)
     ingredients = relationship(
         "MealIngredient", backref="meal", cascade="all, delete-orphan"
     )

--- a/Backend/db_models/possible_ingredient_tag.py
+++ b/Backend/db_models/possible_ingredient_tag.py
@@ -8,4 +8,5 @@ class PossibleIngredientTag(Base):
     __tablename__ = "possible_ingredient_tags"
 
     id = Column(Integer, primary_key=True)
-    tag = Column(String(50), nullable=False)
+    tag = Column(String(50), nullable=False, unique=True)
+

--- a/Backend/db_models/possible_meal_tag.py
+++ b/Backend/db_models/possible_meal_tag.py
@@ -8,5 +8,5 @@ class PossibleMealTag(Base):
     __tablename__ = "possible_meal_tags"
 
     id = Column(Integer, primary_key=True)
-    tag = Column(String(50), nullable=False)
+    tag = Column(String(50), nullable=False, unique=True)
 

--- a/Backend/migrations/README
+++ b/Backend/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/Backend/migrations/env.py
+++ b/Backend/migrations/env.py
@@ -1,0 +1,50 @@
+from __future__ import with_statement
+import sys
+from pathlib import Path
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+# add project path to sys.path to allow importing Backend.db
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from Backend.db import Base, DATABASE_URL
+
+config = context.config
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/Backend/migrations/script.py.mako
+++ b/Backend/migrations/script.py.mako
@@ -1,0 +1,17 @@
+"""
+${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ''}
+
+def upgrade():
+    ${upgrades if upgrades else 'pass'}
+
+def downgrade():
+    ${downgrades if downgrades else 'pass'}

--- a/Backend/migrations/versions/00a7d3b5f188_add_unique_constraints.py
+++ b/Backend/migrations/versions/00a7d3b5f188_add_unique_constraints.py
@@ -1,0 +1,32 @@
+"""add unique constraints to names and tags"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "00a7d3b5f188"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint("uq_ingredients_name", "ingredients", ["name"])
+    op.create_unique_constraint("uq_meals_name", "meals", ["name"])
+    op.create_unique_constraint(
+        "uq_possible_ingredient_tags_tag", "possible_ingredient_tags", ["tag"]
+    )
+    op.create_unique_constraint(
+        "uq_possible_meal_tags_tag", "possible_meal_tags", ["tag"]
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "uq_possible_meal_tags_tag", "possible_meal_tags", type_="unique"
+    )
+    op.drop_constraint(
+        "uq_possible_ingredient_tags_tag", "possible_ingredient_tags", type_="unique"
+    )
+    op.drop_constraint("uq_meals_name", "meals", type_="unique")
+    op.drop_constraint("uq_ingredients_name", "ingredients", type_="unique")

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -5,3 +5,4 @@ marshmallow-sqlalchemy==0.29.0
 pydantic==2.11.7
 fastapi==0.111.0
 uvicorn[standard]==0.29.0
+alembic==1.13.1

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,38 @@
+[alembic]
+script_location = Backend/migrations
+sqlalchemy.url = sqlite:///./app.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+propagate = 0
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S


### PR DESCRIPTION
## Summary
- add unique constraints on names and tags
- set up initial Alembic configuration and migration

## Testing
- `pip install -r Backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement sqlalchemy==2.0.30)*
- `alembic revision --autogenerate -m "add unique constraints"` *(fails: command not found)*
- `alembic upgrade head` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8cb7f67a083228744b68fe19dea01