### PR TITLE
ci: cache backend and frontend dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
+        id: setup-python
         with:
           python-version: '3.11'
+      - name: Cache backend dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: backend-${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('Backend/requirements.txt') }}
+          restore-keys: |
+            backend-${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-
+      - name: Verify pip cache
+        run: ls -al ~/.cache/pip || echo 'No pip cache found'
       - name: Install backend dependencies
         run: |
           source scripts/activate-venv.sh
@@ -33,8 +43,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: '20'
+      - name: Cache frontend dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: frontend-${{ runner.os }}-npm-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('Frontend/nutrition-frontend/package-lock.json') }}
+          restore-keys: |
+            frontend-${{ runner.os }}-npm-${{ steps.setup-node.outputs.node-version }}-
+      - name: Verify npm cache
+        run: ls -al ~/.npm || echo 'No npm cache found'
       - name: Install frontend dependencies
         working-directory: Frontend/nutrition-frontend
         run: npm ci


### PR DESCRIPTION
## Summary
- cache pip dependencies in backend job keyed by requirements and Python version
- cache npm dependencies in frontend job keyed by lockfile and Node version
- verify restored cache directories before installing dependencies

## Testing
- `npm ci`
- `npm test -- --watchAll=false`
- `pytest` *(fails: session error "Failed to read output")*

------
https://chatgpt.com/codex/tasks/task_e_68a92238bfe48322981c2568c838a4f5