### PR TITLE
test: align vitest alias with vite

### DIFF
--- a/Frontend/vitest.config.ts
+++ b/Frontend/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     setupFiles: './src/tests/setupTests.ts',


### PR DESCRIPTION
## Summary
- mirror vite path alias in vitest config so tests resolve @ to src

## Testing
- `npm --prefix Frontend run lint`
- `CI=true npx --prefix Frontend vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ae6a7295fc8322a166c4f35c19430c