### PR TITLE
Ensure API schema script cleans up server

### DIFF
--- a/scripts/update-api-schema.sh
+++ b/scripts/update-api-schema.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+UVICORN_PID=""
+cleanup() {
+  if [[ -n "${UVICORN_PID:-}" ]]; then
+    kill "$UVICORN_PID" 2>/dev/null || true
+    wait "$UVICORN_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT
+
 # Launch the FastAPI app in the background
 PYTHONPATH=Backend uvicorn backend:app --port 8000 &
 UVICORN_PID=$!
@@ -11,10 +20,6 @@ done
 
 # Capture the schema
 curl http://localhost:8000/openapi.json -o Backend/openapi.json
-
-# Shut down the server
-kill $UVICORN_PID
-wait $UVICORN_PID 2>/dev/null || true
 
 # Generate TypeScript types for the frontend
 npx --prefix Frontend/nutrition-frontend openapi-typescript Backend/openapi.json -o Frontend/nutrition-frontend/src/api-types.ts


### PR DESCRIPTION
## Summary
- add cleanup trap so `update-api-schema.sh` always terminates the uvicorn server

## Testing
- `pytest`
- `bash scripts/update-api-schema.sh` (canceled to verify server shutdown)
- `PATH="/tmp:$PATH" bash scripts/update-api-schema.sh` (forced npx failure to verify server shutdown on errors)


------
https://chatgpt.com/codex/tasks/task_e_68a922a1b20883229750a51a7495ef69