### PR TITLE
fix: update vitest setup file path

### DIFF
--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    setupFiles: './src/tests/setupTests.js',
+    setupFiles: './src/tests/setupTests.ts',
     transformMode: {
       web: [/\.[jt]sx?$/],
     },


### PR DESCRIPTION
## Summary
- point vite test setup to TypeScript file

## Testing
- `npm --prefix Frontend test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ae6a2f9b108322919fdccba52bfc61