### PR TITLE
Remove unused Postgres init volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       retries: 5
     volumes:
       - dbdata:/var/lib/postgresql/data
-      - ./Database:/docker-entrypoint-initdb.d
     ports:
       - "${DB_PORT:-5432}:5432"
     networks:


### PR DESCRIPTION
## Summary
- remove empty database init volume from docker-compose

## Testing
- `pwsh ./scripts/compose-up-branch.ps1 -empty` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68a9294e815c8322b7aaed9b56239ec7