### PR TITLE
Fix uvicorn startup in backend container

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -17,10 +17,13 @@ RUN apt-get update && apt-get install -y \
 COPY Backend/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
+# Ensure local binaries from pip (like uvicorn) are on PATH
+ENV PATH="/root/.local/bin:$PATH"
+
 # Copy backend source preserving package structure
 COPY Backend/ /app/Backend
 
 # Copy Alembic configuration for database migrations
 COPY alembic.ini /app/alembic.ini
 
-CMD ["uvicorn", "Backend.backend:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["python", "-m", "uvicorn", "Backend.backend:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./Backend:/app/Backend
       - ./alembic.ini:/app/alembic.ini:ro
-    command: uvicorn Backend.backend:app --host 0.0.0.0 --port 8000 --reload
+    command: python -m uvicorn Backend.backend:app --host 0.0.0.0 --port 8000 --reload
     networks:
       - nutrition-net
     ports:


### PR DESCRIPTION
## Summary
- ensure uvicorn is on PATH in backend Docker image
- use `python -m uvicorn` for backend startup

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ae718349288322af4805ee6ca04277