### PR TITLE
test: stub fetch and silence act warnings

### DIFF
--- a/Frontend/src/tests/MealTable.test.jsx
+++ b/Frontend/src/tests/MealTable.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import MealTable from "../components/data/meal/MealTable";
@@ -66,10 +66,12 @@ describe("MealTable tag filtering", () => {
     renderWithData();
     await userEvent.click(screen.getByLabelText(/Filter tags/i));
     await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
-    expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
-    expect(screen.queryByText("Veg Breakfast")).not.toBeInTheDocument();
-    expect(screen.queryByText("Snack")).not.toBeInTheDocument();
-    expect(screen.queryByText("Mystery Meal")).not.toBeInTheDocument();
+    expect(await screen.findByText("Chicken Dinner")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Veg Breakfast")).not.toBeInTheDocument();
+      expect(screen.queryByText("Snack")).not.toBeInTheDocument();
+      expect(screen.queryByText("Mystery Meal")).not.toBeInTheDocument();
+    });
   });
 
   test("filters meals when multiple tags are selected", async () => {
@@ -78,9 +80,11 @@ describe("MealTable tag filtering", () => {
     await userEvent.click(screen.getByRole("option", { name: "Breakfast" }));
     await userEvent.click(screen.getByLabelText(/Filter tags/i));
     await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
-    expect(screen.getByText("Veg Breakfast")).toBeInTheDocument();
-    expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
-    expect(screen.queryByText("Snack")).not.toBeInTheDocument();
+    expect(await screen.findByText("Veg Breakfast")).toBeInTheDocument();
+    expect(await screen.findByText("Chicken Dinner")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Snack")).not.toBeInTheDocument();
+    });
   });
 
   test("combines search and tag filters", async () => {
@@ -88,8 +92,10 @@ describe("MealTable tag filtering", () => {
     await userEvent.click(screen.getByLabelText(/Filter tags/i));
     await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
     await userEvent.type(screen.getByLabelText(/Search by name/i), "Chicken");
-    expect(screen.getByText("Chicken Dinner")).toBeInTheDocument();
-    expect(screen.queryByText("Veg Breakfast")).not.toBeInTheDocument();
+    expect(await screen.findByText("Chicken Dinner")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Veg Breakfast")).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/Frontend/src/tests/setupTests.ts
+++ b/Frontend/src/tests/setupTests.ts
@@ -2,5 +2,33 @@
 // see: https://github.com/testing-library/jest-dom
 import { expect } from 'vitest';
 import matchers from '@testing-library/jest-dom/matchers';
+import { vi } from 'vitest';
 
 expect.extend(matchers);
+
+// Provide a simple fetch mock that handles relative URLs so tests don't
+// hit the network or throw "Invalid URL" errors.
+vi.stubGlobal(
+  'fetch',
+  (async (input: RequestInfo | URL) => {
+    if (typeof input === 'string' && input.startsWith('/')) {
+      input = 'http://localhost' + input;
+    } else if (input instanceof Request && input.url.startsWith('/')) {
+      input = new Request('http://localhost' + input.url, input);
+    }
+    return new Response('[]', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch,
+);
+
+// Silence React act() warnings from third-party components to keep test
+// output focused on actionable errors.
+const error = console.error;
+vi.spyOn(console, 'error').mockImplementation((msg, ...args) => {
+  if (typeof msg === 'string' && msg.includes('not wrapped in act')) {
+    return;
+  }
+  error(msg, ...args);
+});


### PR DESCRIPTION
## Summary
- mock global fetch to resolve relative API requests in tests
- filter noisy act() warnings from console output
- add async waits in MealTable tests to avoid state update races

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ae704a778c83228827df0eb4218ff3