### PR TITLE
fix: correct table markup and websocket port

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -23,7 +23,7 @@
     "openapi-typescript-fetch": "^2.2.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "WDS_SOCKET_PORT=0 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/Frontend/src/components/planning/Planning.js
+++ b/Frontend/src/components/planning/Planning.js
@@ -5,6 +5,7 @@ import {
   MenuItem,
   Paper,
   Table,
+  TableContainer,
   TableBody,
   TableCell,
   TableHead,
@@ -321,7 +322,8 @@ function Planning() {
         </Button>
       </Box>
 
-      <Table component={Paper} sx={{ mb: 3 }}>
+      <TableContainer component={Paper} sx={{ mb: 3 }}>
+        <Table>
         <TableHead>
           <TableRow>
             <TableCell></TableCell>
@@ -482,11 +484,13 @@ function Planning() {
             }
           })}
         </TableBody>
-      </Table>
+        </Table>
+      </TableContainer>
 
       <Box>
         <h2>Summary</h2>
-        <Table component={Paper}>
+        <TableContainer component={Paper}>
+          <Table>
           <TableHead>
             <TableRow>
               <TableCell></TableCell>
@@ -523,7 +527,8 @@ function Planning() {
               <TableCell>{targetMacros.fiber}</TableCell>
             </TableRow>
           </TableBody>
-        </Table>
+          </Table>
+        </TableContainer>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- wrap planning tables with `TableContainer` to avoid invalid DOM nesting
- configure dev server websocket port to prevent connection errors

## Testing
- `npm --prefix Frontend test`
- `pytest`
- `npm --prefix Frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abc12928808322a527c4a6b6c05488