### PR TITLE
feat: configure vite api proxy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,13 @@ Printed on startup and visible in Docker Desktop as `HOST:CONTAINER`.
 
 ---
 
+## 🌐 Environment Variables
+
+- `BACKEND_PORT` → backend service port (defaults to `8000`; compose scripts set this automatically)
+- `BACKEND_URL` → full URL for the backend API. The frontend dev server proxies `/api` to this value. If unset, it falls back to `http://localhost:${BACKEND_PORT}`.
+
+---
+
 ## 🖥️ Local Development (Non‑Docker)
 
 **Backend (FastAPI):**

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -5,10 +5,18 @@ const backendPort = parseInt(process.env.BACKEND_PORT || '8000', 10);
 const branchOffset = backendPort - 8000;
 const port = 3000 + branchOffset;
 
+const backendUrl = process.env.BACKEND_URL || `http://localhost:${backendPort}`;
+
 export default defineConfig({
   plugins: [react()],
   server: {
     port,
+    proxy: {
+      '/api': {
+        target: backendUrl,
+        changeOrigin: true,
+      },
+    },
   },
   test: {
     environment: 'jsdom',

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Multiple branches can run in parallel without conflicts.
 - Backend API → `http://localhost:<BACKEND_PORT>`
 - PostgreSQL → `localhost:<DB_PORT>`
 
+### 4. Environment Variables
+
+The frontend dev server proxies `/api` requests to the backend. By default it targets the branch-specific port printed above. Set `BACKEND_URL` to point at a different backend host.
+
 ---
 
 ## 🗂️ Project Structure


### PR DESCRIPTION
## Summary
- add Vite dev server proxy that targets BACKEND_URL or the derived backend port
- document BACKEND_URL and BACKEND_PORT variables in README and CONTRIBUTING

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test` *(fails: Failed to parse source for import analysis because the content contains invalid JS syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4e1945a08322b291a4ce44805d34