### PR TITLE
fix: show compose-down options correctly

### DIFF
--- a/scripts/compose-down-branch.ps1
+++ b/scripts/compose-down-branch.ps1
@@ -61,7 +61,7 @@ function Select-Projects {
   }
   Write-Host "Select project(s) to delete:" -ForegroundColor Cyan
   for ($i = 0; $i -lt $Projects.Count; $i++) {
-    "{0,2}) {1}" -f ($i+1), $Projects[$i]
+    Write-Host ("{0,2}) {1}" -f ($i+1), $Projects[$i])
   }
 
   $inputIdx = Read-Host "Enter space-separated numbers or 'all'"


### PR DESCRIPTION
## Summary
- ensure compose-down-branch.ps1 prints option list and no longer duplicates selections

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ab990042c88322aa1b9446fc493ae7