### PR TITLE
Use branch-specific node_modules volume

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Options:
 
 * `-Force` → skip confirmation
 * `-PruneImages` → also remove built images
-* Volumes are removed by default for clean isolation
+* Volumes (including branch-specific `node_modules` cache) are removed by default for clean isolation
 
 **Restart services:**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - backend
     volumes:
       - ./Frontend:/app
-      - /app/node_modules
+      - node_modules:/app/node_modules
     environment:
       CHOKIDAR_USEPOLLING: "true"
     ports:
@@ -57,6 +57,8 @@ services:
 
 volumes:
   dbdata:
+  node_modules:
+    name: "${COMPOSE_PROJECT_NAME:-nutrition}_node_modules"
 
 
 networks:

--- a/scripts/compose-down-branch.ps1
+++ b/scripts/compose-down-branch.ps1
@@ -113,6 +113,7 @@ foreach ($proj in $chosen) {
   # Best-effort cleanup for the default network (it’s usually removed by `down` already)
   $defaultNet = "${proj}_default"
   docker network rm $defaultNet 2>$null | Out-Null
+  docker volume rm "${proj}_node_modules" 2>$null | Out-Null
 }
 
 Write-Host "Done." -ForegroundColor Green

--- a/scripts/compose-down-branch.sh
+++ b/scripts/compose-down-branch.sh
@@ -116,6 +116,7 @@ for proj in "${chosen[@]}"; do
   docker "${args[@]}"
   defaultNet="${proj}_default"
   docker network rm "$defaultNet" >/dev/null 2>&1 || true
-fi
+  docker volume rm "${proj}_node_modules" >/dev/null 2>&1 || true
+  done
 
 echo "Done."

--- a/scripts/compose-restart-branch.ps1
+++ b/scripts/compose-restart-branch.ps1
@@ -18,6 +18,7 @@ $project   = "nutrition-$sanitized"
 Write-Host "Bringing down containers for '$branch'..."
 docker compose -p $project down -v --remove-orphans | Out-Null
 docker network rm "${project}_default" 2>$null | Out-Null
+docker volume rm "${project}_node_modules" 2>$null | Out-Null
 
 Write-Host "Bringing up containers..."
 & "$PSScriptRoot/compose-up-branch.ps1" @PSBoundParameters

--- a/scripts/compose-restart-branch.sh
+++ b/scripts/compose-restart-branch.sh
@@ -12,6 +12,7 @@ project="nutrition-$san"
 echo "Bringing down containers for '$branch'..."
 docker compose -p "$project" down -v --remove-orphans >/dev/null 2>&1 || true
 docker network rm "${project}_default" >/dev/null 2>&1 || true
+docker volume rm "${project}_node_modules" >/dev/null 2>&1 || true
 
 echo "Bringing up containers..."
 "$repo_root/scripts/compose-up-branch.sh" "$@"


### PR DESCRIPTION
## Summary
- use a named `node_modules` volume tied to each branch
- drop the per-branch volume in compose-down/restart scripts
- clarify in contributing docs that branch volumes are wiped automatically

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9978e7fc8322814ff4b40c6b3bd1