### PR TITLE
Fix SQLAlchemy mapper configuration for tests

### DIFF
--- a/Backend/__init__.py
+++ b/Backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package."""

--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -5,8 +5,8 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from db import Base, engine
-from routes import ingredients_router, meals_router
+from .db import Base, engine
+from .routes import ingredients_router, meals_router
 
 app = FastAPI()
 

--- a/Backend/models/ingredient.py
+++ b/Backend/models/ingredient.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List, Optional
 
 from sqlmodel import SQLModel, Field, Relationship

--- a/Backend/models/ingredient_unit.py
+++ b/Backend/models/ingredient_unit.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Optional
 
 from sqlmodel import SQLModel, Field, Relationship

--- a/Backend/models/meal.py
+++ b/Backend/models/meal.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List, Optional
 
 from sqlmodel import SQLModel, Field, Relationship

--- a/Backend/models/meal_ingredient.py
+++ b/Backend/models/meal_ingredient.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Optional
 
 from sqlmodel import SQLModel, Field, Relationship

--- a/Backend/models/nutrition.py
+++ b/Backend/models/nutrition.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Optional
 
 from sqlmodel import SQLModel, Field, Relationship

--- a/Backend/models/possible_ingredient_tag.py
+++ b/Backend/models/possible_ingredient_tag.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List, Optional
 
 from sqlmodel import SQLModel, Field, Relationship

--- a/Backend/models/possible_meal_tag.py
+++ b/Backend/models/possible_meal_tag.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List, Optional
 
 from sqlmodel import SQLModel, Field, Relationship

--- a/Backend/routes/ingredients.py
+++ b/Backend/routes/ingredients.py
@@ -3,8 +3,8 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
-from db import get_db
-from models import Ingredient, PossibleIngredientTag
+from ..db import get_db
+from ..models import Ingredient, PossibleIngredientTag
 
 router = APIRouter(prefix="/ingredients", tags=["ingredients"])
 

--- a/Backend/routes/meals.py
+++ b/Backend/routes/meals.py
@@ -3,8 +3,8 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
-from db import get_db
-from models import Meal, PossibleMealTag
+from ..db import get_db
+from ..models import Meal, PossibleMealTag
 
 router = APIRouter(prefix="/meals", tags=["meals"])
 


### PR DESCRIPTION
## Summary
- make Backend a proper package and use relative imports
- drop postponed annotations in models to avoid SQLAlchemy mapper errors
- simplify API test setup to create/drop tables without Alembic

## Testing
- `pytest Backend/tests/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68a924d49f6c8322a363ca10a7862276