### PR TITLE
Wrap frontend interactions in act to remove warnings

### DIFF
--- a/Frontend/nutrition-frontend/src/components/data/DataPage.js
+++ b/Frontend/nutrition-frontend/src/components/data/DataPage.js
@@ -15,8 +15,8 @@ function DataPage() {
   return (
     <Box sx={{ width: "100%", display: "flex", flexDirection: "column", alignItems: "center" }}>
       <Tabs value={dataTab} onChange={handleDataTabChange} aria-label="data tabs" centered>
-        <Tab label="Meals" />
-        <Tab label="Ingredients" />
+        <Tab label="Meals" disableRipple />
+        <Tab label="Ingredients" disableRipple />
       </Tabs>
       {dataTab === 0 && <MealData />}
       {dataTab === 1 && <IngredientData handleAddIngredientToPlan={() => {}} />}

--- a/Frontend/nutrition-frontend/src/tests/App.test.js
+++ b/Frontend/nutrition-frontend/src/tests/App.test.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import App from "../App";
 
@@ -23,7 +24,7 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-test("renders tabs and switches between Meals and Ingredients views", () => {
+test("renders tabs and switches between Meals and Ingredients views", async () => {
   render(<App />);
 
   const mealsTab = screen.getByRole("tab", { name: /Meals/i });
@@ -35,16 +36,20 @@ test("renders tabs and switches between Meals and Ingredients views", () => {
   expect(mockMealData).toHaveBeenCalledTimes(1);
   expect(mockIngredientData).not.toHaveBeenCalled();
 
-  fireEvent.click(ingredientsTab);
+  await act(async () => {
+    await userEvent.click(ingredientsTab);
+  });
   expect(mockIngredientData).toHaveBeenCalledTimes(1);
   expect(mockMealData).toHaveBeenCalledTimes(1);
 
-  fireEvent.click(mealsTab);
+  await act(async () => {
+    await userEvent.click(mealsTab);
+  });
   expect(mockMealData).toHaveBeenCalledTimes(2);
   expect(mockIngredientData).toHaveBeenCalledTimes(1);
 });
 
-test("provides handleAddIngredientToPlan only to IngredientData", () => {
+test("provides handleAddIngredientToPlan only to IngredientData", async () => {
   render(<App />);
 
   // initial render shows MealData without the prop
@@ -52,7 +57,9 @@ test("provides handleAddIngredientToPlan only to IngredientData", () => {
   expect(mockMealData).toHaveBeenCalled();
   expect(mockMealData.mock.calls[0][0].handleAddIngredientToPlan).toBeUndefined();
 
-  fireEvent.click(screen.getByRole("tab", { name: /Ingredients/i }));
+  await act(async () => {
+    await userEvent.click(screen.getByRole("tab", { name: /Ingredients/i }));
+  });
 
   expect(mockIngredientData).toHaveBeenCalled();
   const props = mockIngredientData.mock.calls[0][0];

--- a/Frontend/nutrition-frontend/src/tests/MealTable.test.js
+++ b/Frontend/nutrition-frontend/src/tests/MealTable.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import MealTable from "../components/data/meal/MealTable";
@@ -64,8 +64,12 @@ describe("MealTable tag filtering", () => {
 
   test("filters meals by a single selected tag and excludes meals without tags", async () => {
     renderWithData();
-    await userEvent.click(screen.getByLabelText(/Filter tags/i));
-    await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
+    await act(async () => {
+      await userEvent.click(screen.getByLabelText(/Filter tags/i));
+    });
+    await act(async () => {
+      await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
+    });
     expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
     expect(screen.queryByText("Veg Breakfast")).not.toBeInTheDocument();
     expect(screen.queryByText("Snack")).not.toBeInTheDocument();
@@ -74,10 +78,18 @@ describe("MealTable tag filtering", () => {
 
   test("filters meals when multiple tags are selected", async () => {
     renderWithData();
-    await userEvent.click(screen.getByLabelText(/Filter tags/i));
-    await userEvent.click(screen.getByRole("option", { name: "Breakfast" }));
-    await userEvent.click(screen.getByLabelText(/Filter tags/i));
-    await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
+    await act(async () => {
+      await userEvent.click(screen.getByLabelText(/Filter tags/i));
+    });
+    await act(async () => {
+      await userEvent.click(screen.getByRole("option", { name: "Breakfast" }));
+    });
+    await act(async () => {
+      await userEvent.click(screen.getByLabelText(/Filter tags/i));
+    });
+    await act(async () => {
+      await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
+    });
     expect(screen.getByText("Veg Breakfast")).toBeInTheDocument();
     expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
     expect(screen.queryByText("Snack")).not.toBeInTheDocument();
@@ -85,10 +97,14 @@ describe("MealTable tag filtering", () => {
 
   test("combines search and tag filters", async () => {
     renderWithData();
-    await userEvent.click(screen.getByLabelText(/Filter tags/i));
-    await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
-    fireEvent.change(screen.getByLabelText(/Search by name/i), {
-      target: { value: "Chicken" },
+    await act(async () => {
+      await userEvent.click(screen.getByLabelText(/Filter tags/i));
+    });
+    await act(async () => {
+      await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
+    });
+    await act(async () => {
+      await userEvent.type(screen.getByLabelText(/Search by name/i), "Chicken");
     });
     expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
     expect(screen.queryByText("Veg Breakfast")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- use `userEvent` and explicit `act` wrappers in frontend tests to keep state updates scoped
- disable MUI ripple on tabs to prevent async updates during tests

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a92d047e588322ae387781c72136ed