### PR TITLE
Rename tag field to name across models and frontend

### DIFF
--- a/Backend/migrations/versions/cc1a9ac14d24_rename_tag_to_name.py
+++ b/Backend/migrations/versions/cc1a9ac14d24_rename_tag_to_name.py
@@ -1,0 +1,21 @@
+"""rename tag column to name in possible tag tables"""
+# Rename tag column to name in possible tag tables
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "cc1a9ac14d24"
+down_revision = "1e93c782c25f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("possible_ingredient_tags", "tag", new_column_name="name")
+    op.alter_column("possible_meal_tags", "tag", new_column_name="name")
+
+
+def downgrade() -> None:
+    op.alter_column("possible_ingredient_tags", "name", new_column_name="tag")
+    op.alter_column("possible_meal_tags", "name", new_column_name="tag")

--- a/Backend/models/possible_ingredient_tag.py
+++ b/Backend/models/possible_ingredient_tag.py
@@ -14,7 +14,7 @@ class PossibleIngredientTag(SQLModel, table=True):
     __tablename__ = "possible_ingredient_tags"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    tag: str = Field(sa_column=Column(String(50), unique=True, nullable=False))
+    name: str = Field(sa_column=Column(String(50), unique=True, nullable=False))
 
     ingredients: List["Ingredient"] = Relationship(
         back_populates="tags", link_model=IngredientTagLink

--- a/Backend/models/possible_meal_tag.py
+++ b/Backend/models/possible_meal_tag.py
@@ -14,7 +14,7 @@ class PossibleMealTag(SQLModel, table=True):
     __tablename__ = "possible_meal_tags"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    tag: str = Field(sa_column=Column(String(50), unique=True, nullable=False))
+    name: str = Field(sa_column=Column(String(50), unique=True, nullable=False))
 
     meals: List["Meal"] = Relationship(
         back_populates="tags", link_model=MealTagLink

--- a/Backend/routes/ingredients.py
+++ b/Backend/routes/ingredients.py
@@ -79,8 +79,9 @@ def delete_ingredient(ingredient_id: int, db: Session = Depends(get_db)) -> dict
 def get_all_possible_tags(
     db: Session = Depends(get_db),
 ) -> List[PossibleIngredientTag]:
-    """Return all possible ingredient tags."""
-    return db.exec(select(PossibleIngredientTag)).all()
+    """Return all possible ingredient tags ordered by name."""
+    statement = select(PossibleIngredientTag).order_by(PossibleIngredientTag.name)
+    return db.exec(statement).all()
 
 
 __all__ = ["router"]

--- a/Backend/routes/meals.py
+++ b/Backend/routes/meals.py
@@ -26,8 +26,9 @@ def get_meal(meal_id: int, db: Session = Depends(get_db)) -> Meal:
 
 @router.get("/possible_tags", response_model=List[PossibleMealTag])
 def get_possible_meal_tags(db: Session = Depends(get_db)) -> List[PossibleMealTag]:
-    """Return all possible meal tags."""
-    return db.exec(select(PossibleMealTag)).all()
+    """Return all possible meal tags ordered by name."""
+    statement = select(PossibleMealTag).order_by(PossibleMealTag.name)
+    return db.exec(statement).all()
 
 
 @router.post("", response_model=Meal, status_code=201)

--- a/Database/test_data/possible_ingredient_tags.csv
+++ b/Database/test_data/possible_ingredient_tags.csv
@@ -1,4 +1,4 @@
-id,tag
+id,name
 1,Fruit
 2,Meat
 3,Vegetable

--- a/Database/test_data/possible_meal_tags.csv
+++ b/Database/test_data/possible_meal_tags.csv
@@ -1,4 +1,4 @@
-id,tag
+id,name
 1,Healthy
 2,High Protein
 3,Vegetarian

--- a/Frontend/nutrition-frontend/src/components/data/ingredient/IngredientTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/ingredient/IngredientTable.js
@@ -33,7 +33,7 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
       return true; // Show all ingredients if no tags are selected
     }
     return selectedTags.some((selectedTag) =>
-      ingredient.tags.some((tag) => tag.name === selectedTag.name)
+      ingredient.tags.some(({ name }) => name === selectedTag.name)
     );
   };
 

--- a/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/MealTable.js
@@ -38,7 +38,7 @@ function MealTable({ onMealDoubleClick = () => {}, onMealCtrlClick = () => {} })
       return false;
     }
     return selectedTags.some((selectedTag) =>
-      meal.tags.some((tag) => tag.name === selectedTag.name)
+      meal.tags.some(({ name }) => name === selectedTag.name)
     );
   };
 

--- a/Frontend/nutrition-frontend/src/contexts/DataContext.js
+++ b/Frontend/nutrition-frontend/src/contexts/DataContext.js
@@ -18,16 +18,36 @@ export const DataProvider = ({ children }) => {
   const ingredientProcessingTagNames = ["Whole Food", "Lightly Processed", "Highly Processed"];
   const ingredientGroupTagNames = ["Vegetable", "Fruit", "Meat", "Dairy", "Grain"];
 
-  const ingredientProcessingTags = possibleIngredientTags ? possibleIngredientTags.filter((tag) => ingredientProcessingTagNames.includes(tag.name)) : [];
-  const ingredientGroupTags = possibleIngredientTags ? possibleIngredientTags.filter((tag) => ingredientGroupTagNames.includes(tag.name)) : [];
-  const ingredientOtherTags = possibleIngredientTags ? possibleIngredientTags.filter((tag) => !ingredientProcessingTagNames.includes(tag.name) && !ingredientGroupTagNames.includes(tag.name)) : [];
+  const ingredientProcessingTags = possibleIngredientTags
+    ? possibleIngredientTags.filter(({ name }) => ingredientProcessingTagNames.includes(name))
+    : [];
+  const ingredientGroupTags = possibleIngredientTags
+    ? possibleIngredientTags.filter(({ name }) => ingredientGroupTagNames.includes(name))
+    : [];
+  const ingredientOtherTags = possibleIngredientTags
+    ? possibleIngredientTags.filter(
+        ({ name }) =>
+          !ingredientProcessingTagNames.includes(name) &&
+          !ingredientGroupTagNames.includes(name)
+      )
+    : [];
 
   const mealDietTagNames = ["Vegetarian", "Vegan", "Carnivore"];
   const mealTypeTagNames = ["Breakfast", "Lunch", "Dinner", "Snack"];
 
-  const mealDietTags = possibleMealTags ? possibleMealTags.filter((tag) => mealDietTagNames.includes(tag.name)) : [];
-  const mealTypeTags = possibleMealTags ? possibleMealTags.filter((tag) => mealTypeTagNames.includes(tag.name)) : [];
-  const mealOtherTags = possibleMealTags ? possibleMealTags.filter((tag) => !mealDietTagNames.includes(tag.name) && !mealTypeTagNames.includes(tag.name)) : [];
+  const mealDietTags = possibleMealTags
+    ? possibleMealTags.filter(({ name }) => mealDietTagNames.includes(name))
+    : [];
+  const mealTypeTags = possibleMealTags
+    ? possibleMealTags.filter(({ name }) => mealTypeTagNames.includes(name))
+    : [];
+  const mealOtherTags = possibleMealTags
+    ? possibleMealTags.filter(
+        ({ name }) =>
+          !mealDietTagNames.includes(name) &&
+          !mealTypeTagNames.includes(name)
+      )
+    : [];
 
   const fetchData = async (url, setData, setLoading, errorHandler, processData) => {
     setLoading(true);


### PR DESCRIPTION
## Summary
- Rename `tag` field to `name` in possible tag SQLModel classes and ensure routes order tags by name
- Add Alembic migration to rename columns in `possible_ingredient_tags` and `possible_meal_tags`
- Update React context and tables to reference the new `name` field

## Testing
- `pytest`
- `npm test` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a8ec30f68c8322accb0c12cdce6bbe