### PR TITLE
fix: use trailing slashes for API create endpoints

### DIFF
--- a/Frontend/src/components/data/ingredient/form/IngredientForm.tsx
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.tsx
@@ -106,7 +106,7 @@ function IngredientForm({ ingredientToEditData }) {
 
     const url = isEditMode
       ? `/api/ingredients/${toDatabaseIngredient.id}`
-      : "/api/ingredients";
+      : "/api/ingredients/";
     const method = isEditMode ? "PUT" : "POST";
     const data = /** @type {IngredientRequest} */ (toDatabaseIngredient);
 

--- a/Frontend/src/components/data/meal/form/MealForm.tsx
+++ b/Frontend/src/components/data/meal/form/MealForm.tsx
@@ -94,7 +94,7 @@ function MealForm({ mealToEditData }) {
         .map((tag) => ({ id: tag.id })),
     };
 
-    const url = isEditMode ? `/api/meals/${mealToEdit.id}` : "/api/meals";
+    const url = isEditMode ? `/api/meals/${mealToEdit.id}` : "/api/meals/";
     const method = isEditMode ? "PUT" : "POST";
 
     handleFetchRequest(url, method, /** @type {MealRequest} */ (toDatabaseMeal))


### PR DESCRIPTION
## Summary
- avoid DNS errors by POSTing to `/api/ingredients/` and `/api/meals/`
- ensure ingredient and meal creation requests hit the correct backend paths

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68afcaaf8e248322bc4880c5ec9a09f8