### PR TITLE
Ensure backend tests import modules via package path

### DIFF
--- a/Backend/tests/test_routes.py
+++ b/Backend/tests/test_routes.py
@@ -1,5 +1,3 @@
-import os
-import sys
 from typing import Iterator
 
 import pytest
@@ -7,12 +5,10 @@ from fastapi.testclient import TestClient
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel, Session, create_engine
 
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
-from backend import app
-from db import get_db
-import models  # ensure models are imported for SQLModel metadata
-from models import PossibleIngredientTag, PossibleMealTag
+from Backend.backend import app
+from Backend.db import get_db
+from Backend import models  # ensure models are imported for SQLModel metadata
+from Backend.models import PossibleIngredientTag, PossibleMealTag
 
 
 @pytest.fixture(name="engine")


### PR DESCRIPTION
## Summary
- import the FastAPI app and DB getter from the Backend package to execute backend.py within package context

## Testing
- ❌ `PYTHONPATH=. pytest Backend/tests/test_routes.py -q` (fails: assert 422 == 200)


------
https://chatgpt.com/codex/tasks/task_e_68a92cf969148322b450f9c19582b272