### PR TITLE
refactor: type request payloads with OpenAPI interfaces

### DIFF
--- a/Frontend/nutrition-frontend/src/components/data/ingredient/form/IngredientForm.js
+++ b/Frontend/nutrition-frontend/src/components/data/ingredient/form/IngredientForm.js
@@ -1,3 +1,4 @@
+// @ts-check
 import React, { useEffect, useCallback, useReducer } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { Button, Collapse, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Box } from "@mui/material";
@@ -10,6 +11,11 @@ import NutritionEdit from "./NutritionEdit";
 import TagEdit from "./TagEdit";
 
 import { handleFetchRequest } from "../../../../utils/utils";
+
+/**
+ * @typedef {import("../../../../api-types").operations["add_ingredient_api_ingredients__post"]["requestBody"]["content"]["application/json"]} IngredientRequest
+ * @typedef {import("../../../../api-types").operations["add_ingredient_api_ingredients__post"]["responses"][201]["content"]["application/json"]} IngredientResponse
+ */
 
 const initialState = {
   isOpen: false,
@@ -102,7 +108,7 @@ function IngredientForm({ ingredientToEditData }) {
     if (isEditMode) {
       const url = `/api/ingredients/${toDatabaseIngredient.id}`;
       const method = "PUT";
-      const data = toDatabaseIngredient;
+      const data = /** @type {IngredientRequest} */ (toDatabaseIngredient);
 
       handleFetchRequest(url, method, data).then(() => {
         setIngredientsNeedsRefetch(true);
@@ -111,7 +117,7 @@ function IngredientForm({ ingredientToEditData }) {
     } else {
       const url = "/api/ingredients";
       const method = "POST";
-      const data = toDatabaseIngredient;
+      const data = /** @type {IngredientRequest} */ (toDatabaseIngredient);
 
       handleFetchRequest(url, method, data).then(() => {
         setIngredientsNeedsRefetch(true);
@@ -128,6 +134,7 @@ function IngredientForm({ ingredientToEditData }) {
         method: "DELETE",
       })
         .then((response) => {
+          /** @type {Promise<IngredientResponse>} */ (response.json());
           if (response.ok) {
             setIngredientsNeedsRefetch(true);
           } else {

--- a/Frontend/nutrition-frontend/src/components/data/meal/form/MealForm.js
+++ b/Frontend/nutrition-frontend/src/components/data/meal/form/MealForm.js
@@ -1,3 +1,4 @@
+// @ts-check
 import React, { useEffect, useCallback, useReducer } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { Button, Collapse, Paper, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
@@ -7,6 +8,11 @@ import { handleFetchRequest } from "../../../../utils/utils";
 
 import MealNameForm from "./MealNameForm";
 import MealIngredientsForm from "./MealIngredientsForm";
+
+/**
+ * @typedef {import("../../../../api-types").operations["add_meal_api_meals_post"]["requestBody"]["content"]["application/json"]} MealRequest
+ * @typedef {import("../../../../api-types").operations["add_meal_api_meals_post"]["responses"][201]["content"]["application/json"]} MealResponse
+ */
 
 const intitalState = {
   isOpen: false,
@@ -91,7 +97,7 @@ function MealForm({ mealToEditData }) {
     const url = isEditMode ? `/api/meals/${mealToEdit.id}` : "/api/meals";
     const method = isEditMode ? "PUT" : "POST";
 
-    handleFetchRequest(url, method, toDatabaseMeal)
+    handleFetchRequest(url, method, /** @type {MealRequest} */ (toDatabaseMeal))
       .then(() => {
         setMealsNeedsRefetch(true);
         if (!isEditMode) {
@@ -110,6 +116,7 @@ function MealForm({ mealToEditData }) {
         method: "DELETE",
       })
         .then((response) => {
+          /** @type {Promise<MealResponse>} */ (response.json());
           if (response.ok) {
             setMealsNeedsRefetch(true);
             handleClearForm();


### PR DESCRIPTION
## Summary
- use generated Ingredient and Meal interfaces for form requests
- annotate delete responses to align with API schema

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9230d26c0832298861c100866c367