### PR TITLE
Enable watchfiles polling in backend dev container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       dockerfile: Backend/Dockerfile
     environment:
       DATABASE_URL: postgresql://nutrition_user:nutrition_pass@db:5432/nutrition
+      WATCHFILES_FORCE_POLLING: "true"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- ensure backend service forces filesystem polling by setting `WATCHFILES_FORCE_POLLING=true`
- keep backend source mounted for live reload

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`
- `docker compose up --build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abc47ad74c8322922ba2b9c40aa337