### PR TITLE
ci: add migration drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
         run: |
           source scripts/activate-venv.sh
           pip install pytest
+      - name: Check migration drift
+        run: |
+          source scripts/activate-venv.sh
+          scripts/check-migration-drift.sh
+          git diff --exit-code Backend/migrations/versions
       - name: Install frontend dependencies for API schema
         working-directory: Frontend
         run: npm ci


### PR DESCRIPTION
## Summary
- run migration drift check using provided script

## Testing
- `pytest`
- `CI=true npm test -- --watchAll=false`
- `scripts/check-migration-drift.sh` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6c1efe2c8322bcb21d57cd82d5ab