### PR TITLE
docs: update frontend commands for Vite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,9 @@ uvicorn Backend.backend:app --reload
 **Frontend (React):**
 
 ```bash
-cd Frontend
-npm start
+npm --prefix Frontend run dev     # start dev server
+npm --prefix Frontend run build   # production build
+npm --prefix Frontend run preview # preview build
 ```
 
 ---
@@ -209,9 +210,9 @@ Before opening a PR:
 * [ ] **Migrations apply cleanly?**
   `alembic upgrade head` (or rely on the sync/drift script outcome)
 * [ ] **Tests pass?**
-  `pytest` (backend) and `npm test` (frontend)
+  `pytest` (backend) and `CI=true npm --prefix Frontend test` (frontend)
 * [ ] **Lint/build ok?**
-  `npm run lint` and `npm run build` (frontend)
+  `npm --prefix Frontend run lint` and `npm --prefix Frontend run build`
 
 ---
 
@@ -282,9 +283,9 @@ The repo includes a **two‑job CI**: `backend` and `frontend`.
 * Checks out repo and sets up Node 20
 * Caches npm modules (`~/.npm`) keyed by `Frontend/package-lock.json`
 * `npm ci` installs exact deps
-* `npm run lint` enforces code quality
-* `npm test -- --watchAll=false` runs unit tests in CI mode
-* `npm run build` ensures the app builds for production
+* `npm --prefix Frontend run lint` enforces code quality
+* `npm --prefix Frontend test -- --watchAll=false` runs unit tests in CI mode
+* `npm --prefix Frontend run build` ensures the app builds for production
 
 **Benefits:**
 

--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Frontend/package*.json ./
 RUN npm install
 COPY Frontend/ .
-CMD ["npm", "start"]
+CMD ["npm", "run", "dev"]
 
 # Build stage
 FROM node:23-slim AS build
@@ -13,7 +13,7 @@ WORKDIR /app
 COPY Frontend/package*.json ./
 RUN npm install
 COPY Frontend/ .
-RUN npx vite build
+RUN npm run build
 
 # Serve with nginx
 FROM nginx:stable-alpine

--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Multiple branches can run in parallel without conflicts.
 
 The frontend dev server proxies `/api` requests to the backend. By default it targets the branch-specific port printed above. Set `BACKEND_URL` to point at a different backend host.
 
+### 5. Frontend Commands
+
+Run the React app directly without Docker:
+
+```bash
+npm --prefix Frontend run dev     # start dev server
+npm --prefix Frontend run build   # production build
+npm --prefix Frontend run preview # preview build
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full contributor workflow details.
+
 ---
 
 ## 🗂️ Project Structure


### PR DESCRIPTION
## Summary
- document Vite dev/build/preview commands in README and CONTRIBUTING
- switch Docker dev and build steps to Vite scripts
- update contributor checklist and CI docs for new frontend commands

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ae58f3a0a48322bd5bf6190e6be67e