### PR TITLE
Fix database import wiping Alembic version

### DIFF
--- a/Database/import_from_csv.py
+++ b/Database/import_from_csv.py
@@ -46,7 +46,7 @@ def get_table_order(session):
     """
         )
     )
-    tables = [r[0] for r in result]
+    tables = [r[0] for r in result if r[0] != "alembic_version"]
 
     result = session.execute(
         text(
@@ -92,6 +92,7 @@ def wipe_data(session, ordered_tables):
             f"TRUNCATE TABLE {', '.join(reversed(ordered_tables))} RESTART IDENTITY CASCADE;"
         )
     )
+    session.commit()
 
 
 MODEL_MAP = {


### PR DESCRIPTION
## Summary
- exclude `alembic_version` from CSV import order
- commit truncation step when wiping data

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68abb8bfb53c83228d367880e6bb5464