### PR TITLE
Configure TypeScript unused expressions rule

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -61,7 +61,15 @@
     },
     "rules": {
       "react/react-in-jsx-scope": "off",
-      "react/prop-types": "off"
+      "react/prop-types": "off",
+      "@typescript-eslint/no-unused-expressions": [
+        "error",
+        {
+          "allowShortCircuit": true,
+          "allowTernary": true,
+          "allowTaggedTemplates": true
+        }
+      ]
     }
   },
   "browserslist": {


### PR DESCRIPTION
## Summary
- allow short-circuit, ternary, and tagged-template expressions for `@typescript-eslint/no-unused-expressions`

## Testing
- `npm --prefix Frontend run lint`
- `pytest`
- `npm --prefix Frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6ffe366c8322b1a0ea94fd89f2e8