### PR TITLE
Ensure update-api-schema.sh locates Python on Windows

### DIFF
--- a/scripts/update-api-schema.sh
+++ b/scripts/update-api-schema.sh
@@ -16,10 +16,26 @@ trap cleanup EXIT INT
 
 BACKEND_PORT="${BACKEND_PORT:-8000}"
 
+# Determine a workable Python command. Default to `python` but fall back to
+# `python3` or `py -3` for environments (such as Windows/WSL) where the default
+# isn't available on the PATH.
+PYTHON_CMD="${PYTHON:-python}"
+PYTHON_ARGS=""
+if ! command -v "$PYTHON_CMD" >/dev/null 2>&1; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_CMD=python3
+  elif command -v py >/dev/null 2>&1; then
+    PYTHON_CMD=py
+    PYTHON_ARGS="-3"
+  else
+    echo "Python is required but was not found on PATH" >&2
+    exit 1
+  fi
+fi
+
 # Launch the FastAPI app in the background using the Python module invocation
-# to avoid relying on the `uvicorn` entry point being on the PATH (which can
-# be an issue on some platforms like Git Bash on Windows).
-python -m uvicorn Backend.backend:app --port "$BACKEND_PORT" &
+# to avoid relying on the `uvicorn` entry point being on the PATH.
+"$PYTHON_CMD" $PYTHON_ARGS -m uvicorn Backend.backend:app --port "$BACKEND_PORT" &
 UVICORN_PID=$!
 # Wait for the server to be ready
 until curl --silent --fail "http://localhost:${BACKEND_PORT}/openapi.json" >/dev/null; do


### PR DESCRIPTION
## Summary
- detect available Python interpreter (python, python3, or py -3) in `update-api-schema.sh`

## Testing
- `./scripts/update-api-schema.sh` *(fails: prompts to install openapi-typescript)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3d44ac2883229170f2a4be3645da