### PR TITLE
feat: allow custom backend port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Update API schema
         run: |
           source scripts/activate-venv.sh
+          export BACKEND_PORT=8000
           scripts/update-api-schema.sh
       - name: Ensure API schema is up to date
         run: |

--- a/README.md
+++ b/README.md
@@ -107,11 +107,14 @@ kill %1
 Use [`openapi-typescript`](https://github.com/drwpow/openapi-typescript) to keep
 frontend TypeScript definitions aligned with the API. The OpenAPI schema and
 TypeScript types are currently synced manually via `scripts/update-api-schema.sh`,
-which regenerates both the backend schema and frontend types:
+which regenerates both the backend schema and frontend types. Set the port used
+by the temporary backend server with the `BACKEND_PORT` environment variable
+(defaults to `8000`) and run the script:
 
 ```bash
 npm --prefix Frontend/nutrition-frontend install   # run once
-npx --prefix Frontend/nutrition-frontend openapi-typescript Backend/openapi.json -o Frontend/nutrition-frontend/src/api-types.ts
+export BACKEND_PORT=8000  # optional
+scripts/update-api-schema.sh
 ```
 
 Run the script whenever API models change and commit the generated file.

--- a/scripts/update-api-schema.sh
+++ b/scripts/update-api-schema.sh
@@ -10,16 +10,18 @@ cleanup() {
 }
 trap cleanup EXIT INT
 
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+
 # Launch the FastAPI app in the background
-PYTHONPATH=Backend uvicorn backend:app --port 8000 &
+PYTHONPATH=Backend uvicorn backend:app --port "$BACKEND_PORT" &
 UVICORN_PID=$!
 # Wait for the server to be ready
-until curl --silent --fail http://localhost:8000/openapi.json >/dev/null; do
+until curl --silent --fail "http://localhost:${BACKEND_PORT}/openapi.json" >/dev/null; do
   sleep 1
 done
 
 # Capture the schema
-curl http://localhost:8000/openapi.json -o Backend/openapi.json
+curl "http://localhost:${BACKEND_PORT}/openapi.json" -o Backend/openapi.json
 
 # Generate TypeScript types for the frontend
 npx --prefix Frontend/nutrition-frontend openapi-typescript Backend/openapi.json -o Frontend/nutrition-frontend/src/api-types.ts


### PR DESCRIPTION
## Summary
- make `update-api-schema.sh` respect `BACKEND_PORT`
- document custom port usage and set in CI

## Testing
- `BACKEND_PORT=8001 scripts/update-api-schema.sh`
- `ps aux | grep uvicorn`
- `PYTHONPATH=$PWD DATABASE_URL=sqlite:///test.db python -m pytest Backend/tests/test_api.py -q`
- `PYTHONPATH=$PWD DATABASE_URL=sqlite:///test.db python -m pytest Backend/tests/test_routes.py -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68a928fba6e48322b187bca656c73bee