### PR TITLE
ci: fix frontend test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         working-directory: Frontend
         env:
           CI: true
-        run: npm test -- --watchAll=false
+        run: npm test
       - name: Production build
         working-directory: Frontend
         run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,7 +284,7 @@ The repo includes a **two‑job CI**: `backend` and `frontend`.
 * Caches npm modules (`~/.npm`) keyed by `Frontend/package-lock.json`
 * `npm ci` installs exact deps
 * `npm --prefix Frontend run lint` enforces code quality
-* `npm --prefix Frontend test -- --watchAll=false` runs unit tests in CI mode
+* `CI=true npm --prefix Frontend test` runs unit tests in CI mode
 * `npm --prefix Frontend run build` ensures the app builds for production
 
 **Benefits:**


### PR DESCRIPTION
## Summary
- run frontend tests in CI without deprecated watchAll flag
- document updated test command

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6e652154832285a3ebdce0c36673