### PR TITLE
refactor: use crypto.randomUUID instead of uuid

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -24,7 +24,6 @@
         "react-virtuoso": "^4.7.1",
         "react-window": "^1.8.10",
         "styled-components": "^6.1.8",
-        "uuid": "^9.0.1",
         "vite": "^7.1.3"
       },
       "devDependencies": {
@@ -7483,19 +7482,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -19,7 +19,6 @@
     "react-virtuoso": "^4.7.1",
     "react-window": "^1.8.10",
     "styled-components": "^6.1.8",
-    "uuid": "^9.0.1",
     "vite": "^7.1.3"
   },
   "scripts": {
@@ -91,11 +90,11 @@
     "eslint": "^8.57.1",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-vitest": "^0.5.4",
+    "eslint-plugin-vitest-globals": "^1.5.0",
     "jsdom": "^26.1.0",
     "openapi-typescript": "^6.7.6",
     "typescript": "^5.4.5",
-    "vitest": "^3.2.4",
-    "eslint-plugin-vitest": "^0.5.4",
-    "eslint-plugin-vitest-globals": "^1.5.0"
+    "vitest": "^3.2.4"
   }
 }

--- a/Frontend/src/components/data/ingredient/form/IngredientForm.tsx
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.tsx
@@ -1,6 +1,5 @@
 // @ts-check
 import React, { useEffect, useCallback, useReducer } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { Button, Collapse, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Box } from "@mui/material";
 
 import { useData } from "@/contexts/DataContext";
@@ -23,8 +22,8 @@ const initialState = {
   isEditMode: false,
   ingredientToEdit: {
     name: "",
-    id: uuidv4(),
-    units: [{ id: "0", ingredient_id: uuidv4(), name: "1g", grams: "1" }],
+    id: crypto.randomUUID(),
+    units: [{ id: "0", ingredient_id: crypto.randomUUID(), name: "1g", grams: "1" }],
     nutrition: {
       calories: 0,
       protein: 0,
@@ -67,8 +66,8 @@ function IngredientForm({ ingredientToEditData }) {
 
   const initializeEmptyIngredient = () => ({
     name: "",
-    id: uuidv4(),
-    units: [{ id: "0", ingredient_id: uuidv4(), name: "1g", grams: "1" }],
+    id: crypto.randomUUID(),
+    units: [{ id: "0", ingredient_id: crypto.randomUUID(), name: "1g", grams: "1" }],
     nutrition: {
       calories: 0,
       protein: 0,

--- a/Frontend/src/components/data/ingredient/form/UnitEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/UnitEdit.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { Button, Select, MenuItem, TextField, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
 
 function AddUnitDialog({ open, onClose, onAddUnit }) {
@@ -71,7 +70,7 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }) {
 
   const handleAddUnit = useCallback(
     (name, grams) => {
-      const tempId = uuidv4();
+      const tempId = crypto.randomUUID();
       const newUnit = {
         id: tempId,
         ingredient_id: ingredient.id,

--- a/Frontend/src/components/data/meal/form/MealForm.tsx
+++ b/Frontend/src/components/data/meal/form/MealForm.tsx
@@ -1,6 +1,5 @@
 // @ts-check
 import React, { useEffect, useCallback, useReducer } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { Button, Collapse, Paper, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
 
 import { useData } from "@/contexts/DataContext";
@@ -20,7 +19,7 @@ const intitalState = {
   isEditMode: false,
   mealToEdit: {
     name: "",
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     ingredients: [],
     tags: [],
   },
@@ -61,7 +60,7 @@ function MealForm({ mealToEditData }) {
 
   const initializeEmptyMeal = () => ({
     name: "",
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     ingredients: [],
     tags: [],
   });


### PR DESCRIPTION
## Summary
- replace uuid dependency with built-in `crypto.randomUUID`
- update ingredient, meal, and unit forms accordingly

## Testing
- `pytest`
- `npm --prefix Frontend run lint`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68afc0cdeff88322ae1c3a08cda766fb