### PR TITLE
ci: verify API schema generation

### DIFF
--- a/.github/workflows/verify-api-schema.yml
+++ b/.github/workflows/verify-api-schema.yml
@@ -1,0 +1,25 @@
+name: Verify API schema
+
+on:
+  pull_request:
+    paths:
+      - 'Backend/**'
+      - 'scripts/update-api-schema.sh'
+      - 'Frontend/nutrition-frontend/src/api-types.ts'
+      - 'Backend/openapi.json'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -r Backend/requirements.txt
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci --prefix Frontend/nutrition-frontend
+      - run: scripts/update-api-schema.sh
+      - run: git diff --exit-code Backend/openapi.json Frontend/nutrition-frontend/src/api-types.ts

--- a/Frontend/nutrition-frontend/src/api-types.ts
+++ b/Frontend/nutrition-frontend/src/api-types.ts
@@ -3,560 +3,422 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
-    "/api/ingredients/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get All Ingredients
-         * @description Return all ingredients.
-         */
-        get: operations["get_all_ingredients_api_ingredients__get"];
-        put?: never;
-        /**
-         * Add Ingredient
-         * @description Create a new ingredient.
-         */
-        post: operations["add_ingredient_api_ingredients__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/ingredients/{ingredient_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Ingredient
-         * @description Retrieve a single ingredient by ID.
-         */
-        get: operations["get_ingredient_api_ingredients__ingredient_id__get"];
-        /**
-         * Update Ingredient
-         * @description Update an existing ingredient.
-         */
-        put: operations["update_ingredient_api_ingredients__ingredient_id__put"];
-        post?: never;
-        /**
-         * Delete Ingredient
-         * @description Delete an ingredient.
-         */
-        delete: operations["delete_ingredient_api_ingredients__ingredient_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/ingredients/possible_tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get All Possible Tags
-         * @description Return all possible ingredient tags ordered by name.
-         */
-        get: operations["get_all_possible_tags_api_ingredients_possible_tags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/meals": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get All Meals
-         * @description Return all meals.
-         */
-        get: operations["get_all_meals_api_meals_get"];
-        put?: never;
-        /**
-         * Add Meal
-         * @description Create a new meal.
-         */
-        post: operations["add_meal_api_meals_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/meals/{meal_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Meal
-         * @description Retrieve a single meal by ID.
-         */
-        get: operations["get_meal_api_meals__meal_id__get"];
-        /**
-         * Update Meal
-         * @description Update an existing meal.
-         */
-        put: operations["update_meal_api_meals__meal_id__put"];
-        post?: never;
-        /**
-         * Delete Meal
-         * @description Delete a meal.
-         */
-        delete: operations["delete_meal_api_meals__meal_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/meals/possible_tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Possible Meal Tags
-         * @description Return all possible meal tags ordered by name.
-         */
-        get: operations["get_possible_meal_tags_api_meals_possible_tags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+  "/api/ingredients/": {
+    /**
+     * Get All Ingredients
+     * @description Return all ingredients.
+     */
+    get: operations["get_all_ingredients_api_ingredients__get"];
+    /**
+     * Add Ingredient
+     * @description Create a new ingredient.
+     */
+    post: operations["add_ingredient_api_ingredients__post"];
+  };
+  "/api/ingredients/{ingredient_id}": {
+    /**
+     * Get Ingredient
+     * @description Retrieve a single ingredient by ID.
+     */
+    get: operations["get_ingredient_api_ingredients__ingredient_id__get"];
+    /**
+     * Update Ingredient
+     * @description Update an existing ingredient.
+     */
+    put: operations["update_ingredient_api_ingredients__ingredient_id__put"];
+    /**
+     * Delete Ingredient
+     * @description Delete an ingredient.
+     */
+    delete: operations["delete_ingredient_api_ingredients__ingredient_id__delete"];
+  };
+  "/api/ingredients/possible_tags": {
+    /**
+     * Get All Possible Tags
+     * @description Return all possible ingredient tags ordered by name.
+     */
+    get: operations["get_all_possible_tags_api_ingredients_possible_tags_get"];
+  };
+  "/api/meals": {
+    /**
+     * Get All Meals
+     * @description Return all meals.
+     */
+    get: operations["get_all_meals_api_meals_get"];
+    /**
+     * Add Meal
+     * @description Create a new meal.
+     */
+    post: operations["add_meal_api_meals_post"];
+  };
+  "/api/meals/{meal_id}": {
+    /**
+     * Get Meal
+     * @description Retrieve a single meal by ID.
+     */
+    get: operations["get_meal_api_meals__meal_id__get"];
+    /**
+     * Update Meal
+     * @description Update an existing meal.
+     */
+    put: operations["update_meal_api_meals__meal_id__put"];
+    /**
+     * Delete Meal
+     * @description Delete a meal.
+     */
+    delete: operations["delete_meal_api_meals__meal_id__delete"];
+  };
+  "/api/meals/possible_tags": {
+    /**
+     * Get Possible Meal Tags
+     * @description Return all possible meal tags ordered by name.
+     */
+    get: operations["get_possible_meal_tags_api_meals_possible_tags_get"];
+  };
 }
+
 export type webhooks = Record<string, never>;
+
 export interface components {
-    schemas: {
-        /** HTTPValidationError */
-        HTTPValidationError: {
-            /** Detail */
-            detail?: components["schemas"]["ValidationError"][];
-        };
-        /**
-         * Ingredient
-         * @description Core ingredient information.
-         */
-        Ingredient: {
-            /** Id */
-            id?: number | null;
-            /** Name */
-            name: string;
-        };
-        /**
-         * Meal
-         * @description Meal with associated ingredients and tags.
-         */
-        Meal: {
-            /** Id */
-            id?: number | null;
-            /** Name */
-            name: string;
-        };
-        /**
-         * PossibleIngredientTag
-         * @description Tag that can be associated with an ingredient.
-         */
-        PossibleIngredientTag: {
-            /** Id */
-            id?: number | null;
-            /** Name */
-            name: string;
-        };
-        /**
-         * PossibleMealTag
-         * @description Tag that can be associated with a meal.
-         */
-        PossibleMealTag: {
-            /** Id */
-            id?: number | null;
-            /** Name */
-            name: string;
-        };
-        /** ValidationError */
-        ValidationError: {
-            /** Location */
-            loc: (string | number)[];
-            /** Message */
-            msg: string;
-            /** Error Type */
-            type: string;
-        };
+  schemas: {
+    /** HTTPValidationError */
+    HTTPValidationError: {
+      /** Detail */
+      detail?: components["schemas"]["ValidationError"][];
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    /**
+     * Ingredient
+     * @description Core ingredient information.
+     */
+    Ingredient: {
+      /** Id */
+      id?: number | null;
+      /** Name */
+      name: string;
+    };
+    /**
+     * Meal
+     * @description Meal with associated ingredients and tags.
+     */
+    Meal: {
+      /** Id */
+      id?: number | null;
+      /** Name */
+      name: string;
+    };
+    /**
+     * PossibleIngredientTag
+     * @description Tag that can be associated with an ingredient.
+     */
+    PossibleIngredientTag: {
+      /** Id */
+      id?: number | null;
+      /** Name */
+      name: string;
+    };
+    /**
+     * PossibleMealTag
+     * @description Tag that can be associated with a meal.
+     */
+    PossibleMealTag: {
+      /** Id */
+      id?: number | null;
+      /** Name */
+      name: string;
+    };
+    /** ValidationError */
+    ValidationError: {
+      /** Location */
+      loc: (string | number)[];
+      /** Message */
+      msg: string;
+      /** Error Type */
+      type: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
+
 export type $defs = Record<string, never>;
+
+export type external = Record<string, never>;
+
 export interface operations {
-    get_all_ingredients_api_ingredients__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+
+  /**
+   * Get All Ingredients
+   * @description Return all ingredients.
+   */
+  get_all_ingredients_api_ingredients__get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Ingredient"][];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Ingredient"][];
-                };
-            };
-        };
+      };
     };
-    add_ingredient_api_ingredients__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["Ingredient"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Ingredient"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Add Ingredient
+   * @description Create a new ingredient.
+   */
+  add_ingredient_api_ingredients__post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Ingredient"];
+      };
     };
-    get_ingredient_api_ingredients__ingredient_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ingredient_id: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["Ingredient"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Ingredient"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
+      };
     };
-    update_ingredient_api_ingredients__ingredient_id__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ingredient_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["Ingredient"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Ingredient"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Get Ingredient
+   * @description Retrieve a single ingredient by ID.
+   */
+  get_ingredient_api_ingredients__ingredient_id__get: {
+    parameters: {
+      path: {
+        ingredient_id: number;
+      };
     };
-    delete_ingredient_api_ingredients__ingredient_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ingredient_id: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Ingredient"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
+      };
     };
-    get_all_possible_tags_api_ingredients_possible_tags_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PossibleIngredientTag"][];
-                };
-            };
-        };
+  };
+  /**
+   * Update Ingredient
+   * @description Update an existing ingredient.
+   */
+  update_ingredient_api_ingredients__ingredient_id__put: {
+    parameters: {
+      path: {
+        ingredient_id: number;
+      };
     };
-    get_all_meals_api_meals_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Meal"][];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Ingredient"];
+      };
     };
-    add_meal_api_meals_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Ingredient"];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["Meal"];
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Meal"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    get_meal_api_meals__meal_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                meal_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Meal"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Delete Ingredient
+   * @description Delete an ingredient.
+   */
+  delete_ingredient_api_ingredients__ingredient_id__delete: {
+    parameters: {
+      path: {
+        ingredient_id: number;
+      };
     };
-    update_meal_api_meals__meal_id__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                meal_id: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: unknown;
+          };
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["Meal"];
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Meal"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    delete_meal_api_meals__meal_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                meal_id: number;
-            };
-            cookie?: never;
+  };
+  /**
+   * Get All Possible Tags
+   * @description Return all possible ingredient tags ordered by name.
+   */
+  get_all_possible_tags_api_ingredients_possible_tags_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PossibleIngredientTag"][];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    get_possible_meal_tags_api_meals_possible_tags_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+  };
+  /**
+   * Get All Meals
+   * @description Return all meals.
+   */
+  get_all_meals_api_meals_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Meal"][];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PossibleMealTag"][];
-                };
-            };
-        };
+      };
     };
+  };
+  /**
+   * Add Meal
+   * @description Create a new meal.
+   */
+  add_meal_api_meals_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Meal"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["Meal"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Meal
+   * @description Retrieve a single meal by ID.
+   */
+  get_meal_api_meals__meal_id__get: {
+    parameters: {
+      path: {
+        meal_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Meal"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Update Meal
+   * @description Update an existing meal.
+   */
+  update_meal_api_meals__meal_id__put: {
+    parameters: {
+      path: {
+        meal_id: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Meal"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Meal"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Meal
+   * @description Delete a meal.
+   */
+  delete_meal_api_meals__meal_id__delete: {
+    parameters: {
+      path: {
+        meal_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: unknown;
+          };
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Possible Meal Tags
+   * @description Return all possible meal tags ordered by name.
+   */
+  get_possible_meal_tags_api_meals_possible_tags_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PossibleMealTag"][];
+        };
+      };
+    };
+  };
 }

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ curl http://localhost:8000/openapi.json -o Backend/openapi.json
 kill %1
 ```
 
+The `scripts/update-api-schema.sh` script automates these steps and also
+generates frontend TypeScript types. It is run automatically in CI but can be
+executed locally when backend models change.
+
 ### Troubleshooting
 * 404 on `/openapi.json` – confirm the server started and you're hitting the correct port.
 * Missing fields – ensure migrations were applied and models import correctly.
@@ -105,16 +109,18 @@ kill %1
 ## 🔄 Syncing Frontend Types
 
 Use [`openapi-typescript`](https://github.com/drwpow/openapi-typescript) to keep
-frontend TypeScript definitions aligned with the API. The OpenAPI schema and
-TypeScript types are currently synced manually via `scripts/update-api-schema.sh`,
-which regenerates both the backend schema and frontend types:
+frontend TypeScript definitions aligned with the API. The helper script
+`scripts/update-api-schema.sh` regenerates both the backend OpenAPI schema and
+the frontend types in one step:
 
 ```bash
-npm --prefix Frontend/nutrition-frontend install   # run once
-npx --prefix Frontend/nutrition-frontend openapi-typescript Backend/openapi.json -o Frontend/nutrition-frontend/src/api-types.ts
+scripts/update-api-schema.sh
 ```
 
-Run the script whenever API models change and commit the generated file.
+A GitHub Actions workflow runs this script whenever backend files change and
+fails if `Backend/openapi.json` or `Frontend/nutrition-frontend/src/api-types.ts`
+are out of date. Run the script locally and commit the generated files before
+pushing.
 
 ### Troubleshooting
 * `openapi-typescript` not found – ensure frontend dev dependencies are installed.
@@ -124,6 +130,8 @@ Run the script whenever API models change and commit the generated file.
 
 * PRs that modify backend models must include an Alembic migration.
 * API changes require an updated `Backend/openapi.json` and synced frontend types.
+  A dedicated workflow runs `scripts/update-api-schema.sh` and fails if these
+  files are out of date.
 * All tests (`pytest` and `npm test`) should pass before merging.
 
 ---

--- a/scripts/update-api-schema.sh
+++ b/scripts/update-api-schema.sh
@@ -1,20 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Launch the FastAPI app in the background
 PYTHONPATH=Backend uvicorn backend:app --port 8000 &
 UVICORN_PID=$!
-# Wait for the server to be ready
+trap "kill $UVICORN_PID 2>/dev/null || true; wait $UVICORN_PID 2>/dev/null || true" EXIT
+
 until curl --silent --fail http://localhost:8000/openapi.json >/dev/null; do
   sleep 1
 done
 
-# Capture the schema
 curl http://localhost:8000/openapi.json -o Backend/openapi.json
 
-# Shut down the server
-kill $UVICORN_PID
-wait $UVICORN_PID 2>/dev/null || true
-
-# Generate TypeScript types for the frontend
 npx --prefix Frontend/nutrition-frontend openapi-typescript Backend/openapi.json -o Frontend/nutrition-frontend/src/api-types.ts


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to regenerate API schema and fail if uncommitted changes remain
- ensure update-api-schema script cleans up background server
- document schema generation automation in README

## Testing
- `pytest`
- `CI=true npm test --prefix Frontend/nutrition-frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a9168560508322a91ae747084a2faa