### PR TITLE
docs: document SQLModel and manual schema sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,17 +153,22 @@ npm install
 npm start
 ```
 
+## OpenAPI / TypeScript Sync
+
+The OpenAPI schema and frontend TypeScript types are currently synced manually
+using `scripts/update-api-schema.sh`. Run this script whenever backend models
+change and commit the updated files.
+
 ---
 
 ## 🧩 Project Structure (Developer View)
 
 ```
 Backend/                  # FastAPI app
-  ├── models/          # SQLAlchemy ORM models
-  ├── models/             # Pydantic models
+  ├── models/          # SQLModel models
   ├── routes/             # API routes
   ├── backend.py          # Entrypoint
-  └── db.py               # SQLAlchemy setup
+  └── db.py               # SQLModel setup
 
 Frontend/nutrition-frontend/
   ├── src/                # React components, context

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A full-stack nutrition planning and tracking app built with:
 
 * 🖥️ **React** frontend (Material UI + Context API)
-* 🐍 **FastAPI** backend (SQLAlchemy + Pydantic)
+* 🐍 **FastAPI** backend (SQLModel)
 * 🐘 **PostgreSQL** database (seeded with food and nutrition data)
 * 🐳 **Docker** for development and deployment
 
@@ -105,17 +105,16 @@ kill %1
 ## 🔄 Syncing Frontend Types
 
 Use [`openapi-typescript`](https://github.com/drwpow/openapi-typescript) to keep
-frontend TypeScript definitions aligned with the API:
+frontend TypeScript definitions aligned with the API. The OpenAPI schema and
+TypeScript types are currently synced manually via `scripts/update-api-schema.sh`,
+which regenerates both the backend schema and frontend types:
 
 ```bash
 npm --prefix Frontend/nutrition-frontend install   # run once
 npx --prefix Frontend/nutrition-frontend openapi-typescript Backend/openapi.json -o Frontend/nutrition-frontend/src/api-types.ts
 ```
 
-Run `scripts/update-api-schema.sh` to regenerate both the backend schema and
-frontend types in one step.
-
-Commit the generated file whenever API models change.
+Run the script whenever API models change and commit the generated file.
 
 ### Troubleshooting
 * `openapi-typescript` not found – ensure frontend dev dependencies are installed.
@@ -134,11 +133,10 @@ Commit the generated file whenever API models change.
 ```
 Nutrition/
 ├── Backend/                     # FastAPI app
-│   ├── models/              # SQLAlchemy ORM models
-│   ├── models/                 # Pydantic models
+│   ├── models/                 # SQLModel models
 │   ├── routes/                 # Ingredient and meal routes
 │   ├── backend.py              # FastAPI entrypoint
-│   ├── db.py                   # SQLAlchemy setup
+│   ├── db.py                   # SQLModel setup
 │   └── Dockerfile              # Backend build config
 │
 ├── Frontend/
@@ -167,7 +165,7 @@ Nutrition/
 * **Backend**
 
   * API routes in `Backend/routes/`
-  * SQLAlchemy models in `models/`, validated by Marshmallow `schemas/`
+  * SQLModel models in `Backend/models/`
 
 * **Frontend**
 


### PR DESCRIPTION
## Summary
- note unified SQLModel usage instead of separate SQLAlchemy/Pydantic layers
- explain that OpenAPI and TypeScript types are manually synced via `scripts/update-api-schema.sh`
- clean up duplicate model entries in project structure docs

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `npm test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9153ababc8322a6f51918828a5dcf