### PR TITLE
Ensure DATABASE_URL uses selected DB_PORT

### DIFF
--- a/scripts/sync-api-and-migrations.ps1
+++ b/scripts/sync-api-and-migrations.ps1
@@ -66,6 +66,24 @@ if (-not $env:DB_PORT) { $env:DB_PORT = Get-FreeTcpPort }
 
 if (-not $env:DATABASE_URL) {
     $env:DATABASE_URL = "postgresql://nutrition_user:nutrition_pass@localhost:$($env:DB_PORT)/nutrition"
+} else {
+    try {
+        $builder = [System.UriBuilder]$env:DATABASE_URL
+        if ($builder.Port -ne [int]$env:DB_PORT) {
+            $builder.Port = [int]$env:DB_PORT
+            $newUrl = $builder.Uri.AbsoluteUri.TrimEnd('/')
+            if ($env:DATABASE_URL -ne $newUrl) {
+                $env:DATABASE_URL = $newUrl
+                Write-Host "Updated DATABASE_URL to $newUrl"
+            }
+        }
+    } catch {
+        $newUrl = $env:DATABASE_URL -replace '(:)\d+(?=/)', "`$1$($env:DB_PORT)"
+        if ($env:DATABASE_URL -ne $newUrl) {
+            $env:DATABASE_URL = $newUrl
+            Write-Host "Updated DATABASE_URL to $newUrl"
+        }
+    }
 }
 
 # Start a temporary database container so the script can run outside the compose stack.


### PR DESCRIPTION
## Summary
- Replace port in existing `DATABASE_URL` with selected `DB_PORT` in sync script
- Notify users when `DATABASE_URL` is updated

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package)*
- `pwsh -NoProfile -Command "Get-Help ./scripts/sync-api-and-migrations.ps1" | head -n 20` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa796a601c8322b870e53a0b82a629