### PR TITLE
Replace meal references with food and clarify migration steps

### DIFF
--- a/Backend/migrations/versions/3a2af5cf8e9b_rename_meal_to_food.py
+++ b/Backend/migrations/versions/3a2af5cf8e9b_rename_meal_to_food.py
@@ -1,4 +1,4 @@
-"""rename meal tables to food"""
+"""rename tables to food"""
 
 from alembic import op
 import sqlalchemy as sa

--- a/Backend/migrations/versions/4f3a5b7c9d01_merge_heads_constraints_and_rename.py
+++ b/Backend/migrations/versions/4f3a5b7c9d01_merge_heads_constraints_and_rename.py
@@ -2,7 +2,7 @@
 
 This merge unifies two independent branches:
 - 2ea617f76053: restore ingredient_id non-null
-- 3a2af5cf8e9b: rename meal tables to food
+- 3a2af5cf8e9b: rename tables to food
 
 No schema changes are applied in this merge; it only reconciles history
 so that future upgrades can target a single head.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,6 +308,8 @@ Before opening a PR:
 * [ ] **Models changed?**
   Run `pwsh ./scripts/db/sync-api-and-migrations.ps1`
   → Commit any new migration(s), `Backend/openapi.json`, `Frontend/src/api-types.ts`
+* [ ] **API endpoints updated?**
+  Confirm new paths (e.g., `/foods`) after running migrations and update docs and clients as needed.
 * [ ] **Frontend API usage added/changed?**
   Ensure `Frontend/src/api-types.ts` is current (via the sync script)
 * [ ] **Migrations apply cleanly?**

--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ Nutrition/
 
 Every ingredient response automatically includes a synthetic `1g` unit for convenience.
 
-**Meals**
+**Foods**
 
-- `GET /meals` – list all
-- `GET /meals/{id}` – single meal
-- `GET /meals/possible_tags` – list tags
-- `POST /meals` – add new
-- `PUT /meals/{id}` – update
-- `DELETE /meals/{id}` – remove
+- `GET /foods` – list all
+- `GET /foods/{id}` – single food
+- `GET /foods/possible_tags` – list tags
+- `POST /foods` – add new
+- `PUT /foods/{id}` – update
+- `DELETE /foods/{id}` – remove
 
 ---
 
@@ -139,10 +139,10 @@ erDiagram
   INGREDIENT ||--|| NUTRITION : contains
   INGREDIENT ||--o{ INGREDIENT_TAG : tagged_with
   INGREDIENT_TAG }o--|| POSSIBLE_INGREDIENT_TAG : references
-  MEAL ||--o{ MEAL_INGREDIENT : includes
-  MEAL_INGREDIENT }o--|| INGREDIENT : uses
-  MEAL ||--o{ MEAL_TAG : tagged_with
-  MEAL_TAG }o--|| POSSIBLE_MEAL_TAG : references
+  FOOD ||--o{ FOOD_INGREDIENT : includes
+  FOOD_INGREDIENT }o--|| INGREDIENT : uses
+  FOOD ||--o{ FOOD_TAG : tagged_with
+  FOOD_TAG }o--|| POSSIBLE_FOOD_TAG : references
 ```
 
 </details>
@@ -153,7 +153,7 @@ erDiagram
 ```mermaid
 classDiagram
   class Ingredient { id; name; Nutrition nutrition; IngredientUnit[] units }
-  class Meal { id; name; MealIngredient[] ingredients; MealTag[] tags }
+  class Food { id; name; FoodIngredient[] ingredients; FoodTag[] tags }
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- replace remaining "Meal" docs with "Food" and update API examples
- scrub old terminology from migration comments
- note migration and `/foods` endpoint updates in contributor guide

## Testing
- `pytest`
- `CI=true npm --prefix Frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b77f132d608322aab148aa4d65231e