### PR TITLE
feat: ensure PowerShell venv script stops on errors

### DIFF
--- a/scripts/activate-venv.ps1
+++ b/scripts/activate-venv.ps1
@@ -7,6 +7,8 @@ param(
     [string]$FrontendPath = (Join-Path (Resolve-Path "$PSScriptRoot/..") "Frontend")
 )
 
+$ErrorActionPreference = 'Stop'
+
 $venvCreated = $false
 if (-Not (Test-Path $VenvPath)) {
     python -m venv $VenvPath


### PR DESCRIPTION
## Summary
- ensure PowerShell venv activation stops on failures for parity with bash script

## Testing
- `shellcheck scripts/activate-venv.sh`
- `pwsh -NoLogo -File scripts/activate-venv.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a2f7bd48322b3605a498034e963