### PR TITLE
Fix API schema script for Windows shells

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.sh text eol=lf

--- a/scripts/update-api-schema.sh
+++ b/scripts/update-api-schema.sh
@@ -1,9 +1,13 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
+# Enable pipefail if supported (e.g., bash, zsh)
+if [ -n "${BASH_VERSION-}" ] || [ -n "${ZSH_VERSION-}" ]; then
+  set -o pipefail
+fi
 
 UVICORN_PID=""
 cleanup() {
-  if [[ -n "${UVICORN_PID:-}" ]]; then
+  if [ -n "${UVICORN_PID:-}" ]; then
     kill "$UVICORN_PID" 2>/dev/null || true
     wait "$UVICORN_PID" 2>/dev/null || true
   fi


### PR DESCRIPTION
## Summary
- make update-api-schema.sh POSIX-compatible and enable `pipefail` only when supported
- enforce LF line endings for shell scripts

## Testing
- `sh -n scripts/update-api-schema.sh`
- `bash -n scripts/update-api-schema.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa21fd066483228e0e7a21fbcfbf0f