### PR TITLE
Expose Alembic config to backend container

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -20,4 +20,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # Copy backend source preserving package structure
 COPY Backend/ /app/Backend
 
+# Copy Alembic configuration for database migrations
+COPY alembic.ini /app/alembic.ini
+
 CMD ["uvicorn", "Backend.backend:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
         condition: service_healthy
     volumes:
       - ./Backend:/app/Backend
+      - ./alembic.ini:/app/alembic.ini:ro
     command: uvicorn Backend.backend:app --host 0.0.0.0 --port 8000 --reload
     networks:
       - nutrition-net


### PR DESCRIPTION
## Summary
- mount alembic.ini into the backend container
- copy alembic.ini into the backend image for migrations

## Testing
- ⚠️ `docker compose config` (command not found)
- ✅ `python - <<'PY'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('docker-compose.yml parsed successfully')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aa1d28609083228be89d9dd60e51c2