### PR TITLE
Reorder possible_tags route definitions

### DIFF
--- a/Backend/routes/ingredients.py
+++ b/Backend/routes/ingredients.py
@@ -15,6 +15,15 @@ def get_all_ingredients(db: Session = Depends(get_db)) -> List[Ingredient]:
     return db.exec(select(Ingredient)).all()
 
 
+@router.get("/possible_tags", response_model=List[PossibleIngredientTag])
+def get_all_possible_tags(
+    db: Session = Depends(get_db),
+) -> List[PossibleIngredientTag]:
+    """Return all possible ingredient tags ordered by name."""
+    statement = select(PossibleIngredientTag).order_by(PossibleIngredientTag.name)
+    return db.exec(statement).all()
+
+
 @router.get("/{ingredient_id}", response_model=Ingredient)
 def get_ingredient(ingredient_id: int, db: Session = Depends(get_db)) -> Ingredient:
     """Retrieve a single ingredient by ID."""
@@ -73,15 +82,6 @@ def delete_ingredient(ingredient_id: int, db: Session = Depends(get_db)) -> dict
     db.delete(ingredient)
     db.commit()
     return {"message": "Ingredient deleted successfully"}
-
-
-@router.get("/possible_tags", response_model=List[PossibleIngredientTag])
-def get_all_possible_tags(
-    db: Session = Depends(get_db),
-) -> List[PossibleIngredientTag]:
-    """Return all possible ingredient tags ordered by name."""
-    statement = select(PossibleIngredientTag).order_by(PossibleIngredientTag.name)
-    return db.exec(statement).all()
 
 
 __all__ = ["router"]

--- a/Backend/routes/meals.py
+++ b/Backend/routes/meals.py
@@ -15,6 +15,13 @@ def get_all_meals(db: Session = Depends(get_db)) -> List[Meal]:
     return db.exec(select(Meal)).all()
 
 
+@router.get("/possible_tags", response_model=List[PossibleMealTag])
+def get_possible_meal_tags(db: Session = Depends(get_db)) -> List[PossibleMealTag]:
+    """Return all possible meal tags ordered by name."""
+    statement = select(PossibleMealTag).order_by(PossibleMealTag.name)
+    return db.exec(statement).all()
+
+
 @router.get("/{meal_id}", response_model=Meal)
 def get_meal(meal_id: int, db: Session = Depends(get_db)) -> Meal:
     """Retrieve a single meal by ID."""
@@ -22,13 +29,6 @@ def get_meal(meal_id: int, db: Session = Depends(get_db)) -> Meal:
     if not meal:
         raise HTTPException(status_code=404, detail="Meal not found")
     return meal
-
-
-@router.get("/possible_tags", response_model=List[PossibleMealTag])
-def get_possible_meal_tags(db: Session = Depends(get_db)) -> List[PossibleMealTag]:
-    """Return all possible meal tags ordered by name."""
-    statement = select(PossibleMealTag).order_by(PossibleMealTag.name)
-    return db.exec(statement).all()
 
 
 @router.post("/", response_model=Meal, status_code=201)


### PR DESCRIPTION
## Summary
- place `/possible_tags` route above `/{ingredient_id}` in ingredients routes
- place `/possible_tags` route above `/{meal_id}` in meals routes

## Testing
- `pytest` *(fails: KeyError: 'DATABASE_URL')*

------
https://chatgpt.com/codex/tasks/task_e_68a9358f726083229eb3681d83a9d85a