### PR TITLE
Improve venv activation dependency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ All development should be run from inside the project's Python virtual environme
 pwsh ./scripts/activate-venv.ps1
 ```
 
-The script creates the `.venv` directory if needed and installs required dependencies.
+The script creates the `.venv` directory if needed and installs or updates
+dependencies. It caches a hash of `Backend/requirements.txt` inside the virtual
+environment and automatically reruns `pip install` whenever that file changes.
 
 ## ▶️ Run the Backend
 

--- a/scripts/activate-venv.ps1
+++ b/scripts/activate-venv.ps1
@@ -14,8 +14,13 @@ if (-Not (Test-Path $VenvPath)) {
 
 & "$VenvPath\Scripts\Activate.ps1"
 
-# Install dependencies if the venv was just created or requirements are missing
-pip show fastapi > $null 2>&1
-if ($venvCreated -or -not $?) {
+# Install dependencies if the venv was just created or the requirements
+# file has changed since the last install. A hash of the requirements file is
+# cached inside the venv to avoid unnecessary reinstalls.
+$hashPath = Join-Path $VenvPath ".requirements.hash"
+$currentHash = (Get-FileHash $RequirementsPath -Algorithm SHA256).Hash
+
+if ($venvCreated -or -not (Test-Path $hashPath) -or (Get-Content $hashPath) -ne $currentHash) {
     pip install -r $RequirementsPath
+    Set-Content $hashPath $currentHash
 }

--- a/scripts/activate-venv.sh
+++ b/scripts/activate-venv.sh
@@ -17,6 +17,13 @@ fi
 # shellcheck disable=SC1090
 source "$VENV_PATH/bin/activate"
 
-if $venv_created || ! pip show fastapi >/dev/null 2>&1; then
+# Reinstall dependencies if the venv was just created or the requirements
+# file has changed since the last install. The hash is cached inside the venv
+# directory to avoid unnecessary reinstalls.
+HASH_PATH="$VENV_PATH/.requirements.hash"
+current_hash="$(sha256sum "$REQUIREMENTS_PATH" | awk '{print $1}')"
+
+if $venv_created || [ ! -f "$HASH_PATH" ] || [ "$current_hash" != "$(cat "$HASH_PATH")" ]; then
     pip install -r "$REQUIREMENTS_PATH"
+    echo "$current_hash" > "$HASH_PATH"
 fi


### PR DESCRIPTION
## Summary
- reinstall backend dependencies when `Backend/requirements.txt` changes or the venv is created
- cache requirements hash inside the venv to avoid redundant installs
- document automatic dependency refresh in the README

## Testing
- `./.venv/bin/python -m pytest` *(fails: ImportError: attempted relative import with no known parent package)*
- `npm --prefix Frontend/nutrition-frontend test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a928f4615c8322875295d155103dc3