### PR TITLE
refactor: centralize test fixtures

### DIFF
--- a/Backend/tests/conftest.py
+++ b/Backend/tests/conftest.py
@@ -1,6 +1,49 @@
+import os
 import sys
+from typing import Iterator
 
+import pytest
 import python_multipart
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from Backend import models  # noqa: F401  ensure models imported for metadata
+from Backend.backend import app
+from Backend.db import get_db
 
 # Ensure tests load python_multipart instead of the deprecated multipart alias.
 sys.modules["multipart"] = python_multipart
+
+
+@pytest.fixture(name="engine")
+def engine_fixture() -> Iterator:
+    database_url = os.environ.get("DATABASE_URL", "sqlite://")
+
+    engine_kwargs = {}
+    if database_url.startswith("sqlite"):
+        engine_kwargs = {
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        }
+
+    engine = create_engine(database_url, **engine_kwargs)
+    SQLModel.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        SQLModel.metadata.drop_all(engine)
+
+
+@pytest.fixture(name="client")
+def client_fixture(engine) -> Iterator[TestClient]:
+    def override_get_db() -> Iterator[Session]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()

--- a/Backend/tests/test_api.py
+++ b/Backend/tests/test_api.py
@@ -1,43 +1,4 @@
-import os
-import sys
-from typing import Iterator
-
-import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy.pool import StaticPool
-from sqlmodel import Session, SQLModel, create_engine
-
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-
-from Backend import models  # ensure models are imported for SQLModel metadata
-from Backend.backend import app
-from Backend.db import get_db
-
-
-@pytest.fixture(name="client")
-def client_fixture() -> Iterator[TestClient]:
-    database_url = os.environ.get("DATABASE_URL", "sqlite://")
-
-    engine_kwargs = {}
-    if database_url.startswith("sqlite"):
-        engine_kwargs = {
-            "connect_args": {"check_same_thread": False},
-            "poolclass": StaticPool,
-        }
-
-    engine = create_engine(database_url, **engine_kwargs)
-    SQLModel.metadata.create_all(engine)
-
-    def override_get_db() -> Iterator[Session]:
-        with Session(engine) as session:
-            yield session
-
-    app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app) as client:
-        yield client
-
-    SQLModel.metadata.drop_all(engine)
-    app.dependency_overrides.clear()
 
 
 def test_ingredient_crud(client: TestClient) -> None:

--- a/Backend/tests/test_full_payloads.py
+++ b/Backend/tests/test_full_payloads.py
@@ -1,39 +1,8 @@
 import pytest
-from typing import Iterator
 from fastapi.testclient import TestClient
-from sqlalchemy.pool import StaticPool
-from sqlmodel import SQLModel, Session, create_engine
+from sqlmodel import Session
 
-from Backend.backend import app
-from Backend.db import get_db
-from Backend import models  # ensure models imported
 from Backend.models import PossibleIngredientTag, PossibleMealTag
-
-
-@pytest.fixture(name="engine")
-def engine_fixture() -> Iterator:
-    engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    SQLModel.metadata.create_all(engine)
-    try:
-        yield engine
-    finally:
-        SQLModel.metadata.drop_all(engine)
-
-
-@pytest.fixture(name="client")
-def client_fixture(engine) -> Iterator[TestClient]:
-    def override_get_db() -> Iterator[Session]:
-        with Session(engine) as session:
-            yield session
-
-    app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app) as client:
-        yield client
-    app.dependency_overrides.clear()
 
 
 def test_full_ingredient_crud(client: TestClient, engine) -> None:
@@ -89,8 +58,18 @@ def test_full_ingredient_crud(client: TestClient, engine) -> None:
             "fiber": 3.0,
         },
         "units": [
-            {"id": unit_ids[0], "ingredient_id": ingredient_id, "name": "gram", "grams": 1.0},
-            {"id": unit_ids[1], "ingredient_id": ingredient_id, "name": "cup", "grams": 128.0},
+            {
+                "id": unit_ids[0],
+                "ingredient_id": ingredient_id,
+                "name": "gram",
+                "grams": 1.0,
+            },
+            {
+                "id": unit_ids[1],
+                "ingredient_id": ingredient_id,
+                "name": "cup",
+                "grams": 128.0,
+            },
         ],
         "tags": [{"id": spicy_id}],
     }


### PR DESCRIPTION
## Summary
- centralize engine and client fixtures in Backend tests
- simplify test modules to reuse shared fixtures

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ab79047ff08322ae81fecf25222efa