### PR TITLE
Ensure ingredient relations are required

### DIFF
--- a/Backend/migrations/versions/2ea617f76053_restore_ingredient_id_non_null.py
+++ b/Backend/migrations/versions/2ea617f76053_restore_ingredient_id_non_null.py
@@ -1,0 +1,48 @@
+"""restore ingredient_id non-null
+
+Revision ID: 2ea617f76053
+Revises: cc1a9ac14d24
+Create Date: 2025-08-24 19:40:56.219151
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2ea617f76053'
+down_revision = 'cc1a9ac14d24'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Re-apply NOT NULL constraint to ingredient_id columns
+    op.alter_column(
+        "ingredient_units",
+        "ingredient_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+    )
+    op.alter_column(
+        "nutrition",
+        "ingredient_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    # Allow NULL values again if reverting
+    op.alter_column(
+        "nutrition",
+        "ingredient_id",
+        existing_type=sa.INTEGER(),
+        nullable=True,
+    )
+    op.alter_column(
+        "ingredient_units",
+        "ingredient_id",
+        existing_type=sa.INTEGER(),
+        nullable=True,
+    )

--- a/Backend/models/ingredient_unit.py
+++ b/Backend/models/ingredient_unit.py
@@ -11,7 +11,7 @@ class IngredientUnit(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     ingredient_id: Optional[int] = Field(
-        default=None, foreign_key="ingredients.id"
+        default=None, foreign_key="ingredients.id", nullable=False
     )
     name: str = Field(sa_column=Column(String(50), nullable=False))
     grams: float = Field(sa_column=Column(Numeric(10, 4, asdecimal=False), nullable=False))

--- a/Backend/models/nutrition.py
+++ b/Backend/models/nutrition.py
@@ -11,7 +11,7 @@ class Nutrition(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     ingredient_id: Optional[int] = Field(
-        default=None, foreign_key="ingredients.id"
+        default=None, foreign_key="ingredients.id", nullable=False
     )
     calories: float = Field(sa_column=Column(Numeric(10, 4, asdecimal=False), nullable=False))
     fat: float = Field(sa_column=Column(Numeric(10, 4, asdecimal=False), nullable=False))


### PR DESCRIPTION
## Summary
- enforce NOT NULL `ingredient_id` columns for ingredient units and nutrition
- add migration ensuring `ingredient_id` columns remain non-null

## Testing
- `pytest Backend/tests`
- `alembic -x dburl=sqlite:///./app.db upgrade head` *(fails: sqlite3 OperationalError: near "ALTER": syntax error)*
- `./scripts/check-migration-drift.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6a15bf5083229d4cd0dc7dd1fe97