### PR TITLE
Reset sequences after CSV import

### DIFF
--- a/Database/import_from_csv.py
+++ b/Database/import_from_csv.py
@@ -162,6 +162,15 @@ def main():
         wipe_data(session, ordered_tables)
         import_csv(session, data_dir, ordered_tables)
 
+        for table in ordered_tables:
+            session.execute(
+                text(
+                    "SELECT setval(pg_get_serial_sequence(:tbl, 'id'), "
+                    "(SELECT COALESCE(MAX(id), 0) + 1 FROM " + table + "), false)"
+                ),
+                {"tbl": table},
+            )
+
         session.commit()
         session.close()
         print("All CSVs imported successfully.")


### PR DESCRIPTION
## Summary
- Reset PostgreSQL sequences after importing CSV data so new records start after the current max ID

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`
- `python Database/import_from_csv.py --test` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b257cd0d748322abdaa2b2fe61b278