### PR TITLE
Install backend dependencies system-wide

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -13,12 +13,9 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies
+# Install dependencies system-wide to ensure modules are available
 COPY Backend/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
-
-# Ensure local binaries from pip (like uvicorn) are on PATH
-ENV PATH="/root/.local/bin:$PATH"
+RUN pip install --no-cache-dir --break-system-packages -r /tmp/requirements.txt
 
 # Copy backend source preserving package structure
 COPY Backend/ /app/Backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,10 @@ services:
     volumes:
       - ./Backend:/app/Backend
       - ./alembic.ini:/app/alembic.ini:ro
-    command: python -m uvicorn Backend.backend:app --host 0.0.0.0 --port 8000 --reload
+    command: >
+      bash -c "set -eux; python -m pip install -v -r Backend/requirements.txt;
+      python -m pip show uvicorn;
+      exec python -m uvicorn Backend.backend:app --host 0.0.0.0 --port 8000 --reload"
     networks:
       - nutrition-net
     ports:


### PR DESCRIPTION
## Summary
- Install Python dependencies system-wide in backend Docker image to ensure modules like `uvicorn` are available at runtime
- Log backend dependency installation and package check during service startup for easier debugging

## Testing
- `pip install -r Backend/requirements.txt`
- `pytest`
- `npm --prefix Frontend install`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68ae74043e88832285be2b30be0f08b5