### PR TITLE
fix nginx proxy for API calls

### DIFF
--- a/Frontend/nginx.conf
+++ b/Frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
   }
 
   location /api/ {
-    proxy_pass http://backend:8000/;
+    proxy_pass http://backend:8000;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Summary
- fix nginx `proxy_pass` to preserve /api path

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68abcc8b86008322affd38cf76ac59bd