### PR TITLE
feat(frontend): allow configurable API base URL

### DIFF
--- a/Frontend/src/utils/utils.js
+++ b/Frontend/src/utils/utils.js
@@ -10,16 +10,19 @@ export const formatCellNumber = (number) => {
   return parseFloat(parseFloat(number).toPrecision(3));
 };
 
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "";
+
 /**
  * Minimal fetch wrapper with OpenAPI-generated types.
- * @param {keyof import("../api-types").paths} url The API endpoint.
+ * @param {keyof import("../api-types").paths | string} url The API endpoint.
  * @param {string} method HTTP method.
  * @param {unknown} data Request payload typed against the schema.
  * @returns {Promise<void>}
  */
 export const handleFetchRequest = async (url, method, data) => {
   try {
-    const response = await fetch(url, {
+    const endpoint = url.startsWith("http") ? url : `${API_BASE_URL}${url}`;
+    const response = await fetch(endpoint, {
       method: method,
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- make frontend fetch wrapper prepend optional REACT_APP_API_BASE_URL so API calls work outside Docker

## Testing
- `pip install -r Backend/requirements.txt`
- `npm --prefix Frontend install`
- `npm --prefix Frontend run lint`
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68abce54d3648322b0dfc2f75603cd9e