### PR TITLE
Ensure sync scripts activate venv and verify dependencies

### DIFF
--- a/scripts/sync-api-and-migrations.sh
+++ b/scripts/sync-api-and-migrations.sh
@@ -25,6 +25,21 @@ fi
 # Ensure we're running from the repository root
 cd "$(dirname "$0")/.."
 
+# Ensure the virtual environment is active and required packages are installed
+if [ -z "${VIRTUAL_ENV:-}" ] || ! command -v uvicorn >/dev/null 2>&1; then
+  echo "Activating virtual environment..."
+  if ! scripts/activate-venv.sh >/tmp/venv.log 2>&1; then
+    cat /tmp/venv.log
+    echo "Failed to activate virtual environment" >&2
+    exit 1
+  fi
+fi
+
+if ! command -v uvicorn >/dev/null 2>&1; then
+  echo "uvicorn command not found after activating virtual environment" >&2
+  exit 1
+fi
+
 #############################
 # Check OpenAPI / Frontend
 #############################


### PR DESCRIPTION
## Summary
- Ensure sync scripts activate the project virtual environment when missing
- Add dependency checks and early exit on failure for Bash and PowerShell sync scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa37baebe083228e019e73a867f1e2