### PR TITLE
Use python -m uvicorn in API schema sync script

### DIFF
--- a/scripts/update-api-schema.sh
+++ b/scripts/update-api-schema.sh
@@ -16,8 +16,10 @@ trap cleanup EXIT INT
 
 BACKEND_PORT="${BACKEND_PORT:-8000}"
 
-# Launch the FastAPI app in the background
-uvicorn Backend.backend:app --port "$BACKEND_PORT" &
+# Launch the FastAPI app in the background using the Python module invocation
+# to avoid relying on the `uvicorn` entry point being on the PATH (which can
+# be an issue on some platforms like Git Bash on Windows).
+python -m uvicorn Backend.backend:app --port "$BACKEND_PORT" &
 UVICORN_PID=$!
 # Wait for the server to be ready
 until curl --silent --fail "http://localhost:${BACKEND_PORT}/openapi.json" >/dev/null; do


### PR DESCRIPTION
## Summary
- run uvicorn via `python -m uvicorn` in update-api-schema.sh for better cross-platform compatibility
- avoid missing `uvicorn` command when running sync scripts on Windows/Git Bash

## Testing
- `./scripts/update-api-schema.sh >/tmp/update.log && tail -n 20 /tmp/update.log`
- `python -m pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68aa3a3bd6b4832293af22e35fed8b4c