### PR TITLE
fix: correct nginx backend host

### DIFF
--- a/Frontend/nutrition-frontend/nginx.conf
+++ b/Frontend/nutrition-frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://nutrition-backend:8000/;
+    proxy_pass http://backend:8000/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary
- point nginx /api proxy to backend service

## Testing
- `npm test -- --watchAll=false`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9c6dce8f88322a9eb320d68866f32