### PR TITLE
Auto-apply migrations in sync script

### DIFF
--- a/scripts/sync-api-and-migrations.ps1
+++ b/scripts/sync-api-and-migrations.ps1
@@ -67,6 +67,10 @@ try {
     if (-not $env:DATABASE_URL) {
         $env:DATABASE_URL = "postgresql://nutrition_user:nutrition_pass@localhost:5432/nutrition"
     }
+
+    Write-Host "Applying database migrations..."
+    alembic upgrade head | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "failed to apply database migrations" }
 }
 catch {
     Write-Error "$_"

--- a/scripts/sync-api-and-migrations.sh
+++ b/scripts/sync-api-and-migrations.sh
@@ -66,6 +66,13 @@ done
 # Ensure the backend connects to the local container
 export DATABASE_URL="${DATABASE_URL:-postgresql://nutrition_user:nutrition_pass@localhost:5432/nutrition}"
 
+echo "Applying database migrations..."
+if ! alembic upgrade head >/tmp/db-upgrade.log 2>&1; then
+  cat /tmp/db-upgrade.log
+  echo "Failed to apply database migrations" >&2
+  exit 1
+fi
+
 #############################
 # Check OpenAPI / Frontend
 #############################


### PR DESCRIPTION
## Summary
- Upgrade the database to head before checking for migrations in sync scripts
- Ensure shell and PowerShell versions apply migrations automatically

## Testing
- `pytest` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa66a78c0883228cce95b7221ab423