### PR TITLE
chore: ignore frontend node modules

### DIFF
--- a/Frontend/.gitignore
+++ b/Frontend/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules/
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
## Summary
- remove stray frontend node_modules directory
- explicitly ignore node_modules in frontend .gitignore

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ab784483ac8322a17099648f02eb1b