### PR TITLE
chore: update frontend paths in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           source scripts/activate-venv.sh
           pip install pytest
       - name: Install frontend dependencies for API schema
-        working-directory: Frontend/nutrition-frontend
+        working-directory: Frontend
         run: npm ci
       - name: Run Alembic migrations
         run: |
@@ -60,7 +60,7 @@ jobs:
           scripts/update-api-schema.sh
       - name: Ensure API schema is up to date
         run: |
-          git diff --exit-code Backend/openapi.json Frontend/nutrition-frontend/src/api-types.ts
+          git diff --exit-code Backend/openapi.json Frontend/src/api-types.ts
       - name: Backend tests
         run: |
           source scripts/activate-venv.sh
@@ -90,22 +90,22 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: frontend-${{ runner.os }}-npm-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('Frontend/nutrition-frontend/package-lock.json') }}
+          key: frontend-${{ runner.os }}-npm-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('Frontend/package-lock.json') }}
           restore-keys: |
             frontend-${{ runner.os }}-npm-${{ steps.setup-node.outputs.node-version }}-
       - name: Verify npm cache
         run: ls -al ~/.npm || echo 'No npm cache found'
       - name: Install frontend dependencies
-        working-directory: Frontend/nutrition-frontend
+        working-directory: Frontend
         run: npm ci
       - name: Frontend lint
-        working-directory: Frontend/nutrition-frontend
+        working-directory: Frontend
         run: npm run lint
       - name: Frontend tests
-        working-directory: Frontend/nutrition-frontend
+        working-directory: Frontend
         env:
           CI: true
         run: npm test -- --watchAll=false
       - name: Production build
-        working-directory: Frontend/nutrition-frontend
+        working-directory: Frontend
         run: npm run build


### PR DESCRIPTION
## Summary
- fix CI workflow to reference `Frontend` directory directly
- update API schema and frontend steps to use new paths

## Testing
- `npm run lint`
- `CI=true npm test -- --watchAll=false`
- `npm run build`
- `git diff --exit-code Backend/openapi.json Frontend/src/api-types.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a9d89f84a08322ba05215a6efd8efa