### PR TITLE
fix: rely on migrations for initial schema

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       dockerfile: Backend/Dockerfile
     environment:
       DATABASE_URL: postgresql://nutrition_user:nutrition_pass@db:5432/nutrition
-      DB_AUTO_CREATE: "true"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- remove DB_AUTO_CREATE env to prevent backend auto-creating tables

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ab9e77075c8322b598ea39e8161031