### PR TITLE
Make ingredient and meal foreign keys optional

### DIFF
--- a/Backend/models/ingredient.py
+++ b/Backend/models/ingredient.py
@@ -17,8 +17,14 @@ class Ingredient(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(sa_column=Column(String(100), unique=True, nullable=False))
 
-    nutrition: Optional[Nutrition] = Relationship(back_populates="ingredient")
-    units: List[IngredientUnit] = Relationship(back_populates="ingredient")
+    nutrition: Optional[Nutrition] = Relationship(
+        back_populates="ingredient",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
+    units: List[IngredientUnit] = Relationship(
+        back_populates="ingredient",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
     tags: List[PossibleIngredientTag] = Relationship(
         back_populates="ingredients", link_model=IngredientTagLink
     )

--- a/Backend/models/ingredient_unit.py
+++ b/Backend/models/ingredient_unit.py
@@ -10,7 +10,9 @@ class IngredientUnit(SQLModel, table=True):
     __tablename__ = "ingredient_units"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    ingredient_id: int = Field(foreign_key="ingredients.id")
+    ingredient_id: Optional[int] = Field(
+        default=None, foreign_key="ingredients.id"
+    )
     name: str = Field(sa_column=Column(String(50), nullable=False))
     grams: float = Field(sa_column=Column(Numeric(10, 4), nullable=False))
 

--- a/Backend/models/meal.py
+++ b/Backend/models/meal.py
@@ -16,7 +16,10 @@ class Meal(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(sa_column=Column(String(100), unique=True, nullable=False))
 
-    ingredients: List[MealIngredient] = Relationship(back_populates="meal")
+    ingredients: List[MealIngredient] = Relationship(
+        back_populates="meal",
+        sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
     tags: List[PossibleMealTag] = Relationship(
         back_populates="meals", link_model=MealTagLink
     )

--- a/Backend/models/meal_ingredient.py
+++ b/Backend/models/meal_ingredient.py
@@ -9,8 +9,12 @@ class MealIngredient(SQLModel, table=True):
 
     __tablename__ = "meal_ingredients"
 
-    ingredient_id: int = Field(foreign_key="ingredients.id", primary_key=True)
-    meal_id: int = Field(foreign_key="meals.id", primary_key=True)
+    ingredient_id: Optional[int] = Field(
+        default=None, foreign_key="ingredients.id", primary_key=True
+    )
+    meal_id: Optional[int] = Field(
+        default=None, foreign_key="meals.id", primary_key=True
+    )
     unit_id: Optional[int] = Field(default=None, foreign_key="ingredient_units.id")
     unit_quantity: Optional[float] = Field(
         default=None, sa_column=Column(Numeric(10, 4))

--- a/Backend/models/nutrition.py
+++ b/Backend/models/nutrition.py
@@ -10,7 +10,9 @@ class Nutrition(SQLModel, table=True):
     __tablename__ = "nutrition"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    ingredient_id: int = Field(foreign_key="ingredients.id")
+    ingredient_id: Optional[int] = Field(
+        default=None, foreign_key="ingredients.id"
+    )
     calories: float = Field(sa_column=Column(Numeric(10, 4), nullable=False))
     fat: float = Field(sa_column=Column(Numeric(10, 4), nullable=False))
     carbohydrates: float = Field(sa_column=Column(Numeric(10, 4), nullable=False))


### PR DESCRIPTION
## Summary
- allow deferred foreign key assignment for `Nutrition`, `IngredientUnit`, and `MealIngredient`
- cascade related items so FKs are set on flush

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a93dd4fe848322952a2a16a0b72d60