### PR TITLE
Fix backend import to run as module

### DIFF
--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -5,8 +5,8 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .db import Base, engine
-from .routes import ingredients_router, meals_router
+from Backend.db import Base, engine
+from Backend.routes import ingredients_router, meals_router
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- use absolute imports in backend application entrypoint

## Testing
- `pytest` *(fails: NameError: name 'sys' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a93cefc09c83228025c66f851c5ec6