### PR TITLE
Activate venv before data import

### DIFF
--- a/scripts/compose-up-branch.ps1
+++ b/scripts/compose-up-branch.ps1
@@ -83,12 +83,16 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # --- Seed data depending on mode ---
-if ($production) {
-  Write-Host "Importing production data..."
-  & python Database/import_from_csv.py --production
-} elseif ($test) {
-  Write-Host "Importing test data..."
-  & python Database/import_from_csv.py --test
+if ($production -or $test) {
+  & "$PSScriptRoot/activate-venv.ps1"
+
+  if ($production) {
+    Write-Host "Importing production data..."
+    & python Database/import_from_csv.py --production
+  } else {
+    Write-Host "Importing test data..."
+    & python Database/import_from_csv.py --test
+  }
 }
 
 if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
## Summary
- ensure compose-up-branch script activates virtualenv before running Python data import

## Testing
- `pytest` *(fails: InvalidRequestError when initializing SQLAlchemy mappers)*

------
https://chatgpt.com/codex/tasks/task_e_68a922ffd6d0832296a1204b850b3ec9