### PR TITLE
fix: add missing python-multipart dependency

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -2,6 +2,7 @@ sqlalchemy>=2.0.37
 psycopg2-binary==2.9.10
 pydantic==2.11.7
 fastapi==0.111.0
+python-multipart==0.0.20
 uvicorn[standard]==0.29.0
 alembic==1.16.4
 sqlmodel>=0.0.21


### PR DESCRIPTION
## Summary
- add python-multipart to backend requirements so tests can import python_multipart

## Testing
- `cd Backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d33db308322acd125c5ffa9bc20