### PR TITLE
docs: document OpenAPI schema script

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,23 @@ python Database/import_from_csv.py --test   # or --production
 
 ## 📚 Generating OpenAPI
 
-FastAPI exposes an OpenAPI schema at `/openapi.json`. Generate a local copy:
+Use `scripts/update-api-schema.sh` as the single source of truth for generating
+`Backend/openapi.json` and syncing frontend TypeScript types. The script spins
+up a temporary FastAPI server, fetches `/openapi.json`, and runs
+[`openapi-typescript`](https://github.com/drwpow/openapi-typescript). Set the
+port with `BACKEND_PORT` (defaults to `8000`) and run:
+
+```bash
+npm --prefix Frontend/nutrition-frontend install   # run once
+export BACKEND_PORT=8000  # optional
+scripts/update-api-schema.sh
+```
+
+Run this script whenever API models change and commit the generated files.
+
+### Advanced: Manual workflow
+
+If you need to generate the schema manually:
 
 ```bash
 uvicorn Backend.backend:app --port 8000 &
@@ -101,29 +117,9 @@ kill %1
 ```
 
 ### Troubleshooting
-* 404 on `/openapi.json` – confirm the server started and you're hitting the correct port.
-* Missing fields – ensure migrations were applied and models import correctly.
-
-## 🔄 Syncing Frontend Types
-
-Use [`openapi-typescript`](https://github.com/drwpow/openapi-typescript) to keep
-frontend TypeScript definitions aligned with the API. The OpenAPI schema and
-TypeScript types are currently synced manually via `scripts/update-api-schema.sh`,
-which regenerates both the backend schema and frontend types. Set the port used
-by the temporary backend server with the `BACKEND_PORT` environment variable
-(defaults to `8000`) and run the script:
-
-```bash
-npm --prefix Frontend/nutrition-frontend install   # run once
-export BACKEND_PORT=8000  # optional
-scripts/update-api-schema.sh
-```
-
-Run the script whenever API models change and commit the generated file.
-
-### Troubleshooting
 * `openapi-typescript` not found – ensure frontend dev dependencies are installed.
-* Generated types missing endpoints – regenerate the OpenAPI spec and rerun the command.
+* Generated types missing endpoints – ensure migrations were applied and rerun the script.
+* 404 on `/openapi.json` – confirm the backend server started and you're hitting the correct port.
 
 ## 🚦 CI/CD Expectations
 


### PR DESCRIPTION
## Summary
- document `scripts/update-api-schema.sh` as canonical way to generate OpenAPI schema and frontend types
- mark manual `uvicorn`/`curl` workflow as an advanced alternative

## Testing
- `pytest`
- `CI=true npm --prefix Frontend/nutrition-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a9caa93a288322ac02c652ef28cfa0