### PR TITLE
fix: update SQLAlchemy to work on Python 3.13

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,7 +1,7 @@
-sqlalchemy==2.0.30
+sqlalchemy>=2.0.37
 psycopg2-binary==2.9.10
 pydantic==2.11.7
 fastapi==0.111.0
 uvicorn[standard]==0.29.0
 alembic==1.13.1
-sqlmodel>=0.0.17
+sqlmodel>=0.0.21


### PR DESCRIPTION
## Summary
- upgrade SQLAlchemy to latest 2.0 release with Python 3.13 support
- bump sqlmodel requirement accordingly

## Testing
- `pip install -r Backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa56f6a9648322851488952dc1035d