### PR TITLE
fix(frontend): default proxy to localhost

### DIFF
--- a/Frontend/src/setupProxy.js
+++ b/Frontend/src/setupProxy.js
@@ -4,7 +4,7 @@ const target =
   process.env.BACKEND_URL ||
   (process.env.BACKEND_PORT
     ? `http://localhost:${process.env.BACKEND_PORT}`
-    : "http://backend:8000");
+    : "http://localhost:8000");
 module.exports = function (app) {
   app.use(
     "/api",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - node_modules:/app/node_modules
     environment:
       CHOKIDAR_USEPOLLING: "true"
+      BACKEND_URL: "http://backend:8000"
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     networks:


### PR DESCRIPTION
## Summary
- ensure front-end dev proxy defaults to `http://localhost:8000`
- set `BACKEND_URL` for dockerized frontend

## Testing
- `npm --prefix Frontend run lint` *(fails: ESLint couldn't find config)*
- `CI=true npm --prefix Frontend test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abc8597dc48322a3ccb15d2e940d48