### PR TITLE
Fix PowerShell Start-Process argument handling

### DIFF
--- a/scripts/update-api-schema.ps1
+++ b/scripts/update-api-schema.ps1
@@ -30,8 +30,9 @@ if (-not $python) {
     }
 }
 
-# Launch the FastAPI app in the background
-$uvicorn = Start-Process -FilePath $python -ArgumentList $pythonArgs + @("-m", "uvicorn", "Backend.backend:app", "--port", $backendPort) -PassThru
+# Launch the FastAPI app in the background. Ensure that the Python arguments
+# array is combined correctly before being passed to Start-Process.
+$uvicorn = Start-Process -FilePath $python -ArgumentList ($pythonArgs + @("-m", "uvicorn", "Backend.backend:app", "--port", $backendPort)) -PassThru
 
 try {
     # Wait for the server to be ready and capture the schema


### PR DESCRIPTION
## Summary
- fix update-api-schema.ps1 by combining argument arrays before Start-Process call

## Testing
- `./.venv/bin/python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa41ff072c83229711f11aa97d470a