### PR TITLE
feat: track active requests in data context

### DIFF
--- a/Frontend/src/components/data/ingredient/form/IngredientForm.js
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.js
@@ -60,7 +60,7 @@ const reducer = (state, action) => {
 
 function IngredientForm({ ingredientToEditData }) {
   //#region State and Dispatch
-  const { setIngredientsNeedsRefetch, setFetching } = useData();
+  const { setIngredientsNeedsRefetch, startRequest, endRequest } = useData();
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const { isOpen, openConfirmationDialog, isEditMode, ingredientToEdit, needsClearForm, needsFillForm } = state;
@@ -105,24 +105,20 @@ function IngredientForm({ ingredientToEditData }) {
       delete toDatabaseIngredient.id;
     }
 
-    if (isEditMode) {
-      const url = `/api/ingredients/${toDatabaseIngredient.id}`;
-      const method = "PUT";
-      const data = /** @type {IngredientRequest} */ (toDatabaseIngredient);
+    const url = isEditMode
+      ? `/api/ingredients/${toDatabaseIngredient.id}`
+      : "/api/ingredients";
+    const method = isEditMode ? "PUT" : "POST";
+    const data = /** @type {IngredientRequest} */ (toDatabaseIngredient);
 
-      handleFetchRequest(url, method, data).then(() => {
+    startRequest();
+    handleFetchRequest(url, method, data)
+      .then(() => {
         setIngredientsNeedsRefetch(true);
-        setFetching(false);
-      });
-    } else {
-      const url = "/api/ingredients";
-      const method = "POST";
-      const data = /** @type {IngredientRequest} */ (toDatabaseIngredient);
+      })
+      .finally(endRequest);
 
-      handleFetchRequest(url, method, data).then(() => {
-        setIngredientsNeedsRefetch(true);
-        setFetching(false);
-      });
+    if (!isEditMode) {
       handleClearForm();
     }
     setIngredientsNeedsRefetch(true);

--- a/Frontend/src/components/data/meal/form/MealForm.js
+++ b/Frontend/src/components/data/meal/form/MealForm.js
@@ -53,7 +53,7 @@ const reducer = (state, action) => {
 
 function MealForm({ mealToEditData }) {
   //#region States
-  const { setMealsNeedsRefetch, setFetching } = useData();
+  const { setMealsNeedsRefetch, startRequest, endRequest } = useData();
   const [state, dispatch] = useReducer(reducer, intitalState);
 
   const { isOpen, openConfirmationDialog, isEditMode, mealToEdit, needsClearForm, needsFillForm } = state;
@@ -74,7 +74,7 @@ function MealForm({ mealToEditData }) {
   }, []);
 
   const handleMealAction = () => {
-    setFetching(true);
+    startRequest();
 
     const toDatabaseMeal = {
       name: mealToEdit.name,
@@ -104,14 +104,12 @@ function MealForm({ mealToEditData }) {
           handleClearForm();
         }
       })
-      .finally(() => {
-        setFetching(false);
-      });
+      .finally(endRequest);
   };
 
   const handleMealDelete = () => {
     if (mealToEdit) {
-      setFetching(true);
+      startRequest();
       fetch(`/api/meals/${mealToEdit.id}`, {
         method: "DELETE",
       })
@@ -128,7 +126,7 @@ function MealForm({ mealToEditData }) {
           console.error("Error:", error);
         })
         .finally(() => {
-          setFetching(false);
+          endRequest();
           handleCloseConfirmationDialog();
         });
     }


### PR DESCRIPTION
## Summary
- track active requests with a counter in `DataContext`
- derive `fetching` from the active request count
- use request counter for fetch helpers and form API calls

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7935da108322a6d49c8e5c301f46