### PR TITLE
Commit CSV imports per table

### DIFF
--- a/Database/import_from_csv.py
+++ b/Database/import_from_csv.py
@@ -121,6 +121,11 @@ def import_csv(session, folder, ordered_tables):
                 rows = list(reader)
                 objects = [model(**row) for row in rows]
                 session.add_all(objects)
+                try:
+                    session.commit()
+                except Exception as e:
+                    session.rollback()
+                    raise RuntimeError(f"Failed importing {table}: {e}") from e
         else:
             print(f"No CSV found for {table}")
 


### PR DESCRIPTION
## Summary
- commit each table's CSV import to persist data before loading dependent tables
- rollback and raise a clear error if a table fails to import

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68abb510441c83228edc564093320a34