### PR TITLE
Add PowerShell script to sync API and migrations

### DIFF
--- a/scripts/sync-api-and-migrations.ps1
+++ b/scripts/sync-api-and-migrations.ps1
@@ -1,0 +1,96 @@
+# scripts/sync-api-and-migrations.ps1
+# Synchronize the OpenAPI schema and database migrations with the current models.
+#
+# The script first regenerates the OpenAPI schema and frontend TypeScript types
+# using scripts/update-api-schema.sh. If this results in changes, the user is
+# prompted whether to keep the updates. In CI or when invoked with -y, the
+# updates are kept automatically.
+#
+# Next, it runs `alembic revision --autogenerate` in check mode to determine if
+# model changes require a new migration. If differences are detected, the user is
+# asked whether to create a migration. Passing -y (or setting CI=true) will
+# automatically create the migration.
+#
+# This makes the script suitable for interactive use and automation (e.g. GitHub
+# Actions). When run in automation, provide `-y` to auto-accept prompts or set the
+# CI environment variable to `true`.
+
+[CmdletBinding()]
+param(
+    [Alias("y")]
+    [switch]$Auto
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Determine whether to auto-accept prompts
+$autoMode = $Auto.IsPresent -or $env:CI -eq "true"
+
+# Ensure we're running from the repository root
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+#############################
+# Check OpenAPI / Frontend
+#############################
+
+$logFile = [System.IO.Path]::GetTempFileName()
+& bash "$PSScriptRoot/update-api-schema.sh" *> $logFile 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Get-Content $logFile
+    Write-Error "Failed to update API schema"
+    Remove-Item $logFile
+    exit 1
+}
+Remove-Item $logFile
+
+git diff --quiet -- Backend/openapi.json Frontend/src/api-types.ts
+$apiDiff = $LASTEXITCODE -ne 0
+
+if ($apiDiff) {
+    Write-Host "OpenAPI schema or frontend types are out of date."
+    if ($autoMode) {
+        Write-Host "Keeping generated API files."
+    } else {
+        $resp = Read-Host "Keep generated API files? [y/N]"
+        if ($resp -notmatch '^[Yy]$') {
+            git checkout -- Backend/openapi.json Frontend/src/api-types.ts | Out-Null
+            Write-Host "Reverted API changes."
+        }
+    }
+} else {
+    Write-Host "OpenAPI schema and frontend types are up to date."
+}
+
+#############################
+# Check database migrations
+#############################
+
+$tmpfile = [System.IO.Path]::GetTempFileName()
+alembic revision --autogenerate -m "tmp" --stdout | Out-File -FilePath $tmpfile -Encoding utf8
+if ($LASTEXITCODE -ne 0) {
+    Remove-Item $tmpfile
+    Write-Error "Failed to check for migration changes"
+    exit 1
+}
+$needsMigration = Select-String -Path $tmpfile -Pattern 'op\.' -Quiet
+if ($needsMigration) {
+    Write-Host "Model changes detected that are not captured in migrations."
+    if ($autoMode) {
+        $msg = "auto migration"
+        alembic revision --autogenerate -m $msg | Out-Null
+        Write-Host "Created migration: $msg"
+    } else {
+        $resp = Read-Host "Generate new migration now? [y/N]"
+        if ($resp -match '^[Yy]$') {
+            $msg = Read-Host "Migration message"
+            alembic revision --autogenerate -m $msg | Out-Null
+        } else {
+            Write-Host "Skipping migration generation."
+        }
+    }
+} else {
+    Write-Host "Database migrations are up to date."
+}
+Remove-Item $tmpfile


### PR DESCRIPTION
## Summary
- add PowerShell script that syncs OpenAPI schema and database migrations

## Testing
- `pwsh -File scripts/sync-api-and-migrations.ps1 -y` *(fails: command not found)*
- `pytest` *(fails: httpx not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc5d26788322b36b49afd80ccbc0