### PR TITLE
Ensure activate scripts refresh dependencies for active venvs

### DIFF
--- a/scripts/activate-venv.ps1
+++ b/scripts/activate-venv.ps1
@@ -12,7 +12,10 @@ if (-Not (Test-Path $VenvPath)) {
     $venvCreated = $true
 }
 
-& "$VenvPath\Scripts\Activate.ps1"
+# Activate the virtual environment unless we're already inside it.
+if ($env:VIRTUAL_ENV -ne $VenvPath) {
+    & "$VenvPath\Scripts\Activate.ps1"
+}
 
 # Install dependencies if the venv was just created or the requirements
 # file has changed since the last install. A hash of the requirements file is

--- a/scripts/activate-venv.sh
+++ b/scripts/activate-venv.sh
@@ -14,8 +14,11 @@ if [ ! -d "$VENV_PATH" ]; then
     venv_created=true
 fi
 
-# shellcheck disable=SC1090
-source "$VENV_PATH/bin/activate"
+# Activate the virtual environment unless we're already inside it.
+if [ "$VIRTUAL_ENV" != "$VENV_PATH" ]; then
+    # shellcheck disable=SC1090
+    source "$VENV_PATH/bin/activate"
+fi
 
 # Reinstall dependencies if the venv was just created or the requirements
 # file has changed since the last install. The hash is cached inside the venv


### PR DESCRIPTION
## Summary
- Skip reactivating the virtual environment when it's already active
- Always re-run dependency install when `requirements.txt` changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d35a31e48322ae7bb61a9efc8a37