### PR TITLE
Fix fill form reset action type casing

### DIFF
--- a/Frontend/src/components/data/ingredient/form/IngredientForm.js
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.js
@@ -183,7 +183,7 @@ function IngredientForm({ ingredientToEditData }) {
 
   useEffect(() => {
     if (needsFillForm) {
-      dispatch({ type: "SET_Fill_FORM", payload: false });
+      dispatch({ type: "SET_FILL_FORM", payload: false });
     }
   }, [needsFillForm]); // Reset needsFillForm flag after it's been used
   //#endregion Effects

--- a/Frontend/src/components/data/meal/form/MealForm.js
+++ b/Frontend/src/components/data/meal/form/MealForm.js
@@ -167,7 +167,7 @@ function MealForm({ mealToEditData }) {
 
   useEffect(() => {
     if (needsFillForm) {
-      dispatch({ type: "SET_Fill_FORM", payload: false });
+      dispatch({ type: "SET_FILL_FORM", payload: false });
     }
   }, [needsFillForm]); // Reset needsFillForm flag after it's been used
   //#endregion Effects


### PR DESCRIPTION
## Summary
- fix inconsistent casing for SET_FILL_FORM action in ingredient and meal forms

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7964329c8322b0205dbb52ae1548