### PR TITLE
Use Vite API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+# Base URL for the backend API used by the frontend
+VITE_API_BASE_URL=http://localhost:8000

--- a/Frontend/src/utils/utils.jsx
+++ b/Frontend/src/utils/utils.jsx
@@ -10,7 +10,7 @@ export const formatCellNumber = (number) => {
   return parseFloat(parseFloat(number).toPrecision(3));
 };
 
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "";
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
 
 /**
  * Minimal fetch wrapper with OpenAPI-generated types.


### PR DESCRIPTION
## Summary
- replace deprecated CRA API base URL with `import.meta.env.VITE_API_BASE_URL`
- document `VITE_API_BASE_URL` in `.env.example`

## Testing
- `npm --prefix Frontend run build`
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6abcd144832299ead9ccf4a0e82e