### PR TITLE
Serve 1g ingredient unit via API

### DIFF
--- a/Frontend/src/components/data/ingredient/IngredientTable.js
+++ b/Frontend/src/components/data/ingredient/IngredientTable.js
@@ -1,13 +1,29 @@
 // IngredientTable.js
 
 import React, { useState } from "react";
-import { Box, TextField, TableContainer, Table, TableHead, TableBody, TableRow, TableCell, Paper, MenuItem, Select, TablePagination } from "@mui/material";
+import {
+  Box,
+  TextField,
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+  Paper,
+  MenuItem,
+  Select,
+  TablePagination,
+} from "@mui/material";
 
 import { useData } from "../../../contexts/DataContext";
 import { formatCellNumber } from "../../../utils/utils";
 import TagFilter from "../../common/TagFilter";
 
-function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlClick = () => {} }) {
+function IngredientTable({
+  onIngredientDoubleClick = () => {},
+  onIngredientCtrlClick = () => {},
+}) {
   //#region States
   const {
     ingredients,
@@ -33,7 +49,7 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
       return true; // Show all ingredients if no tags are selected
     }
     return selectedTags.some((selectedTag) =>
-      ingredient.tags.some(({ name }) => name === selectedTag.name)
+      ingredient.tags.some(({ name }) => name === selectedTag.name),
     );
   };
 
@@ -48,16 +64,13 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
   };
 
   const handleUnitChange = (event, ingredientId) => {
-    const selectedUnitId = event.target.value; // Store only the id of the selected unit
+    const selectedUnitId = event.target.value;
     setIngredients((prevIngredients) =>
       prevIngredients.map((ingredient) =>
         ingredient.id === ingredientId
-          ? {
-              ...ingredient,
-              selectedUnitId,
-            }
-          : ingredient
-      )
+          ? { ...ingredient, selectedUnitId }
+          : ingredient,
+      ),
     );
   };
 
@@ -75,9 +88,14 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
   const indexOfLastItem = currentPage * itemsPerPage;
   const indexOfFirstItem = indexOfLastItem - itemsPerPage;
   const filteredIngredients = ingredients
-    .filter((ingredient) => ingredient.name.toLowerCase().includes(search.toLowerCase()))
+    .filter((ingredient) =>
+      ingredient.name.toLowerCase().includes(search.toLowerCase()),
+    )
     .filter(handleTagFilter);
-  const currentIngredients = filteredIngredients.slice(indexOfFirstItem, indexOfLastItem);
+  const currentIngredients = filteredIngredients.slice(
+    indexOfFirstItem,
+    indexOfLastItem,
+  );
 
   const allIngredientTags = [
     ...ingredientProcessingTags.map((tag) => ({ ...tag, group: "Processing" })),
@@ -119,34 +137,78 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
             </TableRow>
           </TableHead>
           <TableBody>
-            {currentIngredients.map((ingredient) => (
-              <TableRow
-                key={ingredient.id}
-                onDoubleClick={() => handleIngredientDoubleClick(ingredient)}
-                onClick={(event) => handleIngredientClick(event, ingredient)}>
-                <TableCell>{ingredient.name}</TableCell>
-                <TableCell>
-                  <Select
-                    value={ingredient.selectedUnitId}
-                    size="small"
-                    onChange={(event) => handleUnitChange(event, ingredient.id)}
-                    style={{ minWidth: "120px", display: "inline-block" }}>
-                    {ingredient.units.map((unit) => (
-                      <MenuItem
-                        key={unit.id}
-                        value={unit.id}>
-                        {unit.name}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </TableCell>
-                <TableCell>{formatCellNumber(ingredient.nutrition.calories * (ingredient.units.find((unit) => unit.id === ingredient.selectedUnitId)?.grams || 1))}</TableCell>
-                <TableCell>{formatCellNumber(ingredient.nutrition.protein * (ingredient.units.find((unit) => unit.id === ingredient.selectedUnitId)?.grams || 1))}</TableCell>
-                <TableCell>{formatCellNumber(ingredient.nutrition.carbohydrates * (ingredient.units.find((unit) => unit.id === ingredient.selectedUnitId)?.grams || 1))}</TableCell>
-                <TableCell>{formatCellNumber(ingredient.nutrition.fat * (ingredient.units.find((unit) => unit.id === ingredient.selectedUnitId)?.grams || 1))}</TableCell>
-                <TableCell>{formatCellNumber(ingredient.nutrition.fiber * (ingredient.units.find((unit) => unit.id === ingredient.selectedUnitId)?.grams || 1))}</TableCell>
-              </TableRow>
-            ))}
+            {currentIngredients.map((ingredient) => {
+              const defaultUnitId =
+                ingredient.units.find((unit) => unit.grams === 1)?.id ??
+                ingredient.units[0]?.id;
+              const selectedUnitId = ingredient.selectedUnitId ?? defaultUnitId;
+
+              return (
+                <TableRow
+                  key={ingredient.id}
+                  onDoubleClick={() => handleIngredientDoubleClick(ingredient)}
+                  onClick={(event) => handleIngredientClick(event, ingredient)}
+                >
+                  <TableCell>{ingredient.name}</TableCell>
+                  <TableCell>
+                    <Select
+                      value={selectedUnitId}
+                      size="small"
+                      onChange={(event) =>
+                        handleUnitChange(event, ingredient.id)
+                      }
+                      style={{ minWidth: "120px", display: "inline-block" }}
+                    >
+                      {ingredient.units.map((unit) => (
+                        <MenuItem key={unit.id} value={unit.id}>
+                          {unit.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      ingredient.nutrition.calories *
+                        (ingredient.units.find(
+                          (unit) => unit.id === selectedUnitId,
+                        )?.grams || 1),
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      ingredient.nutrition.protein *
+                        (ingredient.units.find(
+                          (unit) => unit.id === selectedUnitId,
+                        )?.grams || 1),
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      ingredient.nutrition.carbohydrates *
+                        (ingredient.units.find(
+                          (unit) => unit.id === selectedUnitId,
+                        )?.grams || 1),
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      ingredient.nutrition.fat *
+                        (ingredient.units.find(
+                          (unit) => unit.id === selectedUnitId,
+                        )?.grams || 1),
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      ingredient.nutrition.fiber *
+                        (ingredient.units.find(
+                          (unit) => unit.id === selectedUnitId,
+                        )?.grams || 1),
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       </TableContainer>

--- a/Frontend/src/components/data/ingredient/form/IngredientForm.js
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.js
@@ -1,7 +1,16 @@
 // @ts-check
 import React, { useEffect, useCallback, useReducer } from "react";
 import { v4 as uuidv4 } from "uuid";
-import { Button, Collapse, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Box } from "@mui/material";
+import {
+  Button,
+  Collapse,
+  Paper,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+} from "@mui/material";
 
 import { useData } from "../../../../contexts/DataContext";
 
@@ -63,7 +72,14 @@ function IngredientForm({ ingredientToEditData }) {
   const { setIngredientsNeedsRefetch, setFetching } = useData();
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  const { isOpen, openConfirmationDialog, isEditMode, ingredientToEdit, needsClearForm, needsFillForm } = state;
+  const {
+    isOpen,
+    openConfirmationDialog,
+    isEditMode,
+    ingredientToEdit,
+    needsClearForm,
+    needsFillForm,
+  } = state;
 
   const initializeEmptyIngredient = () => ({
     name: "",
@@ -96,7 +112,7 @@ function IngredientForm({ ingredientToEditData }) {
       units: ingredientToEdit.units
         .filter((unit) => unit.name !== "1g") // Remove the 1g unit from ingredientToEdit
         .map(({ id, ...unit }) =>
-          typeof id === "number" ? { id, ...unit } : unit
+          typeof id === "number" ? { id, ...unit } : unit,
         ),
     };
 
@@ -158,11 +174,20 @@ function IngredientForm({ ingredientToEditData }) {
   //#region Effects
   useEffect(() => {
     if (!ingredientToEditData) {
-      dispatch({ type: "SET_INGREDIENT", payload: initializeEmptyIngredient() });
+      dispatch({
+        type: "SET_INGREDIENT",
+        payload: initializeEmptyIngredient(),
+      });
       dispatch({ type: "SET_EDIT_MODE", payload: false });
       dispatch({ type: "OPEN_FORM", payload: false });
     } else {
-      dispatch({ type: "SET_INGREDIENT", payload: { ...ingredientToEditData } });
+      const defaultUnitId =
+        ingredientToEditData.units.find((unit) => unit.grams === 1)?.id ??
+        ingredientToEditData.units[0]?.id;
+      dispatch({
+        type: "SET_INGREDIENT",
+        payload: { ...ingredientToEditData, selectedUnitId: defaultUnitId },
+      });
       dispatch({ type: "SET_EDIT_MODE", payload: true });
       dispatch({ type: "OPEN_FORM", payload: true });
       dispatch({ type: "SET_FILL_FORM", payload: true });
@@ -192,7 +217,11 @@ function IngredientForm({ ingredientToEditData }) {
     <div>
       <Paper>
         <Box sx={{ display: "flex", justifyContent: "center" }}>
-          <Button onClick={() => dispatch({ type: "OPEN_FORM", payload: !isOpen })}>{isOpen ? "Close" : "Add Ingredient"}</Button>
+          <Button
+            onClick={() => dispatch({ type: "OPEN_FORM", payload: !isOpen })}
+          >
+            {isOpen ? "Close" : "Add Ingredient"}
+          </Button>
         </Box>
         <Collapse in={isOpen}>
           <>
@@ -219,15 +248,26 @@ function IngredientForm({ ingredientToEditData }) {
             />
 
             <Button onClick={handleClearForm}>Clear</Button>
-            <Button onClick={handleIngredientAction}>{isEditMode ? "Update" : "Add"}</Button>
-            {isEditMode && <Button onClick={() => dispatch({ type: "SET_CONFIRMATION_DIALOG", payload: true })}>Delete</Button>}
+            <Button onClick={handleIngredientAction}>
+              {isEditMode ? "Update" : "Add"}
+            </Button>
+            {isEditMode && (
+              <Button
+                onClick={() =>
+                  dispatch({ type: "SET_CONFIRMATION_DIALOG", payload: true })
+                }
+              >
+                Delete
+              </Button>
+            )}
           </>
         </Collapse>
       </Paper>
 
       <Dialog
         open={openConfirmationDialog}
-        onClose={handleCloseConfirmationDialog}>
+        onClose={handleCloseConfirmationDialog}
+      >
         <DialogTitle>Delete Ingredient</DialogTitle>
         <DialogContent>
           <div>Are you sure you want to delete this ingredient?</div>

--- a/Frontend/src/components/data/ingredient/form/UnitEdit.js
+++ b/Frontend/src/components/data/ingredient/form/UnitEdit.js
@@ -1,6 +1,15 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { v4 as uuidv4 } from "uuid";
-import { Button, Select, MenuItem, TextField, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
+import {
+  Button,
+  Select,
+  MenuItem,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+} from "@mui/material";
 
 function AddUnitDialog({ open, onClose, onAddUnit }) {
   const [unitName, setUnitName] = useState("");
@@ -13,8 +22,14 @@ function AddUnitDialog({ open, onClose, onAddUnit }) {
       return;
     }
     const gramsFloat = parseFloat(unitGrams);
-    if (isNaN(gramsFloat) || gramsFloat <= 0 || !/^(\d*\.?\d{0,4})$/.test(unitGrams)) {
-      setValidationError("Please enter a valid grams value up to 4 decimal places");
+    if (
+      isNaN(gramsFloat) ||
+      gramsFloat <= 0 ||
+      !/^(\d*\.?\d{0,4})$/.test(unitGrams)
+    ) {
+      setValidationError(
+        "Please enter a valid grams value up to 4 decimal places",
+      );
       return;
     }
     onAddUnit(unitName, gramsFloat.toFixed(4));
@@ -24,9 +39,7 @@ function AddUnitDialog({ open, onClose, onAddUnit }) {
   };
 
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}>
+    <Dialog open={open} onClose={onClose}>
       <DialogTitle>Add Unit</DialogTitle>
       <DialogContent>
         <TextField
@@ -34,8 +47,14 @@ function AddUnitDialog({ open, onClose, onAddUnit }) {
           variant="outlined"
           value={unitName}
           onChange={(e) => setUnitName(e.target.value)}
-          error={Boolean(validationError && validationError.includes("Unit name"))}
-          helperText={validationError && validationError.includes("Unit name") ? validationError : ""}
+          error={Boolean(
+            validationError && validationError.includes("Unit name"),
+          )}
+          helperText={
+            validationError && validationError.includes("Unit name")
+              ? validationError
+              : ""
+          }
         />
         <TextField
           label="Unit grams"
@@ -43,15 +62,16 @@ function AddUnitDialog({ open, onClose, onAddUnit }) {
           value={unitGrams}
           onChange={(e) => setUnitGrams(e.target.value)}
           error={Boolean(validationError && validationError.includes("grams"))}
-          helperText={validationError && validationError.includes("grams") ? validationError : "Enter a number up to 4 decimal places"}
+          helperText={
+            validationError && validationError.includes("grams")
+              ? validationError
+              : "Enter a number up to 4 decimal places"
+          }
         />
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleAddUnit}>
+        <Button variant="contained" color="primary" onClick={handleAddUnit}>
           Add
         </Button>
       </DialogActions>
@@ -64,9 +84,12 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }) {
 
   const handleSelectedUnitChange = useCallback(
     (event) => {
-      dispatch({ type: "SET_INGREDIENT", payload: { ...ingredient, selectedUnitId: event.target.value } });
+      dispatch({
+        type: "SET_INGREDIENT",
+        payload: { ...ingredient, selectedUnitId: event.target.value },
+      });
     },
-    [ingredient, dispatch]
+    [ingredient, dispatch],
   );
 
   const handleAddUnit = useCallback(
@@ -78,31 +101,46 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }) {
         name: name.trim(),
         grams: grams,
       };
-      dispatch({ type: "SET_INGREDIENT", payload: { ...ingredient, units: [...ingredient.units, newUnit], selectedUnitId: tempId } });
+      dispatch({
+        type: "SET_INGREDIENT",
+        payload: {
+          ...ingredient,
+          units: [...ingredient.units, newUnit],
+          selectedUnitId: tempId,
+        },
+      });
     },
-    [dispatch, ingredient]
+    [dispatch, ingredient],
   );
 
   useEffect(() => {
     if (needsClearForm) {
-      dispatch({ type: "SET_INGREDIENT", payload: { ...ingredient, units: [], selectedUnitId: 0 } });
+      dispatch({
+        type: "SET_INGREDIENT",
+        payload: { ...ingredient, units: [], selectedUnitId: undefined },
+      });
     }
   }, [needsClearForm, dispatch, ingredient]);
 
   return (
-    <div style={{ display: "flex", flexDirection: "row", alignItems: "center" }}>
+    <div
+      style={{ display: "flex", flexDirection: "row", alignItems: "center" }}
+    >
       <div>
         <Select
           style={{ textAlign: "center" }}
           labelId="unit-select-label"
           id="unit-select"
-          value={ingredient.selectedUnitId || 0}
-          onChange={handleSelectedUnitChange}>
+          value={
+            ingredient.selectedUnitId ??
+            ingredient.units.find((unit) => unit.grams === 1)?.id ??
+            ""
+          }
+          onChange={handleSelectedUnitChange}
+        >
           {ingredient.units &&
             ingredient.units.map((unit) => (
-              <MenuItem
-                key={unit.id}
-                value={unit.id}>
+              <MenuItem key={unit.id} value={unit.id}>
                 {unit.name}
               </MenuItem>
             ))}

--- a/Frontend/src/components/data/meal/form/MealIngredientsForm.js
+++ b/Frontend/src/components/data/meal/form/MealIngredientsForm.js
@@ -1,5 +1,18 @@
 import React, { useEffect, useState, useCallback } from "react";
-import { Button, TextField, Select, MenuItem, Dialog, TableContainer, Table, TableHead, TableRow, TableCell, Paper, TableBody } from "@mui/material";
+import {
+  Button,
+  TextField,
+  Select,
+  MenuItem,
+  Dialog,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  Paper,
+  TableBody,
+} from "@mui/material";
 
 import { useData } from "../../../../contexts/DataContext";
 import IngredientTable from "../../ingredient/IngredientTable";
@@ -30,7 +43,13 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
   };
 
   const handleAddIngredient = (ingredient) => {
-    dispatch({ type: "SET_MEAL", payload: { ...meal, ingredients: [...meal.ingredients, buildMealIngredient(ingredient)] } });
+    dispatch({
+      type: "SET_MEAL",
+      payload: {
+        ...meal,
+        ingredients: [...meal.ingredients, buildMealIngredient(ingredient)],
+      },
+    });
     handleCloseIngredientsDialog();
   };
 
@@ -38,13 +57,19 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
     return {
       ingredient_id: ingredient.id,
       meal_id: meal.id,
-      unit_id: ingredient.selectedUnitId ? ingredient.selectedUnitId : null,
+      unit_id:
+        ingredient.selectedUnitId ??
+        ingredient.units.find((u) => u.grams === 1)?.id ??
+        null,
       unit_quantity: 1,
     };
   };
 
   const handleUnitQuantityChange = (event, index) => {
-    const newUnitQuantities = { ...unitQuantities, [index]: event.target.value };
+    const newUnitQuantities = {
+      ...unitQuantities,
+      [index]: event.target.value,
+    };
     setUnitQuantities(newUnitQuantities);
     handleUpdateIngredientUnitQuantity(index, event.target.value);
   };
@@ -65,7 +90,10 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
     };
     if (!isNaN(updatedIngredients[index].unit_quantity)) {
       // Don't update if the field is empty
-      dispatch({ type: "SET_MEAL", payload: { ...meal, ingredients: updatedIngredients } });
+      dispatch({
+        type: "SET_MEAL",
+        payload: { ...meal, ingredients: updatedIngredients },
+      });
     }
   };
 
@@ -73,20 +101,45 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
     (meal_ingredient) => {
       if (!meal_ingredient) return;
 
-      const dataIngredient = ingredients.find((item) => item.id === meal_ingredient.ingredient_id);
+      const dataIngredient = ingredients.find(
+        (item) => item.id === meal_ingredient.ingredient_id,
+      );
 
-      const unitId = meal_ingredient.unit_id ?? 0; // If meal_ingredient.unit_id is undefined or null, use 0
-      const dataUnit = dataIngredient.units.find((unit) => unit.id === unitId) || dataIngredient.units[0]; // Fallback to the first unit if not found
+      const unitId = meal_ingredient.unit_id;
+      const dataUnit =
+        dataIngredient.units.find((unit) => unit.id === unitId) ||
+        dataIngredient.units.find((unit) => unit.grams === 1) ||
+        dataIngredient.units[0];
 
       return {
-        calories: dataIngredient.nutrition.calories ? dataIngredient.nutrition.calories * dataUnit.grams * meal_ingredient.unit_quantity : 0,
-        protein: dataIngredient.nutrition.protein ? dataIngredient.nutrition.protein * dataUnit.grams * meal_ingredient.unit_quantity : 0,
-        fat: dataIngredient.nutrition.fat ? dataIngredient.nutrition.fat * dataUnit.grams * meal_ingredient.unit_quantity : 0,
-        carbs: dataIngredient.nutrition.carbohydrates ? dataIngredient.nutrition.carbohydrates * dataUnit.grams * meal_ingredient.unit_quantity : 0,
-        fiber: dataIngredient.nutrition.fiber ? dataIngredient.nutrition.fiber * dataUnit.grams * meal_ingredient.unit_quantity : 0,
+        calories: dataIngredient.nutrition.calories
+          ? dataIngredient.nutrition.calories *
+            dataUnit.grams *
+            meal_ingredient.unit_quantity
+          : 0,
+        protein: dataIngredient.nutrition.protein
+          ? dataIngredient.nutrition.protein *
+            dataUnit.grams *
+            meal_ingredient.unit_quantity
+          : 0,
+        fat: dataIngredient.nutrition.fat
+          ? dataIngredient.nutrition.fat *
+            dataUnit.grams *
+            meal_ingredient.unit_quantity
+          : 0,
+        carbs: dataIngredient.nutrition.carbohydrates
+          ? dataIngredient.nutrition.carbohydrates *
+            dataUnit.grams *
+            meal_ingredient.unit_quantity
+          : 0,
+        fiber: dataIngredient.nutrition.fiber
+          ? dataIngredient.nutrition.fiber *
+            dataUnit.grams *
+            meal_ingredient.unit_quantity
+          : 0,
       };
     },
-    [ingredients]
+    [ingredients],
   );
 
   const handleUnitChange = (event, ingredientIndex) => {
@@ -96,7 +149,10 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
       ...updatedIngredients[ingredientIndex],
       unit_id: newUnitId,
     };
-    dispatch({ type: "SET_MEAL", payload: { ...meal, ingredients: updatedIngredients } });
+    dispatch({
+      type: "SET_MEAL",
+      payload: { ...meal, ingredients: updatedIngredients },
+    });
   };
   //#endregion Handles
 
@@ -108,10 +164,13 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
   }, [needsClearForm, dispatch, meal]); // Clear ingredients when needsClearForm is true
 
   useEffect(() => {
-    const initialUnitQuantities = meal.ingredients.reduce((acc, ingredient, index) => {
-      acc[index] = ingredient.unit_quantity.toString();
-      return acc;
-    }, {});
+    const initialUnitQuantities = meal.ingredients.reduce(
+      (acc, ingredient, index) => {
+        acc[index] = ingredient.unit_quantity.toString();
+        return acc;
+      },
+      {},
+    );
     setUnitQuantities(initialUnitQuantities);
   }, [meal]); // Initialize or reset the unit quantities when meal changes, ensuring inputs are up-to-date
 
@@ -126,7 +185,7 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
         acc.fiber += macros.fiber;
         return acc;
       },
-      { calories: 0, protein: 0, fat: 0, carbs: 0, fiber: 0 }
+      { calories: 0, protein: 0, fat: 0, carbs: 0, fiber: 0 },
     );
 
     setTotalMacros(totals);
@@ -162,22 +221,30 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
 
           <TableBody>
             {meal.ingredients.map((ingredient, index) => {
-              const dataIngredient = ingredients.find((item) => item.id === ingredient.ingredient_id);
+              const dataIngredient = ingredients.find(
+                (item) => item.id === ingredient.ingredient_id,
+              );
+              const defaultUnitId =
+                dataIngredient.units.find((unit) => unit.grams === 1)?.id ??
+                dataIngredient.units[0]?.id;
 
               return (
                 <TableRow key={index}>
-                  <TableCell>{dataIngredient ? dataIngredient.name : "Unknown Ingredient"}</TableCell>
+                  <TableCell>
+                    {dataIngredient
+                      ? dataIngredient.name
+                      : "Unknown Ingredient"}
+                  </TableCell>
                   <TableCell>
                     <div>
                       <Select
                         style={{ textAlign: "center" }}
-                        value={ingredient.unit_id || 0}
+                        value={ingredient.unit_id ?? defaultUnitId}
                         onChange={(event) => handleUnitChange(event, index)}
-                        inputProps={{ "aria-label": "Without label" }}>
+                        inputProps={{ "aria-label": "Without label" }}
+                      >
                         {dataIngredient.units.map((unit) => (
-                          <MenuItem
-                            key={unit.id}
-                            value={unit.id}>
+                          <MenuItem key={unit.id} value={unit.id}>
                             {unit.name}
                           </MenuItem>
                         ))}
@@ -188,7 +255,9 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
                     <TextField
                       type="number"
                       value={unitQuantities[index] || ""}
-                      onChange={(event) => handleUnitQuantityChange(event, index)}
+                      onChange={(event) =>
+                        handleUnitQuantityChange(event, index)
+                      }
                       onBlur={() => handleUnitQuantityBlur(index)}
                       onKeyDown={(event) => {
                         if (event.key === "Enter") event.target.blur();
@@ -196,20 +265,38 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
                       InputProps={{ inputProps: { min: 0 } }}
                     />
                   </TableCell>
-                  <TableCell>{formatCellNumber(calculateTotalIngredientMacros(ingredient).calories)}</TableCell>
-                  <TableCell>{formatCellNumber(calculateTotalIngredientMacros(ingredient).protein)}</TableCell>
-                  <TableCell>{formatCellNumber(calculateTotalIngredientMacros(ingredient).fat)}</TableCell>
-                  <TableCell>{formatCellNumber(calculateTotalIngredientMacros(ingredient).carbs)}</TableCell>
-                  <TableCell>{formatCellNumber(calculateTotalIngredientMacros(ingredient).fiber)}</TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      calculateTotalIngredientMacros(ingredient).calories,
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      calculateTotalIngredientMacros(ingredient).protein,
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      calculateTotalIngredientMacros(ingredient).fat,
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      calculateTotalIngredientMacros(ingredient).carbs,
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCellNumber(
+                      calculateTotalIngredientMacros(ingredient).fiber,
+                    )}
+                  </TableCell>
                 </TableRow>
               );
             })}
           </TableBody>
         </Table>
       </TableContainer>
-      <Button
-        variant="contained"
-        onClick={handleOpenIngredientsDialog}>
+      <Button variant="contained" onClick={handleOpenIngredientsDialog}>
         Add Ingredients
       </Button>
 
@@ -218,7 +305,8 @@ function MealIngredientsForm({ meal, dispatch, needsClearForm }) {
         onClose={handleCloseIngredientsDialog}
         maxWidth="lg"
         scroll="body"
-        fullWidth>
+        fullWidth
+      >
         <IngredientTable onIngredientDoubleClick={handleAddIngredient} />
       </Dialog>
     </div>

--- a/Frontend/src/contexts/DataContext.js
+++ b/Frontend/src/contexts/DataContext.js
@@ -21,20 +21,34 @@ export const DataProvider = ({ children }) => {
 
   const [fetching, setFetching] = useState(false);
 
-  const ingredientProcessingTagNames = ["Whole Food", "Lightly Processed", "Highly Processed"];
-  const ingredientGroupTagNames = ["Vegetable", "Fruit", "Meat", "Dairy", "Grain"];
+  const ingredientProcessingTagNames = [
+    "Whole Food",
+    "Lightly Processed",
+    "Highly Processed",
+  ];
+  const ingredientGroupTagNames = [
+    "Vegetable",
+    "Fruit",
+    "Meat",
+    "Dairy",
+    "Grain",
+  ];
 
   const ingredientProcessingTags = possibleIngredientTags
-    ? possibleIngredientTags.filter(({ name }) => ingredientProcessingTagNames.includes(name))
+    ? possibleIngredientTags.filter(({ name }) =>
+        ingredientProcessingTagNames.includes(name),
+      )
     : [];
   const ingredientGroupTags = possibleIngredientTags
-    ? possibleIngredientTags.filter(({ name }) => ingredientGroupTagNames.includes(name))
+    ? possibleIngredientTags.filter(({ name }) =>
+        ingredientGroupTagNames.includes(name),
+      )
     : [];
   const ingredientOtherTags = possibleIngredientTags
     ? possibleIngredientTags.filter(
         ({ name }) =>
           !ingredientProcessingTagNames.includes(name) &&
-          !ingredientGroupTagNames.includes(name)
+          !ingredientGroupTagNames.includes(name),
       )
     : [];
 
@@ -50,8 +64,7 @@ export const DataProvider = ({ children }) => {
   const mealOtherTags = possibleMealTags
     ? possibleMealTags.filter(
         ({ name }) =>
-          !mealDietTagNames.includes(name) &&
-          !mealTypeTagNames.includes(name)
+          !mealDietTagNames.includes(name) && !mealTypeTagNames.includes(name),
       )
     : [];
 
@@ -73,43 +86,21 @@ export const DataProvider = ({ children }) => {
         setLoading(false);
       }
     },
-    []
+    [],
   );
 
   const fetchIngredients = useCallback(() => {
     const url = "/api/ingredients";
 
-    const add1gUnit = (data) => {
-      return data.map((ingredient) => {
-        const ingredientsWithFloatGrams = ingredient.units.map((unit) => ({
-          ...unit,
-          grams: parseFloat(unit.grams),
-        }));
-        // Add a default 1g unit to the ingredient
-        return {
-          ...ingredient,
-          units: [...ingredientsWithFloatGrams, { id: 0, ingredient_id: ingredient.id, name: "1g", grams: 1 }],
-          selectedUnitId: 0,
-        };
-      });
-    };
-
-    fetchData(
-      url,
-      setIngredients,
-      setFetching,
-      () => setIngredientsNeedsRefetch(true),
-      add1gUnit
+    fetchData(url, setIngredients, setFetching, () =>
+      setIngredientsNeedsRefetch(true),
     );
   }, [fetchData]);
 
   const fetchPossibleIngredientTags = useCallback(() => {
     const url = "/api/ingredients/possible_tags";
-    fetchData(
-      url,
-      setPossibleIngredientTags,
-      setFetching,
-      () => console.error("Error fetching tags")
+    fetchData(url, setPossibleIngredientTags, setFetching, () =>
+      console.error("Error fetching tags"),
     );
   }, [fetchData]);
 
@@ -133,17 +124,14 @@ export const DataProvider = ({ children }) => {
       setMeals,
       setFetching,
       () => setMealsNeedsRefetch(true),
-      processData
+      processData,
     );
   }, [fetchData]);
 
   const fetchPossibleMealTags = useCallback(() => {
     const url = "/api/meals/possible_tags";
-    fetchData(
-      url,
-      setPossibleMealTags,
-      setFetching,
-      () => console.error("Error fetching tags")
+    fetchData(url, setPossibleMealTags, setFetching, () =>
+      console.error("Error fetching tags"),
     );
   }, [fetchData]);
 


### PR DESCRIPTION
## Summary
- Always append a 1 g unit when returning ingredients from the backend
- Drop frontend workaround that injected a 1 g unit client-side
- Use API units throughout ingredient and meal components

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test --runTestsByPath src/tests/App.test.js src/tests/MealTable.test.js --json`


------
https://chatgpt.com/codex/tasks/task_e_68ab786b18e08322b03591fd3b242aaa