### PR TITLE
Silence multipart deprecation warning

### DIFF
--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -1,6 +1,14 @@
 """FastAPI application entry point."""
 
 import os
+import sys
+
+import python_multipart
+
+# Ensure Starlette imports the modern `python_multipart` module instead of the
+# deprecated `multipart` alias. This prevents a PendingDeprecationWarning during
+# application startup.
+sys.modules["multipart"] = python_multipart
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware

--- a/Backend/tests/conftest.py
+++ b/Backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+
+import python_multipart
+
+# Ensure tests load python_multipart instead of the deprecated multipart alias.
+sys.modules["multipart"] = python_multipart


### PR DESCRIPTION
## Summary
- ensure Starlette uses `python_multipart` instead of the deprecated `multipart` alias
- pre-load `python_multipart` in tests to avoid deprecation warnings

## Testing
- `pytest Backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a9c67423008322a7ee684d7bff61fe