### PR TITLE
Fix sync script shell window

### DIFF
--- a/scripts/update-api-schema.ps1
+++ b/scripts/update-api-schema.ps1
@@ -30,9 +30,9 @@ if (-not $python) {
     }
 }
 
-# Launch the FastAPI app in the background. Ensure that the Python arguments
-# array is combined correctly before being passed to Start-Process.
-$uvicorn = Start-Process -FilePath $python -ArgumentList ($pythonArgs + @("-m", "uvicorn", "Backend.backend:app", "--port", $backendPort)) -PassThru
+# Launch the FastAPI app in the background within the current terminal window.
+# Ensure that the Python arguments array is combined correctly before being passed to Start-Process.
+$uvicorn = Start-Process -FilePath $python -ArgumentList ($pythonArgs + @("-m", "uvicorn", "Backend.backend:app", "--port", $backendPort)) -NoNewWindow -PassThru
 
 try {
     # Wait for the server to be ready and capture the schema


### PR DESCRIPTION
## Summary
- launch uvicorn in current terminal to prevent extra shell windows when syncing API and migrations

## Testing
- `pwsh -NoLogo -Command "Write-Output 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa460126b883228b27b360afb4b33f