### PR TITLE
feat: add bash virtual environment activation script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,20 @@ The [README](README.md) has the high-level overview and quick start.
 
 ## Virtual environment
 
-All development tasks should be run from inside the project's Python virtual environment. The helper script will create and activate it and install dependencies as needed:
+All development tasks should be run from inside the project's Python virtual environment.
+Run one of the activation scripts from the repository root before using any tooling.
+The script will create the environment if it doesn't exist and install dependencies as needed.
+
+Windows (PowerShell):
 
 ```powershell
 pwsh ./scripts/activate-venv.ps1
+```
+
+macOS/Linux (Bash):
+
+```bash
+source ./scripts/activate-venv.sh
 ```
 
 ## 🔀 Branching
@@ -136,9 +146,18 @@ You can also run backend/frontend directly on your machine.
 
 ### Backend (FastAPI)
 
-Virtual Environment Setup
+Virtual environment setup (run one):
+
+Windows (PowerShell):
+
 ```powershell
 pwsh ./scripts/activate-venv.ps1
+```
+
+macOS/Linux (Bash):
+
+```bash
+source ./scripts/activate-venv.sh
 ```
 
 # Run backend

--- a/scripts/activate-venv.sh
+++ b/scripts/activate-venv.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Ensure the project's virtual environment exists, activate it, and
+# install required packages if they are missing
+
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_PATH="${VENV_PATH:-$ROOT_DIR/.venv}"
+REQUIREMENTS_PATH="${REQUIREMENTS_PATH:-$ROOT_DIR/Backend/requirements.txt}"
+
+venv_created=false
+if [ ! -d "$VENV_PATH" ]; then
+    python -m venv "$VENV_PATH"
+    venv_created=true
+fi
+
+# shellcheck disable=SC1090
+source "$VENV_PATH/bin/activate"
+
+if $venv_created || ! pip show fastapi >/dev/null 2>&1; then
+    pip install -r "$REQUIREMENTS_PATH"
+fi


### PR DESCRIPTION
## Summary
- add `activate-venv.sh` for macOS/Linux virtual environment setup
- document both PowerShell and Bash activation scripts in contributing guide

## Testing
- `bash -n scripts/activate-venv.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9153dbd0083229aa358ec152cd1d2