### PR TITLE
Rename meals to foods in backend tests and OpenAPI

### DIFF
--- a/Backend/openapi.json
+++ b/Backend/openapi.json
@@ -1,1 +1,1026 @@
-{"openapi":"3.1.0","info":{"title":"FastAPI","version":"0.1.0"},"paths":{"/api/ingredients/":{"get":{"tags":["ingredients"],"summary":"Get All Ingredients","description":"Return all ingredients.","operationId":"get_all_ingredients_api_ingredients__get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/IngredientRead"},"type":"array","title":"Response Get All Ingredients Api Ingredients  Get"}}}}}},"post":{"tags":["ingredients"],"summary":"Add Ingredient","description":"Create a new ingredient.","operationId":"add_ingredient_api_ingredients__post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientCreate"}}},"required":true},"responses":{"201":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/ingredients/possible_tags":{"get":{"tags":["ingredients"],"summary":"Get All Possible Tags","description":"Return all possible ingredient tags ordered by name.","operationId":"get_all_possible_tags_api_ingredients_possible_tags_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/PossibleIngredientTag"},"type":"array","title":"Response Get All Possible Tags Api Ingredients Possible Tags Get"}}}}}}},"/api/ingredients/{ingredient_id}":{"get":{"tags":["ingredients"],"summary":"Get Ingredient","description":"Retrieve a single ingredient by ID.","operationId":"get_ingredient_api_ingredients__ingredient_id__get","parameters":[{"name":"ingredient_id","in":"path","required":true,"schema":{"type":"integer","title":"Ingredient Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["ingredients"],"summary":"Update Ingredient","description":"Update an existing ingredient.","operationId":"update_ingredient_api_ingredients__ingredient_id__put","parameters":[{"name":"ingredient_id","in":"path","required":true,"schema":{"type":"integer","title":"Ingredient Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["ingredients"],"summary":"Delete Ingredient","description":"Delete an ingredient.","operationId":"delete_ingredient_api_ingredients__ingredient_id__delete","parameters":[{"name":"ingredient_id","in":"path","required":true,"schema":{"type":"integer","title":"Ingredient Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Ingredient Api Ingredients  Ingredient Id  Delete"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/meals/":{"get":{"tags":["meals"],"summary":"Get All Meals","description":"Return all meals.","operationId":"get_all_meals_api_meals__get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/MealRead"},"type":"array","title":"Response Get All Meals Api Meals  Get"}}}}}},"post":{"tags":["meals"],"summary":"Add Meal","description":"Create a new meal.","operationId":"add_meal_api_meals__post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealCreate"}}},"required":true},"responses":{"201":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/meals/possible_tags":{"get":{"tags":["meals"],"summary":"Get Possible Meal Tags","description":"Return all possible meal tags ordered by name.","operationId":"get_possible_meal_tags_api_meals_possible_tags_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/PossibleMealTag"},"type":"array","title":"Response Get Possible Meal Tags Api Meals Possible Tags Get"}}}}}}},"/api/meals/{meal_id}":{"get":{"tags":["meals"],"summary":"Get Meal","description":"Retrieve a single meal by ID.","operationId":"get_meal_api_meals__meal_id__get","parameters":[{"name":"meal_id","in":"path","required":true,"schema":{"type":"integer","title":"Meal Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["meals"],"summary":"Update Meal","description":"Update an existing meal.","operationId":"update_meal_api_meals__meal_id__put","parameters":[{"name":"meal_id","in":"path","required":true,"schema":{"type":"integer","title":"Meal Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["meals"],"summary":"Delete Meal","description":"Delete a meal.","operationId":"delete_meal_api_meals__meal_id__delete","parameters":[{"name":"meal_id","in":"path","required":true,"schema":{"type":"integer","title":"Meal Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Meal Api Meals  Meal Id  Delete"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}}},"components":{"schemas":{"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"IngredientCreate":{"properties":{"name":{"type":"string","title":"Name"},"nutrition":{"anyOf":[{"$ref":"#/components/schemas/NutritionCreate"},{"type":"null"}]},"units":{"items":{"$ref":"#/components/schemas/IngredientUnitCreate"},"type":"array","title":"Units"},"tags":{"items":{"$ref":"#/components/schemas/TagRef"},"type":"array","title":"Tags"}},"type":"object","required":["name"],"title":"IngredientCreate","description":"Schema for creating an ingredient."},"IngredientRead":{"properties":{"id":{"type":"integer","title":"Id"},"name":{"type":"string","title":"Name"},"nutrition":{"anyOf":[{"$ref":"#/components/schemas/Nutrition"},{"type":"null"}]},"units":{"items":{"$ref":"#/components/schemas/IngredientUnit"},"type":"array","title":"Units"},"tags":{"items":{"$ref":"#/components/schemas/PossibleIngredientTag"},"type":"array","title":"Tags"}},"type":"object","required":["id","name"],"title":"IngredientRead","description":"Schema for reading ingredient data."},"IngredientUnit":{"properties":{"id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Id"},"ingredient_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Ingredient Id"},"name":{"type":"string","title":"Name"},"grams":{"type":"number","title":"Grams"}},"type":"object","required":["name","grams"],"title":"IngredientUnit","description":"Measurement unit for an ingredient."},"IngredientUnitCreate":{"properties":{"name":{"type":"string","title":"Name"},"grams":{"type":"number","title":"Grams"}},"type":"object","required":["name","grams"],"title":"IngredientUnitCreate","description":"Schema for creating ingredient unit data."},"IngredientUpdate":{"properties":{"name":{"type":"string","title":"Name"},"nutrition":{"anyOf":[{"$ref":"#/components/schemas/NutritionCreate"},{"type":"null"}]},"units":{"items":{"$ref":"#/components/schemas/IngredientUnitCreate"},"type":"array","title":"Units"},"tags":{"items":{"$ref":"#/components/schemas/TagRef"},"type":"array","title":"Tags"}},"type":"object","required":["name"],"title":"IngredientUpdate","description":"Schema for updating an ingredient."},"MealCreate":{"properties":{"name":{"type":"string","title":"Name"},"ingredients":{"items":{"$ref":"#/components/schemas/MealIngredientCreate"},"type":"array","title":"Ingredients"},"tags":{"items":{"$ref":"#/components/schemas/TagRef"},"type":"array","title":"Tags"}},"type":"object","required":["name"],"title":"MealCreate","description":"Schema for creating a meal."},"MealIngredient":{"properties":{"ingredient_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Ingredient Id"},"meal_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Meal Id"},"unit_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Unit Id"},"unit_quantity":{"anyOf":[{"type":"number"},{"type":"null"}],"title":"Unit Quantity"}},"type":"object","title":"MealIngredient","description":"Link between a meal and an ingredient with quantity information."},"MealIngredientCreate":{"properties":{"ingredient_id":{"type":"integer","title":"Ingredient Id"},"unit_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Unit Id"},"unit_quantity":{"anyOf":[{"type":"number"},{"type":"null"}],"title":"Unit Quantity"}},"type":"object","required":["ingredient_id"],"title":"MealIngredientCreate","description":"Schema for creating meal ingredient linkage."},"MealRead":{"properties":{"id":{"type":"integer","title":"Id"},"name":{"type":"string","title":"Name"},"ingredients":{"items":{"$ref":"#/components/schemas/MealIngredient"},"type":"array","title":"Ingredients"},"tags":{"items":{"$ref":"#/components/schemas/PossibleMealTag"},"type":"array","title":"Tags"}},"type":"object","required":["id","name"],"title":"MealRead","description":"Schema for reading meal data."},"MealUpdate":{"properties":{"name":{"type":"string","title":"Name"},"ingredients":{"items":{"$ref":"#/components/schemas/MealIngredientCreate"},"type":"array","title":"Ingredients"},"tags":{"items":{"$ref":"#/components/schemas/TagRef"},"type":"array","title":"Tags"}},"type":"object","required":["name"],"title":"MealUpdate","description":"Schema for updating a meal."},"Nutrition":{"properties":{"id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Id"},"ingredient_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Ingredient Id"},"calories":{"type":"number","title":"Calories"},"fat":{"type":"number","title":"Fat"},"carbohydrates":{"type":"number","title":"Carbohydrates"},"protein":{"type":"number","title":"Protein"},"fiber":{"type":"number","title":"Fiber"}},"type":"object","required":["calories","fat","carbohydrates","protein","fiber"],"title":"Nutrition","description":"Nutritional information for a single ingredient."},"NutritionCreate":{"properties":{"calories":{"type":"number","title":"Calories"},"fat":{"type":"number","title":"Fat"},"carbohydrates":{"type":"number","title":"Carbohydrates"},"protein":{"type":"number","title":"Protein"},"fiber":{"type":"number","title":"Fiber"}},"type":"object","required":["calories","fat","carbohydrates","protein","fiber"],"title":"NutritionCreate","description":"Schema for creating nutrition data."},"PossibleIngredientTag":{"properties":{"id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Id"},"name":{"type":"string","title":"Name"}},"type":"object","required":["name"],"title":"PossibleIngredientTag","description":"Tag that can be associated with an ingredient."},"PossibleMealTag":{"properties":{"id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Id"},"name":{"type":"string","title":"Name"}},"type":"object","required":["name"],"title":"PossibleMealTag","description":"Tag that can be associated with a meal."},"TagRef":{"properties":{"id":{"type":"integer","title":"Id"}},"type":"object","required":["id"],"title":"TagRef","description":"Reference to an existing tag by ID."},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/ingredients/": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get All Ingredients",
+        "description": "Return all ingredients.",
+        "operationId": "get_all_ingredients_api_ingredients__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/IngredientRead"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Ingredients Api Ingredients  Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Add Ingredient",
+        "description": "Create a new ingredient.",
+        "operationId": "add_ingredient_api_ingredients__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngredientCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ingredients/possible_tags": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get All Possible Tags",
+        "description": "Return all possible ingredient tags ordered by name.",
+        "operationId": "get_all_possible_tags_api_ingredients_possible_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PossibleIngredientTag"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Possible Tags Api Ingredients Possible Tags Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ingredients/{ingredient_id}": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get Ingredient",
+        "description": "Retrieve a single ingredient by ID.",
+        "operationId": "get_ingredient_api_ingredients__ingredient_id__get",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Update Ingredient",
+        "description": "Update an existing ingredient.",
+        "operationId": "update_ingredient_api_ingredients__ingredient_id__put",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngredientUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Delete Ingredient",
+        "description": "Delete an ingredient.",
+        "operationId": "delete_ingredient_api_ingredients__ingredient_id__delete",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Ingredient Api Ingredients  Ingredient Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/foods/": {
+      "get": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Get All Foods",
+        "description": "Return all foods.",
+        "operationId": "get_all_foods_api_foods__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoodRead"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Foods Api Foods  Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Add Food",
+        "description": "Create a new food.",
+        "operationId": "add_food_api_foods__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoodCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoodRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/foods/possible_tags": {
+      "get": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Get Possible Food Tags",
+        "description": "Return all possible food tags ordered by name.",
+        "operationId": "get_possible_food_tags_api_foods_possible_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PossibleFoodTag"
+                  },
+                  "type": "array",
+                  "title": "Response Get Possible Food Tags Api Foods Possible Tags Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/foods/{food_id}": {
+      "get": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Get Food",
+        "description": "Retrieve a single food by ID.",
+        "operationId": "get_food_api_foods__food_id__get",
+        "parameters": [
+          {
+            "name": "food_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Food Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoodRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Update Food",
+        "description": "Update an existing food.",
+        "operationId": "update_food_api_foods__food_id__put",
+        "parameters": [
+          {
+            "name": "food_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Food Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoodUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoodRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Delete Food",
+        "description": "Delete a food.",
+        "operationId": "delete_food_api_foods__food_id__delete",
+        "parameters": [
+          {
+            "name": "food_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Food Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Food Api Foods  Food Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FoodCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ingredients": {
+            "items": {
+              "$ref": "#/components/schemas/FoodIngredientCreate"
+            },
+            "type": "array",
+            "title": "Ingredients"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "FoodCreate",
+        "description": "Schema for creating a food."
+      },
+      "FoodIngredient": {
+        "properties": {
+          "ingredient_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingredient Id"
+          },
+          "food_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Food Id"
+          },
+          "unit_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Id"
+          },
+          "unit_quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Quantity"
+          }
+        },
+        "type": "object",
+        "title": "FoodIngredient",
+        "description": "Link between a food and an ingredient with quantity information."
+      },
+      "FoodIngredientCreate": {
+        "properties": {
+          "ingredient_id": {
+            "type": "integer",
+            "title": "Ingredient Id"
+          },
+          "unit_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Id"
+          },
+          "unit_quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Quantity"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ingredient_id"
+        ],
+        "title": "FoodIngredientCreate",
+        "description": "Schema for creating food ingredient linkage."
+      },
+      "FoodRead": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ingredients": {
+            "items": {
+              "$ref": "#/components/schemas/FoodIngredient"
+            },
+            "type": "array",
+            "title": "Ingredients"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/PossibleFoodTag"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "FoodRead",
+        "description": "Schema for reading food data."
+      },
+      "FoodUpdate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ingredients": {
+            "items": {
+              "$ref": "#/components/schemas/FoodIngredientCreate"
+            },
+            "type": "array",
+            "title": "Ingredients"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "FoodUpdate",
+        "description": "Schema for updating a food."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "IngredientCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "nutrition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NutritionCreate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "units": {
+            "items": {
+              "$ref": "#/components/schemas/IngredientUnitCreate"
+            },
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "IngredientCreate",
+        "description": "Schema for creating an ingredient."
+      },
+      "IngredientRead": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "nutrition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Nutrition"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "units": {
+            "items": {
+              "$ref": "#/components/schemas/IngredientUnit"
+            },
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/PossibleIngredientTag"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "IngredientRead",
+        "description": "Schema for reading ingredient data."
+      },
+      "IngredientUnit": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "ingredient_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingredient Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "grams": {
+            "type": "number",
+            "title": "Grams"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "grams"
+        ],
+        "title": "IngredientUnit",
+        "description": "Measurement unit for an ingredient."
+      },
+      "IngredientUnitCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "grams": {
+            "type": "number",
+            "title": "Grams"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "grams"
+        ],
+        "title": "IngredientUnitCreate",
+        "description": "Schema for creating ingredient unit data."
+      },
+      "IngredientUpdate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "nutrition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NutritionCreate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "units": {
+            "items": {
+              "$ref": "#/components/schemas/IngredientUnitCreate"
+            },
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "IngredientUpdate",
+        "description": "Schema for updating an ingredient."
+      },
+      "Nutrition": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "ingredient_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingredient Id"
+          },
+          "calories": {
+            "type": "number",
+            "title": "Calories"
+          },
+          "fat": {
+            "type": "number",
+            "title": "Fat"
+          },
+          "carbohydrates": {
+            "type": "number",
+            "title": "Carbohydrates"
+          },
+          "protein": {
+            "type": "number",
+            "title": "Protein"
+          },
+          "fiber": {
+            "type": "number",
+            "title": "Fiber"
+          }
+        },
+        "type": "object",
+        "required": [
+          "calories",
+          "fat",
+          "carbohydrates",
+          "protein",
+          "fiber"
+        ],
+        "title": "Nutrition",
+        "description": "Nutritional information for a single ingredient."
+      },
+      "NutritionCreate": {
+        "properties": {
+          "calories": {
+            "type": "number",
+            "title": "Calories"
+          },
+          "fat": {
+            "type": "number",
+            "title": "Fat"
+          },
+          "carbohydrates": {
+            "type": "number",
+            "title": "Carbohydrates"
+          },
+          "protein": {
+            "type": "number",
+            "title": "Protein"
+          },
+          "fiber": {
+            "type": "number",
+            "title": "Fiber"
+          }
+        },
+        "type": "object",
+        "required": [
+          "calories",
+          "fat",
+          "carbohydrates",
+          "protein",
+          "fiber"
+        ],
+        "title": "NutritionCreate",
+        "description": "Schema for creating nutrition data."
+      },
+      "PossibleFoodTag": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "PossibleFoodTag",
+        "description": "Tag that can be associated with a food."
+      },
+      "PossibleIngredientTag": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "PossibleIngredientTag",
+        "description": "Tag that can be associated with an ingredient."
+      },
+      "TagRef": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "TagRef",
+        "description": "Reference to an existing tag by ID."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/Backend/tests/test_full_payloads.py
+++ b/Backend/tests/test_full_payloads.py
@@ -89,13 +89,13 @@ def test_full_ingredient_crud(client: TestClient, engine) -> None:
 
 def test_full_food_crud(client: TestClient, engine) -> None:
     with Session(engine) as session:
-        meal_tag1 = PossibleFoodTag(name="Breakfast")
-        meal_tag2 = PossibleFoodTag(name="Healthy")
+        food_tag1 = PossibleFoodTag(name="Breakfast")
+        food_tag2 = PossibleFoodTag(name="Healthy")
         ing_tag = PossibleIngredientTag(name="Vegetable")
-        session.add_all([meal_tag1, meal_tag2, ing_tag])
+        session.add_all([food_tag1, food_tag2, ing_tag])
         session.commit()
-        meal_tag1_id = meal_tag1.id
-        meal_tag2_id = meal_tag2.id
+        food_tag1_id = food_tag1.id
+        food_tag2_id = food_tag2.id
         ing_tag_id = ing_tag.id
 
     ingredient_payload = {
@@ -126,42 +126,42 @@ def test_full_food_crud(client: TestClient, engine) -> None:
                 "unit_quantity": 2.0,
             }
         ],
-        "tags": [{"id": meal_tag1_id}, {"id": meal_tag2_id}],
+        "tags": [{"id": food_tag1_id}, {"id": food_tag2_id}],
     }
 
     response = client.post("/api/foods", json=food_payload)
     assert response.status_code == 201
     food = response.json()
-    meal_id = food["id"]
+    food_id = food["id"]
     assert food["ingredients"][0]["unit_quantity"] == pytest.approx(2.0)
     assert {t["name"] for t in food["tags"]} == {"Breakfast", "Healthy"}
 
-    response = client.get(f"/api/foods/{meal_id}")
+    response = client.get(f"/api/foods/{food_id}")
     assert response.status_code == 200
     fetched = response.json()
 
     update_payload = {
-        "id": meal_id,
+        "id": food_id,
         "name": "Onion Omelette Deluxe",
         "ingredients": [
             {
                 "ingredient_id": ingredient_id,
-                "food_id": meal_id,
+                "food_id": food_id,
                 "unit_id": unit_id,
                 "unit_quantity": 3.0,
             }
         ],
-        "tags": [{"id": meal_tag1_id}],
+        "tags": [{"id": food_tag1_id}],
     }
 
-    response = client.put(f"/api/foods/{meal_id}", json=update_payload)
+    response = client.put(f"/api/foods/{food_id}", json=update_payload)
     assert response.status_code == 200
     updated = response.json()
     assert updated["name"] == "Onion Omelette Deluxe"
     assert updated["ingredients"][0]["unit_quantity"] == pytest.approx(3.0)
     assert len(updated["tags"]) == 1 and updated["tags"][0]["name"] == "Breakfast"
 
-    response = client.delete(f"/api/foods/{meal_id}")
+    response = client.delete(f"/api/foods/{food_id}")
     assert response.status_code == 200
-    response = client.get(f"/api/foods/{meal_id}")
+    response = client.get(f"/api/foods/{food_id}")
     assert response.status_code == 404


### PR DESCRIPTION
## Summary
- update OpenAPI spec to expose `/foods` endpoints and `Food*` schemas
- rename leftover meal references in full payload test to food terminology

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b775f942d88322a63f4580edc1f496