### PR TITLE
Remove unnecessary act wrappers in tests

### DIFF
--- a/Frontend/nutrition-frontend/src/tests/App.test.js
+++ b/Frontend/nutrition-frontend/src/tests/App.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import App from "../App";
@@ -36,15 +36,11 @@ test("renders tabs and switches between Meals and Ingredients views", async () =
   expect(mockMealData).toHaveBeenCalledTimes(1);
   expect(mockIngredientData).not.toHaveBeenCalled();
 
-  await act(async () => {
-    await userEvent.click(ingredientsTab);
-  });
+  await userEvent.click(ingredientsTab);
   expect(mockIngredientData).toHaveBeenCalledTimes(1);
   expect(mockMealData).toHaveBeenCalledTimes(1);
 
-  await act(async () => {
-    await userEvent.click(mealsTab);
-  });
+  await userEvent.click(mealsTab);
   expect(mockMealData).toHaveBeenCalledTimes(2);
   expect(mockIngredientData).toHaveBeenCalledTimes(1);
 });
@@ -57,9 +53,7 @@ test("provides handleAddIngredientToPlan only to IngredientData", async () => {
   expect(mockMealData).toHaveBeenCalled();
   expect(mockMealData.mock.calls[0][0].handleAddIngredientToPlan).toBeUndefined();
 
-  await act(async () => {
-    await userEvent.click(screen.getByRole("tab", { name: /Ingredients/i }));
-  });
+  await userEvent.click(screen.getByRole("tab", { name: /Ingredients/i }));
 
   expect(mockIngredientData).toHaveBeenCalled();
   const props = mockIngredientData.mock.calls[0][0];

--- a/Frontend/nutrition-frontend/src/tests/MealTable.test.js
+++ b/Frontend/nutrition-frontend/src/tests/MealTable.test.js
@@ -1,4 +1,4 @@
-import { render, screen, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import MealTable from "../components/data/meal/MealTable";
@@ -64,12 +64,8 @@ describe("MealTable tag filtering", () => {
 
   test("filters meals by a single selected tag and excludes meals without tags", async () => {
     renderWithData();
-    await act(async () => {
-      await userEvent.click(screen.getByLabelText(/Filter tags/i));
-    });
-    await act(async () => {
-      await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
-    });
+    await userEvent.click(screen.getByLabelText(/Filter tags/i));
+    await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
     expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
     expect(screen.queryByText("Veg Breakfast")).not.toBeInTheDocument();
     expect(screen.queryByText("Snack")).not.toBeInTheDocument();
@@ -78,18 +74,10 @@ describe("MealTable tag filtering", () => {
 
   test("filters meals when multiple tags are selected", async () => {
     renderWithData();
-    await act(async () => {
-      await userEvent.click(screen.getByLabelText(/Filter tags/i));
-    });
-    await act(async () => {
-      await userEvent.click(screen.getByRole("option", { name: "Breakfast" }));
-    });
-    await act(async () => {
-      await userEvent.click(screen.getByLabelText(/Filter tags/i));
-    });
-    await act(async () => {
-      await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
-    });
+    await userEvent.click(screen.getByLabelText(/Filter tags/i));
+    await userEvent.click(screen.getByRole("option", { name: "Breakfast" }));
+    await userEvent.click(screen.getByLabelText(/Filter tags/i));
+    await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
     expect(screen.getByText("Veg Breakfast")).toBeInTheDocument();
     expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
     expect(screen.queryByText("Snack")).not.toBeInTheDocument();
@@ -97,15 +85,9 @@ describe("MealTable tag filtering", () => {
 
   test("combines search and tag filters", async () => {
     renderWithData();
-    await act(async () => {
-      await userEvent.click(screen.getByLabelText(/Filter tags/i));
-    });
-    await act(async () => {
-      await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
-    });
-    await act(async () => {
-      await userEvent.type(screen.getByLabelText(/Search by name/i), "Chicken");
-    });
+    await userEvent.click(screen.getByLabelText(/Filter tags/i));
+    await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
+    await userEvent.type(screen.getByLabelText(/Search by name/i), "Chicken");
     expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
     expect(screen.queryByText("Veg Breakfast")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- drop React Testing Library `act` wrappers in App.test.js and MealTable.test.js

## Testing
- `npm run lint`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a938ba13ac8322be514df2c009cfda