### PR TITLE
Use custom proxy middleware for API

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "http-proxy-middleware": "^2.0.6",
         "openapi-typescript-fetch": "^2.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -2,7 +2,6 @@
   "name": "nutrition-frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://backend:8000",
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
@@ -20,6 +19,7 @@
     "react-window": "^1.8.10",
     "styled-components": "^6.1.8",
     "web-vitals": "^2.1.4",
+    "http-proxy-middleware": "^2.0.6",
     "openapi-typescript-fetch": "^2.2.1"
   },
   "scripts": {

--- a/Frontend/src/setupProxy.js
+++ b/Frontend/src/setupProxy.js
@@ -1,0 +1,10 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+module.exports = function (app) {
+  app.use(
+    "/api",
+    createProxyMiddleware({
+      target: "http://backend:8000",
+      changeOrigin: true,
+    })
+  );
+};


### PR DESCRIPTION
## Summary
- remove CRA `proxy` setting and add `http-proxy-middleware`
- proxy `/api` calls to backend via `setupProxy.js`

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`
- `npm --prefix Frontend run lint`
- `docker compose build frontend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abc4a928a4832282550a70ee1804f8