### PR TITLE
docs: clarify schema source for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ The server will be available at <http://localhost:8000> by default.
 
 ## 🛠️ Running Migrations
 
+> **Note:** SQLModel models are the source of truth. Database migrations and the OpenAPI
+> schema are generated from these models. After modifying models, run `alembic revision --autogenerate`
+> and `scripts/update-api-schema.sh`, then commit the new migration, `Backend/openapi.json`, and
+> `Frontend/nutrition-frontend/src/api-types.ts`.
+
 The backend uses [Alembic](https://alembic.sqlalchemy.org/) for schema changes.
 Run these commands from the repository root:
 


### PR DESCRIPTION
## Summary
- clarify that SQLModel models are the schema source of truth
- remind contributors to run alembic autogenerate and update API schema

## Testing
- `pytest`
- `CI=true npm --prefix Frontend/nutrition-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a9cabbac3c8322ad6343f8caff0ac5