### PR TITLE
refactor: centralize branch env helpers

### DIFF
--- a/scripts/compose-down-branch.sh
+++ b/scripts/compose-down-branch.sh
@@ -42,18 +42,13 @@ PY
 
 prioritize_current_branch() {
   local projects=("$@")
-  local branch sanitized current
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-  if [[ -n "$branch" ]]; then
-    sanitized=$(echo "$branch" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^[-]*//;s/[-]*$//')
-    current="nutrition-$sanitized"
-    if printf '%s\n' "${projects[@]}" | grep -qx "$current"; then
-      echo "$current"
-      for p in "${projects[@]}"; do
-        [[ "$p" == "$current" ]] || echo "$p"
-      done
-      return
-    fi
+  local current="nutrition-$BRANCH_SANITIZED"
+  if printf '%s\n' "${projects[@]}" | grep -qx "$current"; then
+    echo "$current"
+    for p in "${projects[@]}"; do
+      [[ "$p" == "$current" ]] || echo "$p"
+    done
+    return
   fi
   printf '%s\n' "${projects[@]}"
 }
@@ -83,8 +78,9 @@ select_projects() {
   printf '%s\n' "${selection[@]}" | sort -u
 }
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$repo_root"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/branch-env.sh"
+branch_env_load
+cd "$REPO_ROOT"
 
 mapfile -t projects < <(get_compose_projects)
 mapfile -t projects < <(prioritize_current_branch "${projects[@]}")

--- a/scripts/compose-restart-branch.ps1
+++ b/scripts/compose-restart-branch.ps1
@@ -8,17 +8,14 @@ param(
   [string[]]$Services
 )
 
-$repoRoot = Split-Path -Parent $PSScriptRoot
-Set-Location $repoRoot
+. "$PSScriptRoot/lib/branch-env.ps1"
+$envInfo = Set-BranchEnv
+Set-Location $envInfo.RepoRoot
 
-$branch    = (git rev-parse --abbrev-ref HEAD).Trim()
-$sanitized = ($branch.ToLower() -replace '[^a-z0-9]', '-').Trim('-')
-$project   = "nutrition-$sanitized"
-
-Write-Host "Bringing down containers for '$branch'..."
-docker compose -p $project down -v --remove-orphans | Out-Null
-docker network rm "${project}_default" 2>$null | Out-Null
-docker volume rm "${project}_node_modules" 2>$null | Out-Null
+Write-Host "Bringing down containers for '$($envInfo.Branch)'..."
+docker compose -p $envInfo.Project down -v --remove-orphans | Out-Null
+docker network rm "${($envInfo.Project)}_default" 2>$null | Out-Null
+docker volume rm "${($envInfo.Project)}_node_modules" 2>$null | Out-Null
 
 Write-Host "Bringing up containers..."
 & "$PSScriptRoot/compose-up-branch.ps1" @PSBoundParameters

--- a/scripts/compose-restart-branch.sh
+++ b/scripts/compose-restart-branch.sh
@@ -2,17 +2,14 @@
 # scripts/compose-restart-branch.sh
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$repo_root"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/branch-env.sh"
+branch_env_load
+cd "$REPO_ROOT"
 
-branch="$(git rev-parse --abbrev-ref HEAD | tr -d '\n')"
-san="$(echo "$branch" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^[-]*//;s/[-]*$//')"
-project="nutrition-$san"
-
-echo "Bringing down containers for '$branch'..."
-docker compose -p "$project" down -v --remove-orphans >/dev/null 2>&1 || true
-docker network rm "${project}_default" >/dev/null 2>&1 || true
-docker volume rm "${project}_node_modules" >/dev/null 2>&1 || true
+echo "Bringing down containers for '$BRANCH_NAME'..."
+docker compose -p "$COMPOSE_PROJECT" down -v --remove-orphans >/dev/null 2>&1 || true
+docker network rm "${COMPOSE_PROJECT}_default" >/dev/null 2>&1 || true
+docker volume rm "${COMPOSE_PROJECT}_node_modules" >/dev/null 2>&1 || true
 
 echo "Bringing up containers..."
-"$repo_root/scripts/compose-up-branch.sh" "$@"
+"$REPO_ROOT/scripts/compose-up-branch.sh" "$@"

--- a/scripts/import-from-csv.sh
+++ b/scripts/import-from-csv.sh
@@ -23,28 +23,15 @@ case "$1" in
     ;;
 esac
 
-# Determine repo root
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$repo_root"
-
-# Determine branch-specific project name
-branch="$(git rev-parse --abbrev-ref HEAD)"
-san=$(echo "$branch" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^[-]*//;s/[-]*$//')
-project="nutrition-$san"
+source "$(dirname "${BASH_SOURCE[0]}")/lib/branch-env.sh"
+branch_env_load
+cd "$REPO_ROOT"
 
 # Ensure containers are running for this branch
-if [[ -z $(docker compose -p "$project" ps -q 2>/dev/null) ]]; then
-  echo "Warning: no containers running for branch '$branch'. Run the compose script first." >&2
+if [[ -z $(docker compose -p "$COMPOSE_PROJECT" ps -q 2>/dev/null) ]]; then
+  echo "Warning: no containers running for branch '$BRANCH_NAME'. Run the compose script first." >&2
   exit 1
 fi
-
-# Get mapped database port
-port_line=$(docker compose -p "$project" port db 5432 2>/dev/null || true)
-if [[ -z "$port_line" ]]; then
-  echo "Warning: unable to determine database port for project '$project'." >&2
-  exit 1
-fi
-DB_PORT=${port_line##*:}
 
 export DB_PORT
 python Database/import_from_csv.py "$flag"

--- a/scripts/lib/branch-env.ps1
+++ b/scripts/lib/branch-env.ps1
@@ -1,0 +1,39 @@
+# scripts/lib/branch-env.ps1
+# Shared helpers for branch-specific environment variables.
+
+function Get-RepoRoot {
+  git rev-parse --show-toplevel
+}
+
+function Get-SanitizedBranch {
+  param(
+    [string]$Branch
+  )
+  if (-not $Branch) {
+    $Branch = (git rev-parse --abbrev-ref HEAD).Trim()
+  }
+  return ($Branch.ToLower() -replace '[^a-z0-9]', '-').Trim('-')
+}
+
+# Compute branch-specific environment variables and export them.
+# Returns a hashtable with RepoRoot, Branch, Sanitized, Project, and PortOffset.
+function Set-BranchEnv {
+  $repoRoot = Get-RepoRoot
+  $branch   = (git -C $repoRoot rev-parse --abbrev-ref HEAD).Trim()
+  $sanitized = Get-SanitizedBranch $branch
+  $project  = "nutrition-$sanitized"
+  $offset   = [math]::Abs($branch.GetHashCode()) % 100
+
+  $env:REPO_ROOT       = $repoRoot
+  $env:BRANCH_NAME     = $branch
+  $env:BRANCH_SANITIZED= $sanitized
+  $env:COMPOSE_PROJECT = $project
+  $env:PORT_OFFSET     = $offset
+  $env:DB_PORT         = 5432 + $offset
+  $env:BACKEND_PORT    = 8000 + $offset
+  $env:FRONTEND_PORT   = 3000 + $offset
+  $env:DATABASE_URL    = "postgresql://nutrition_user:nutrition_pass@localhost:$($env:DB_PORT)/nutrition"
+
+  return @{ RepoRoot=$repoRoot; Branch=$branch; Sanitized=$sanitized; Project=$project; PortOffset=$offset }
+}
+

--- a/scripts/lib/branch-env.sh
+++ b/scripts/lib/branch-env.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# scripts/lib/branch-env.sh
+# Shared helpers for branch-specific environment variables.
+
+# Return the absolute path to the repository root.
+branch_env_repo_root() {
+  git rev-parse --show-toplevel
+}
+
+# Sanitize a Git branch name to be Docker/filename friendly.
+# Usage: branch_env_sanitize_branch "feature/My Branch" -> "feature-my-branch"
+branch_env_sanitize_branch() {
+  local branch="${1:?branch name required}"
+  echo "$branch" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/^[-]*//;s/[-]*$//'
+}
+
+# Compute branch-specific environment variables and export them.
+# Sets: REPO_ROOT, BRANCH_NAME, BRANCH_SANITIZED, COMPOSE_PROJECT,
+#       PORT_OFFSET, DB_PORT, BACKEND_PORT, FRONTEND_PORT, DATABASE_URL
+branch_env_load() {
+  REPO_ROOT="$(branch_env_repo_root)"
+  BRANCH_NAME="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD | tr -d '\n')"
+  BRANCH_SANITIZED="$(branch_env_sanitize_branch "$BRANCH_NAME")"
+  COMPOSE_PROJECT="nutrition-$BRANCH_SANITIZED"
+  local offset_hex
+  offset_hex="$(printf '%s' "$BRANCH_NAME" | sha1sum | head -c 2)"
+  PORT_OFFSET=$((0x$offset_hex % 100))
+  DB_PORT=$((5432 + PORT_OFFSET))
+  BACKEND_PORT=$((8000 + PORT_OFFSET))
+  FRONTEND_PORT=$((3000 + PORT_OFFSET))
+  DATABASE_URL="postgresql://nutrition_user:nutrition_pass@localhost:$DB_PORT/nutrition"
+  export REPO_ROOT BRANCH_NAME BRANCH_SANITIZED COMPOSE_PROJECT PORT_OFFSET \
+    DB_PORT BACKEND_PORT FRONTEND_PORT DATABASE_URL
+}
+


### PR DESCRIPTION
## Summary
- add reusable branch-env helpers for Bash and PowerShell
- refactor compose/import scripts to source shared branch environment logic

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b2751bb14c832287870b54cdb952db