### PR TITLE
Improve fetch error handling in forms

### DIFF
--- a/Frontend/src/components/data/ingredient/form/IngredientForm.js
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.js
@@ -116,6 +116,9 @@ function IngredientForm({ ingredientToEditData }) {
       .then(() => {
         setIngredientsNeedsRefetch(true);
       })
+      .catch((error) => {
+        console.error("Error:", error);
+      })
       .finally(endRequest);
 
     if (!isEditMode) {

--- a/Frontend/src/components/data/meal/form/MealForm.js
+++ b/Frontend/src/components/data/meal/form/MealForm.js
@@ -104,6 +104,9 @@ function MealForm({ mealToEditData }) {
           handleClearForm();
         }
       })
+      .catch((error) => {
+        console.error("Error:", error);
+      })
       .finally(endRequest);
   };
 

--- a/Frontend/src/utils/utils.js
+++ b/Frontend/src/utils/utils.js
@@ -17,26 +17,21 @@ export const formatCellNumber = (number) => {
  * @param {unknown} data Request payload typed against the schema.
  * @returns {Promise<void>}
  */
-export const handleFetchRequest = (url, method, data) => {
-  return new Promise((resolve, reject) => {
-    fetch(url, {
+export const handleFetchRequest = async (url, method, data) => {
+  try {
+    const response = await fetch(url, {
       method: method,
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(data),
-    })
-      .then((response) => {
-        if (response.ok) {
-          resolve();
-        } else {
-          console.error("Failed to make request");
-          reject();
-        }
-      })
-      .catch((error) => {
-        console.error("Error:", error);
-        reject();
-      });
-  });
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to make request");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+    throw error;
+  }
 };


### PR DESCRIPTION
## Summary
- use async/await in fetch wrapper and propagate caught errors
- catch errors in ingredient and meal forms to avoid unhandled rejections

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`
- `npm --prefix Frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abca0888d883228648cae6cb925653