### PR TITLE
Ensure compose-up scripts set DATABASE_URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ Ensures:
 
 * Correct **per-branch project name**
 * Correct **branch-specific ports**
+* Sets `DATABASE_URL` for local utilities to match the branch's DB port
 * Optional CSV import (based on mode)
 
 **Stop services:**

--- a/scripts/compose-up-branch.ps1
+++ b/scripts/compose-up-branch.ps1
@@ -43,6 +43,7 @@ $offset              = [math]::Abs($branch.GetHashCode()) % 100
 $env:DB_PORT        = 5432 + $offset
 $env:BACKEND_PORT   = 8000 + $offset
 $env:FRONTEND_PORT  = 3000 + $offset
+$env:DATABASE_URL   = "postgresql://nutrition_user:nutrition_pass@localhost:$env:DB_PORT/nutrition"
 
 Write-Host "Starting '$branch' with ports:`n  DB: $env:DB_PORT`n  Backend: $env:BACKEND_PORT`n  Frontend: $env:FRONTEND_PORT"
 

--- a/scripts/compose-up-branch.sh
+++ b/scripts/compose-up-branch.sh
@@ -50,6 +50,7 @@ offset=$((0x$offset_hex % 100))
 export DB_PORT=$((5432 + offset))
 export BACKEND_PORT=$((8000 + offset))
 export FRONTEND_PORT=$((3000 + offset))
+export DATABASE_URL="postgresql://nutrition_user:nutrition_pass@localhost:$DB_PORT/nutrition"
 
 echo "Starting '$branch' with ports:"
 echo "  DB: $DB_PORT"


### PR DESCRIPTION
## Summary
- set DATABASE_URL to match branch-specific DB_PORT in compose-up scripts
- document automatic DATABASE_URL configuration in CONTRIBUTING

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68aba257a1508322a56cbe642236b108