### PR TITLE
Fix backend module imports and route ordering

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 COPY Backend/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-# Copy backend source
-COPY Backend/ /app
+# Copy backend source preserving package structure
+COPY Backend/ /app/Backend
 
-CMD ["uvicorn", "backend:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "Backend.backend:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/Backend/routes/ingredients.py
+++ b/Backend/routes/ingredients.py
@@ -15,6 +15,15 @@ def get_all_ingredients(db: Session = Depends(get_db)) -> List[Ingredient]:
     return db.exec(select(Ingredient)).all()
 
 
+@router.get("/possible_tags", response_model=List[PossibleIngredientTag])
+def get_all_possible_tags(
+    db: Session = Depends(get_db),
+) -> List[PossibleIngredientTag]:
+    """Return all possible ingredient tags ordered by name."""
+    statement = select(PossibleIngredientTag).order_by(PossibleIngredientTag.name)
+    return db.exec(statement).all()
+
+
 @router.get("/{ingredient_id}", response_model=Ingredient)
 def get_ingredient(ingredient_id: int, db: Session = Depends(get_db)) -> Ingredient:
     """Retrieve a single ingredient by ID."""
@@ -75,13 +84,5 @@ def delete_ingredient(ingredient_id: int, db: Session = Depends(get_db)) -> dict
     return {"message": "Ingredient deleted successfully"}
 
 
-@router.get("/possible_tags", response_model=List[PossibleIngredientTag])
-def get_all_possible_tags(
-    db: Session = Depends(get_db),
-) -> List[PossibleIngredientTag]:
-    """Return all possible ingredient tags ordered by name."""
-    statement = select(PossibleIngredientTag).order_by(PossibleIngredientTag.name)
-    return db.exec(statement).all()
-
-
 __all__ = ["router"]
+

--- a/Backend/routes/meals.py
+++ b/Backend/routes/meals.py
@@ -15,6 +15,13 @@ def get_all_meals(db: Session = Depends(get_db)) -> List[Meal]:
     return db.exec(select(Meal)).all()
 
 
+@router.get("/possible_tags", response_model=List[PossibleMealTag])
+def get_possible_meal_tags(db: Session = Depends(get_db)) -> List[PossibleMealTag]:
+    """Return all possible meal tags ordered by name."""
+    statement = select(PossibleMealTag).order_by(PossibleMealTag.name)
+    return db.exec(statement).all()
+
+
 @router.get("/{meal_id}", response_model=Meal)
 def get_meal(meal_id: int, db: Session = Depends(get_db)) -> Meal:
     """Retrieve a single meal by ID."""
@@ -22,13 +29,6 @@ def get_meal(meal_id: int, db: Session = Depends(get_db)) -> Meal:
     if not meal:
         raise HTTPException(status_code=404, detail="Meal not found")
     return meal
-
-
-@router.get("/possible_tags", response_model=List[PossibleMealTag])
-def get_possible_meal_tags(db: Session = Depends(get_db)) -> List[PossibleMealTag]:
-    """Return all possible meal tags ordered by name."""
-    statement = select(PossibleMealTag).order_by(PossibleMealTag.name)
-    return db.exec(statement).all()
 
 
 @router.post("/", response_model=Meal, status_code=201)
@@ -74,3 +74,4 @@ def delete_meal(meal_id: int, db: Session = Depends(get_db)) -> dict:
 
 
 __all__ = ["router"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       db:
         condition: service_healthy
     volumes:
-      - ./Backend:/app
-    command: uvicorn backend:app --host 0.0.0.0 --port 8000 --reload
+      - ./Backend:/app/Backend
+    command: uvicorn Backend.backend:app --host 0.0.0.0 --port 8000 --reload
     networks:
       - nutrition-net
     ports:

--- a/scripts/update-api-schema.sh
+++ b/scripts/update-api-schema.sh
@@ -13,7 +13,7 @@ trap cleanup EXIT INT
 BACKEND_PORT="${BACKEND_PORT:-8000}"
 
 # Launch the FastAPI app in the background
-PYTHONPATH=Backend uvicorn backend:app --port "$BACKEND_PORT" &
+uvicorn Backend.backend:app --port "$BACKEND_PORT" &
 UVICORN_PID=$!
 # Wait for the server to be ready
 until curl --silent --fail "http://localhost:${BACKEND_PORT}/openapi.json" >/dev/null; do


### PR DESCRIPTION
## Summary
- preserve Backend package structure and run app via `Backend.backend:app`
- adjust API schema script and docker config to use module path
- reorder ingredient and meal routes so static `possible_tags` paths resolve correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9366c4cc0832289830591b497cc17