### PR TITLE
Enable React Router v7 future flags

### DIFF
--- a/Frontend/src/App.js
+++ b/Frontend/src/App.js
@@ -13,7 +13,7 @@ import "./styles/App.css";
 
 function App() {
   return (
-    <Router>
+    <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <DataProvider>
         <MainLayout>
           <Routes>
@@ -31,4 +31,3 @@ function App() {
 }
 
 export default App;
-


### PR DESCRIPTION
## Summary
- Opt-in to React Router v7 `startTransition` and relative splat path behaviors.

## Testing
- `pip install -r Backend/requirements.txt`
- `npm --prefix Frontend install`
- `npm --prefix Frontend run lint`
- `npx prettier Frontend/src/App.js -w`
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68abbc50b2b4832286c50f60dc68cc2b