### PR TITLE
fix: support alembic temp path

### DIFF
--- a/scripts/sync-api-and-migrations.ps1
+++ b/scripts/sync-api-and-migrations.ps1
@@ -119,7 +119,12 @@ if ($apiDiff) {
 # Check database migrations
 #############################
 
-$tmpdir = New-Item -ItemType Directory -Path ([System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName()))
+# Alembic 1.13+ requires that generated revision files live within one of the
+# configured version locations. Creating the temporary directory inside the
+# project's migrations path keeps the check compatible across Alembic versions
+# while ensuring the directory is cleaned up afterwards.
+$migrationRoot = Join-Path $repoRoot "Backend/migrations"
+$tmpdir = New-Item -ItemType Directory -Path (Join-Path $migrationRoot ([System.IO.Path]::GetRandomFileName()))
 alembic revision --autogenerate -m "tmp" --version-path $tmpdir.FullName | Out-Null
 if ($LASTEXITCODE -ne 0) {
     Remove-Item $tmpdir -Recurse -Force

--- a/scripts/sync-api-and-migrations.sh
+++ b/scripts/sync-api-and-migrations.sh
@@ -103,7 +103,10 @@ fi
 # Check database migrations
 #############################
 
-tmpdir="$(mktemp -d)"
+# Alembic 1.13+ only permits revision generation within configured version
+# locations. Use a temporary directory inside the project's migrations folder so
+# the check remains compatible across Alembic versions.
+tmpdir="$(mktemp -d Backend/migrations/tmp.XXXXXX)"
 if ! alembic revision --autogenerate -m "tmp" --version-path "$tmpdir" >/dev/null; then
   rm -r "$tmpdir"
   echo "Failed to check for migration changes" >&2


### PR DESCRIPTION
## Summary
- ensure temporary Alembic revisions are generated inside migrations directory
- keep sync scripts compatible with Alembic 1.13+

## Testing
- `pytest`
- ⚠️ `./scripts/sync-api-and-migrations.sh -y` (requires docker; operation cancelled)

------
https://chatgpt.com/codex/tasks/task_e_68aa6b4f05588322a8a5af753a7efbf3