### PR TITLE
feat: add compose restart script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,14 @@ Options:
 * `-PruneImages` → also remove built images
 * Volumes are removed by default for clean isolation
 
+**Restart services:**
+
+```pwsh
+pwsh ./scripts/compose-restart-branch.ps1 -test      # or -production / -empty
+```
+
+Stops and then starts the current branch's containers with the chosen seed mode.
+
 ---
 
 ## ⚙️ Port Mapping

--- a/scripts/compose-restart-branch.ps1
+++ b/scripts/compose-restart-branch.ps1
@@ -1,0 +1,23 @@
+# scripts/compose-restart-branch.ps1
+[CmdletBinding()]
+param(
+  [switch]$production,
+  [switch]$test,
+  [switch]$empty,
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$Services
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Set-Location $repoRoot
+
+$branch    = (git rev-parse --abbrev-ref HEAD).Trim()
+$sanitized = ($branch.ToLower() -replace '[^a-z0-9]', '-').Trim('-')
+$project   = "nutrition-$sanitized"
+
+Write-Host "Bringing down containers for '$branch'..."
+docker compose -p $project down -v --remove-orphans | Out-Null
+docker network rm "${project}_default" 2>$null | Out-Null
+
+Write-Host "Bringing up containers..."
+& "$PSScriptRoot/compose-up-branch.ps1" @PSBoundParameters

--- a/scripts/compose-restart-branch.sh
+++ b/scripts/compose-restart-branch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# scripts/compose-restart-branch.sh
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+branch="$(git rev-parse --abbrev-ref HEAD | tr -d '\n')"
+san="$(echo "$branch" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^[-]*//;s/[-]*$//')"
+project="nutrition-$san"
+
+echo "Bringing down containers for '$branch'..."
+docker compose -p "$project" down -v --remove-orphans >/dev/null 2>&1 || true
+docker network rm "${project}_default" >/dev/null 2>&1 || true
+
+echo "Bringing up containers..."
+"$repo_root/scripts/compose-up-branch.sh" "$@"


### PR DESCRIPTION
## Summary
- add scripts to bring down then restart branch containers
- document compose restart workflow

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ab98b2022883229cfd3a6f2e1f1873