### PR TITLE
fix: use relative path in PowerShell API sync script

### DIFF
--- a/scripts/sync-api-and-migrations.ps1
+++ b/scripts/sync-api-and-migrations.ps1
@@ -36,7 +36,8 @@ Set-Location $repoRoot
 #############################
 
 $logFile = [System.IO.Path]::GetTempFileName()
-& bash "$PSScriptRoot/update-api-schema.sh" *> $logFile 2>&1
+# Using a relative path ensures compatibility with Windows paths when invoking bash
+& bash "./scripts/update-api-schema.sh" *> $logFile 2>&1
 if ($LASTEXITCODE -ne 0) {
     Get-Content $logFile
     Write-Error "Failed to update API schema"


### PR DESCRIPTION
## Summary
- invoke update-api-schema.sh using a repository-relative path for better Windows compatibility

## Testing
- `pytest Backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1f8189388322bd30f89ceaef296d