### PR TITLE
Ensure temp Alembic versions dir is recognized

### DIFF
--- a/scripts/sync-api-and-migrations.ps1
+++ b/scripts/sync-api-and-migrations.ps1
@@ -129,12 +129,13 @@ if ($apiDiff) {
 #############################
 
 # Alembic 1.13+ requires that generated revision files live within one of the
-# configured version locations. Creating the temporary directory inside the
-# project's migrations path keeps the check compatible across Alembic versions
-# while ensuring the directory is cleaned up afterwards.
-$migrationRoot = Join-Path $repoRoot "Backend/migrations"
+# configured version locations. Create the temporary directory inside the
+# project's versions folder and specify both locations via --version-path and
+# --version-paths so the check remains compatible across Alembic versions while
+# ensuring the directory is cleaned up afterwards.
+$migrationRoot = Join-Path $repoRoot "Backend/migrations/versions"
 $tmpdir = New-Item -ItemType Directory -Path (Join-Path $migrationRoot ([System.IO.Path]::GetRandomFileName()))
-alembic revision --autogenerate -m "tmp" --version-path $tmpdir.FullName | Out-Null
+alembic revision --autogenerate -m "tmp" --version-path $tmpdir.FullName --version-paths $migrationRoot | Out-Null
 if ($LASTEXITCODE -ne 0) {
     Remove-Item $tmpdir -Recurse -Force
     Write-Error "Failed to check for migration changes"

--- a/scripts/sync-api-and-migrations.sh
+++ b/scripts/sync-api-and-migrations.sh
@@ -113,10 +113,11 @@ fi
 #############################
 
 # Alembic 1.13+ only permits revision generation within configured version
-# locations. Use a temporary directory inside the project's migrations folder so
-# the check remains compatible across Alembic versions.
-tmpdir="$(mktemp -d Backend/migrations/tmp.XXXXXX)"
-if ! alembic revision --autogenerate -m "tmp" --version-path "$tmpdir" >/dev/null; then
+# locations. Create the temporary directory inside the project's versions
+# directory and add both locations via --version-path and --version-paths so the
+# check remains compatible across Alembic versions.
+tmpdir="$(mktemp -d Backend/migrations/versions/tmp.XXXXXX)"
+if ! alembic revision --autogenerate -m "tmp" --version-path "$tmpdir" --version-paths Backend/migrations/versions:"$tmpdir" >/dev/null; then
   rm -r "$tmpdir"
   echo "Failed to check for migration changes" >&2
   exit 1


### PR DESCRIPTION
## Summary
- create temporary alembic revision directories under `Backend/migrations/versions`
- pass the temporary directory through `--version-path` and `--version-paths`

## Testing
- `bash -n scripts/sync-api-and-migrations.sh`
- `pwsh -NoLogo -NoProfile -Command "[System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw -Path 'scripts/sync-api-and-migrations.ps1'), [ref]\$null) > \$null"`


------
https://chatgpt.com/codex/tasks/task_e_68aa6e05bf748322bac0a9864dcdcac8