### PR TITLE
Add grouped tag CRUD endpoints for ingredients and meals

### DIFF
--- a/Backend/models/possible_ingredient_tag.py
+++ b/Backend/models/possible_ingredient_tag.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from sqlmodel import SQLModel, Field, Relationship
-from sqlalchemy import Column, String
+from sqlalchemy import Column, String, UniqueConstraint
 
 from .ingredient_tag import IngredientTagLink
 
@@ -10,9 +10,11 @@ class PossibleIngredientTag(SQLModel, table=True):
     """Tag that can be associated with an ingredient."""
 
     __tablename__ = "possible_ingredient_tags"
+    __table_args__ = (UniqueConstraint("name", "group"),)
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(sa_column=Column(String(50), unique=True, nullable=False))
+    name: str = Field(sa_column=Column(String(50), nullable=False))
+    group: str = Field(sa_column=Column(String(50), nullable=False))
 
     ingredients: List["Ingredient"] = Relationship(
         back_populates="tags", link_model=IngredientTagLink

--- a/Backend/models/possible_meal_tag.py
+++ b/Backend/models/possible_meal_tag.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from sqlmodel import SQLModel, Field, Relationship
-from sqlalchemy import Column, String
+from sqlalchemy import Column, String, UniqueConstraint
 
 from .meal_tag import MealTagLink
 
@@ -10,9 +10,11 @@ class PossibleMealTag(SQLModel, table=True):
     """Tag that can be associated with a meal."""
 
     __tablename__ = "possible_meal_tags"
+    __table_args__ = (UniqueConstraint("name", "group"),)
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(sa_column=Column(String(50), unique=True, nullable=False))
+    name: str = Field(sa_column=Column(String(50), nullable=False))
+    group: str = Field(sa_column=Column(String(50), nullable=False))
 
     meals: List["Meal"] = Relationship(
         back_populates="tags", link_model=MealTagLink

--- a/Backend/models/schemas.py
+++ b/Backend/models/schemas.py
@@ -41,6 +41,34 @@ class TagRef(SQLModel):
     id: int
 
 
+class PossibleIngredientTagCreate(SQLModel):
+    """Schema for creating a possible ingredient tag."""
+
+    name: str
+    group: str
+
+
+class PossibleIngredientTagUpdate(SQLModel):
+    """Schema for updating a possible ingredient tag."""
+
+    name: Optional[str] = None
+    group: Optional[str] = None
+
+
+class PossibleMealTagCreate(SQLModel):
+    """Schema for creating a possible meal tag."""
+
+    name: str
+    group: str
+
+
+class PossibleMealTagUpdate(SQLModel):
+    """Schema for updating a possible meal tag."""
+
+    name: Optional[str] = None
+    group: Optional[str] = None
+
+
 class IngredientCreate(SQLModel):
     """Schema for creating an ingredient."""
 
@@ -98,6 +126,10 @@ __all__ = [
     "IngredientUnitCreate",
     "MealIngredientCreate",
     "TagRef",
+    "PossibleIngredientTagCreate",
+    "PossibleIngredientTagUpdate",
+    "PossibleMealTagCreate",
+    "PossibleMealTagUpdate",
     "IngredientCreate",
     "IngredientUpdate",
     "IngredientRead",

--- a/Backend/openapi.json
+++ b/Backend/openapi.json
@@ -1,1 +1,1404 @@
-{"openapi":"3.1.0","info":{"title":"FastAPI","version":"0.1.0"},"paths":{"/api/ingredients/":{"get":{"tags":["ingredients"],"summary":"Get All Ingredients","description":"Return all ingredients.","operationId":"get_all_ingredients_api_ingredients__get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/IngredientRead"},"type":"array","title":"Response Get All Ingredients Api Ingredients  Get"}}}}}},"post":{"tags":["ingredients"],"summary":"Add Ingredient","description":"Create a new ingredient.","operationId":"add_ingredient_api_ingredients__post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientCreate"}}},"required":true},"responses":{"201":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/ingredients/possible_tags":{"get":{"tags":["ingredients"],"summary":"Get All Possible Tags","description":"Return all possible ingredient tags ordered by name.","operationId":"get_all_possible_tags_api_ingredients_possible_tags_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/PossibleIngredientTag"},"type":"array","title":"Response Get All Possible Tags Api Ingredients Possible Tags Get"}}}}}}},"/api/ingredients/{ingredient_id}":{"get":{"tags":["ingredients"],"summary":"Get Ingredient","description":"Retrieve a single ingredient by ID.","operationId":"get_ingredient_api_ingredients__ingredient_id__get","parameters":[{"name":"ingredient_id","in":"path","required":true,"schema":{"type":"integer","title":"Ingredient Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["ingredients"],"summary":"Update Ingredient","description":"Update an existing ingredient.","operationId":"update_ingredient_api_ingredients__ingredient_id__put","parameters":[{"name":"ingredient_id","in":"path","required":true,"schema":{"type":"integer","title":"Ingredient Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/IngredientRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["ingredients"],"summary":"Delete Ingredient","description":"Delete an ingredient.","operationId":"delete_ingredient_api_ingredients__ingredient_id__delete","parameters":[{"name":"ingredient_id","in":"path","required":true,"schema":{"type":"integer","title":"Ingredient Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Ingredient Api Ingredients  Ingredient Id  Delete"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/meals/":{"get":{"tags":["meals"],"summary":"Get All Meals","description":"Return all meals.","operationId":"get_all_meals_api_meals__get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/MealRead"},"type":"array","title":"Response Get All Meals Api Meals  Get"}}}}}},"post":{"tags":["meals"],"summary":"Add Meal","description":"Create a new meal.","operationId":"add_meal_api_meals__post","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealCreate"}}},"required":true},"responses":{"201":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/meals/possible_tags":{"get":{"tags":["meals"],"summary":"Get Possible Meal Tags","description":"Return all possible meal tags ordered by name.","operationId":"get_possible_meal_tags_api_meals_possible_tags_get","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/PossibleMealTag"},"type":"array","title":"Response Get Possible Meal Tags Api Meals Possible Tags Get"}}}}}}},"/api/meals/{meal_id}":{"get":{"tags":["meals"],"summary":"Get Meal","description":"Retrieve a single meal by ID.","operationId":"get_meal_api_meals__meal_id__get","parameters":[{"name":"meal_id","in":"path","required":true,"schema":{"type":"integer","title":"Meal Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["meals"],"summary":"Update Meal","description":"Update an existing meal.","operationId":"update_meal_api_meals__meal_id__put","parameters":[{"name":"meal_id","in":"path","required":true,"schema":{"type":"integer","title":"Meal Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MealRead"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["meals"],"summary":"Delete Meal","description":"Delete a meal.","operationId":"delete_meal_api_meals__meal_id__delete","parameters":[{"name":"meal_id","in":"path","required":true,"schema":{"type":"integer","title":"Meal Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"object","additionalProperties":true,"title":"Response Delete Meal Api Meals  Meal Id  Delete"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}}},"components":{"schemas":{"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"IngredientCreate":{"properties":{"name":{"type":"string","title":"Name"},"nutrition":{"anyOf":[{"$ref":"#/components/schemas/NutritionCreate"},{"type":"null"}]},"units":{"items":{"$ref":"#/components/schemas/IngredientUnitCreate"},"type":"array","title":"Units"},"tags":{"items":{"$ref":"#/components/schemas/TagRef"},"type":"array","title":"Tags"}},"type":"object","required":["name"],"title":"IngredientCreate","description":"Schema for creating an ingredient."},"IngredientRead":{"properties":{"id":{"type":"integer","title":"Id"},"name":{"type":"string","title":"Name"},"nutrition":{"anyOf":[{"$ref":"#/components/schemas/Nutrition"},{"type":"null"}]},"units":{"items":{"$ref":"#/components/schemas/IngredientUnit"},"type":"array","title":"Units"},"tags":{"items":{"$ref":"#/components/schemas/PossibleIngredientTag"},"type":"array","title":"Tags"}},"type":"object","required":["id","name"],"title":"IngredientRead","description":"Schema for reading ingredient data."},"IngredientUnit":{"properties":{"id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Id"},"ingredient_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Ingredient Id"},"name":{"type":"string","title":"Name"},"grams":{"type":"number","title":"Grams"}},"type":"object","required":["name","grams"],"title":"IngredientUnit","description":"Measurement unit for an ingredient."},"IngredientUnitCreate":{"properties":{"name":{"type":"string","title":"Name"},"grams":{"type":"number","title":"Grams"}},"type":"object","required":["name","grams"],"title":"IngredientUnitCreate","description":"Schema for creating ingredient unit data."},"IngredientUpdate":{"properties":{"name":{"type":"string","title":"Name"},"nutrition":{"anyOf":[{"$ref":"#/components/schemas/NutritionCreate"},{"type":"null"}]},"units":{"items":{"$ref":"#/components/schemas/IngredientUnitCreate"},"type":"array","title":"Units"},"tags":{"items":{"$ref":"#/components/schemas/TagRef"},"type":"array","title":"Tags"}},"type":"object","required":["name"],"title":"IngredientUpdate","description":"Schema for updating an ingredient."},"MealCreate":{"properties":{"name":{"type":"string","title":"Name"},"ingredients":{"items":{"$ref":"#/components/schemas/MealIngredientCreate"},"type":"array","title":"Ingredients"},"tags":{"items":{"$ref":"#/components/schemas/TagRef"},"type":"array","title":"Tags"}},"type":"object","required":["name"],"title":"MealCreate","description":"Schema for creating a meal."},"MealIngredient":{"properties":{"ingredient_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Ingredient Id"},"meal_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Meal Id"},"unit_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Unit Id"},"unit_quantity":{"anyOf":[{"type":"number"},{"type":"null"}],"title":"Unit Quantity"}},"type":"object","title":"MealIngredient","description":"Link between a meal and an ingredient with quantity information."},"MealIngredientCreate":{"properties":{"ingredient_id":{"type":"integer","title":"Ingredient Id"},"unit_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Unit Id"},"unit_quantity":{"anyOf":[{"type":"number"},{"type":"null"}],"title":"Unit Quantity"}},"type":"object","required":["ingredient_id"],"title":"MealIngredientCreate","description":"Schema for creating meal ingredient linkage."},"MealRead":{"properties":{"id":{"type":"integer","title":"Id"},"name":{"type":"string","title":"Name"},"ingredients":{"items":{"$ref":"#/components/schemas/MealIngredient"},"type":"array","title":"Ingredients"},"tags":{"items":{"$ref":"#/components/schemas/PossibleMealTag"},"type":"array","title":"Tags"}},"type":"object","required":["id","name"],"title":"MealRead","description":"Schema for reading meal data."},"MealUpdate":{"properties":{"name":{"type":"string","title":"Name"},"ingredients":{"items":{"$ref":"#/components/schemas/MealIngredientCreate"},"type":"array","title":"Ingredients"},"tags":{"items":{"$ref":"#/components/schemas/TagRef"},"type":"array","title":"Tags"}},"type":"object","required":["name"],"title":"MealUpdate","description":"Schema for updating a meal."},"Nutrition":{"properties":{"id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Id"},"ingredient_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Ingredient Id"},"calories":{"type":"number","title":"Calories"},"fat":{"type":"number","title":"Fat"},"carbohydrates":{"type":"number","title":"Carbohydrates"},"protein":{"type":"number","title":"Protein"},"fiber":{"type":"number","title":"Fiber"}},"type":"object","required":["calories","fat","carbohydrates","protein","fiber"],"title":"Nutrition","description":"Nutritional information for a single ingredient."},"NutritionCreate":{"properties":{"calories":{"type":"number","title":"Calories"},"fat":{"type":"number","title":"Fat"},"carbohydrates":{"type":"number","title":"Carbohydrates"},"protein":{"type":"number","title":"Protein"},"fiber":{"type":"number","title":"Fiber"}},"type":"object","required":["calories","fat","carbohydrates","protein","fiber"],"title":"NutritionCreate","description":"Schema for creating nutrition data."},"PossibleIngredientTag":{"properties":{"id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Id"},"name":{"type":"string","title":"Name"}},"type":"object","required":["name"],"title":"PossibleIngredientTag","description":"Tag that can be associated with an ingredient."},"PossibleMealTag":{"properties":{"id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Id"},"name":{"type":"string","title":"Name"}},"type":"object","required":["name"],"title":"PossibleMealTag","description":"Tag that can be associated with a meal."},"TagRef":{"properties":{"id":{"type":"integer","title":"Id"}},"type":"object","required":["id"],"title":"TagRef","description":"Reference to an existing tag by ID."},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/ingredients/": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get All Ingredients",
+        "description": "Return all ingredients.",
+        "operationId": "get_all_ingredients_api_ingredients__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/IngredientRead"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Ingredients Api Ingredients  Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Add Ingredient",
+        "description": "Create a new ingredient.",
+        "operationId": "add_ingredient_api_ingredients__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngredientCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ingredients/possible_tags": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get All Possible Tags",
+        "description": "Return all possible ingredient tags ordered by name.",
+        "operationId": "get_all_possible_tags_api_ingredients_possible_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PossibleIngredientTag"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Possible Tags Api Ingredients Possible Tags Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Create Possible Tag",
+        "description": "Create a new possible ingredient tag.",
+        "operationId": "create_possible_tag_api_ingredients_possible_tags_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PossibleIngredientTagCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PossibleIngredientTag"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ingredients/possible_tags/{tag_id}": {
+      "put": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Update Possible Tag",
+        "description": "Update an existing possible ingredient tag.",
+        "operationId": "update_possible_tag_api_ingredients_possible_tags__tag_id__put",
+        "parameters": [
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PossibleIngredientTagUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PossibleIngredientTag"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Delete Possible Tag",
+        "description": "Delete a possible ingredient tag if not linked.",
+        "operationId": "delete_possible_tag_api_ingredients_possible_tags__tag_id__delete",
+        "parameters": [
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Possible Tag Api Ingredients Possible Tags  Tag Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ingredients/{ingredient_id}": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get Ingredient",
+        "description": "Retrieve a single ingredient by ID.",
+        "operationId": "get_ingredient_api_ingredients__ingredient_id__get",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Update Ingredient",
+        "description": "Update an existing ingredient.",
+        "operationId": "update_ingredient_api_ingredients__ingredient_id__put",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngredientUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Delete Ingredient",
+        "description": "Delete an ingredient.",
+        "operationId": "delete_ingredient_api_ingredients__ingredient_id__delete",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Ingredient Api Ingredients  Ingredient Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/meals/": {
+      "get": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Get All Meals",
+        "description": "Return all meals.",
+        "operationId": "get_all_meals_api_meals__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MealRead"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Meals Api Meals  Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Add Meal",
+        "description": "Create a new meal.",
+        "operationId": "add_meal_api_meals__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MealCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MealRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/meals/possible_tags": {
+      "get": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Get Possible Meal Tags",
+        "description": "Return all possible meal tags ordered by name.",
+        "operationId": "get_possible_meal_tags_api_meals_possible_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PossibleMealTag"
+                  },
+                  "type": "array",
+                  "title": "Response Get Possible Meal Tags Api Meals Possible Tags Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Create Possible Meal Tag",
+        "description": "Create a new possible meal tag.",
+        "operationId": "create_possible_meal_tag_api_meals_possible_tags_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PossibleMealTagCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PossibleMealTag"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/meals/possible_tags/{tag_id}": {
+      "put": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Update Possible Meal Tag",
+        "description": "Update an existing possible meal tag.",
+        "operationId": "update_possible_meal_tag_api_meals_possible_tags__tag_id__put",
+        "parameters": [
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PossibleMealTagUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PossibleMealTag"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Delete Possible Meal Tag",
+        "description": "Delete a possible meal tag if not linked.",
+        "operationId": "delete_possible_meal_tag_api_meals_possible_tags__tag_id__delete",
+        "parameters": [
+          {
+            "name": "tag_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Tag Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Possible Meal Tag Api Meals Possible Tags  Tag Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/meals/{meal_id}": {
+      "get": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Get Meal",
+        "description": "Retrieve a single meal by ID.",
+        "operationId": "get_meal_api_meals__meal_id__get",
+        "parameters": [
+          {
+            "name": "meal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Meal Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MealRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Update Meal",
+        "description": "Update an existing meal.",
+        "operationId": "update_meal_api_meals__meal_id__put",
+        "parameters": [
+          {
+            "name": "meal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Meal Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MealUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MealRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "meals"
+        ],
+        "summary": "Delete Meal",
+        "description": "Delete a meal.",
+        "operationId": "delete_meal_api_meals__meal_id__delete",
+        "parameters": [
+          {
+            "name": "meal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Meal Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Meal Api Meals  Meal Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "IngredientCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "nutrition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NutritionCreate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "units": {
+            "items": {
+              "$ref": "#/components/schemas/IngredientUnitCreate"
+            },
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "IngredientCreate",
+        "description": "Schema for creating an ingredient."
+      },
+      "IngredientRead": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "nutrition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Nutrition"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "units": {
+            "items": {
+              "$ref": "#/components/schemas/IngredientUnit"
+            },
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/PossibleIngredientTag"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "IngredientRead",
+        "description": "Schema for reading ingredient data."
+      },
+      "IngredientUnit": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "ingredient_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingredient Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "grams": {
+            "type": "number",
+            "title": "Grams"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "grams"
+        ],
+        "title": "IngredientUnit",
+        "description": "Measurement unit for an ingredient."
+      },
+      "IngredientUnitCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "grams": {
+            "type": "number",
+            "title": "Grams"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "grams"
+        ],
+        "title": "IngredientUnitCreate",
+        "description": "Schema for creating ingredient unit data."
+      },
+      "IngredientUpdate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "nutrition": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NutritionCreate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "units": {
+            "items": {
+              "$ref": "#/components/schemas/IngredientUnitCreate"
+            },
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "IngredientUpdate",
+        "description": "Schema for updating an ingredient."
+      },
+      "MealCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ingredients": {
+            "items": {
+              "$ref": "#/components/schemas/MealIngredientCreate"
+            },
+            "type": "array",
+            "title": "Ingredients"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "MealCreate",
+        "description": "Schema for creating a meal."
+      },
+      "MealIngredient": {
+        "properties": {
+          "ingredient_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingredient Id"
+          },
+          "meal_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meal Id"
+          },
+          "unit_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Id"
+          },
+          "unit_quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Quantity"
+          }
+        },
+        "type": "object",
+        "title": "MealIngredient",
+        "description": "Link between a meal and an ingredient with quantity information."
+      },
+      "MealIngredientCreate": {
+        "properties": {
+          "ingredient_id": {
+            "type": "integer",
+            "title": "Ingredient Id"
+          },
+          "unit_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Id"
+          },
+          "unit_quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Quantity"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ingredient_id"
+        ],
+        "title": "MealIngredientCreate",
+        "description": "Schema for creating meal ingredient linkage."
+      },
+      "MealRead": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ingredients": {
+            "items": {
+              "$ref": "#/components/schemas/MealIngredient"
+            },
+            "type": "array",
+            "title": "Ingredients"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/PossibleMealTag"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "MealRead",
+        "description": "Schema for reading meal data."
+      },
+      "MealUpdate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "ingredients": {
+            "items": {
+              "$ref": "#/components/schemas/MealIngredientCreate"
+            },
+            "type": "array",
+            "title": "Ingredients"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "MealUpdate",
+        "description": "Schema for updating a meal."
+      },
+      "Nutrition": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "ingredient_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingredient Id"
+          },
+          "calories": {
+            "type": "number",
+            "title": "Calories"
+          },
+          "fat": {
+            "type": "number",
+            "title": "Fat"
+          },
+          "carbohydrates": {
+            "type": "number",
+            "title": "Carbohydrates"
+          },
+          "protein": {
+            "type": "number",
+            "title": "Protein"
+          },
+          "fiber": {
+            "type": "number",
+            "title": "Fiber"
+          }
+        },
+        "type": "object",
+        "required": [
+          "calories",
+          "fat",
+          "carbohydrates",
+          "protein",
+          "fiber"
+        ],
+        "title": "Nutrition",
+        "description": "Nutritional information for a single ingredient."
+      },
+      "NutritionCreate": {
+        "properties": {
+          "calories": {
+            "type": "number",
+            "title": "Calories"
+          },
+          "fat": {
+            "type": "number",
+            "title": "Fat"
+          },
+          "carbohydrates": {
+            "type": "number",
+            "title": "Carbohydrates"
+          },
+          "protein": {
+            "type": "number",
+            "title": "Protein"
+          },
+          "fiber": {
+            "type": "number",
+            "title": "Fiber"
+          }
+        },
+        "type": "object",
+        "required": [
+          "calories",
+          "fat",
+          "carbohydrates",
+          "protein",
+          "fiber"
+        ],
+        "title": "NutritionCreate",
+        "description": "Schema for creating nutrition data."
+      },
+      "PossibleIngredientTag": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "group": {
+            "type": "string",
+            "title": "Group"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "group"
+        ],
+        "title": "PossibleIngredientTag",
+        "description": "Tag that can be associated with an ingredient."
+      },
+      "PossibleIngredientTagCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "group": {
+            "type": "string",
+            "title": "Group"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "group"
+        ],
+        "title": "PossibleIngredientTagCreate",
+        "description": "Schema for creating a possible ingredient tag."
+      },
+      "PossibleIngredientTagUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group"
+          }
+        },
+        "type": "object",
+        "title": "PossibleIngredientTagUpdate",
+        "description": "Schema for updating a possible ingredient tag."
+      },
+      "PossibleMealTag": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "group": {
+            "type": "string",
+            "title": "Group"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "group"
+        ],
+        "title": "PossibleMealTag",
+        "description": "Tag that can be associated with a meal."
+      },
+      "PossibleMealTagCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "group": {
+            "type": "string",
+            "title": "Group"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "group"
+        ],
+        "title": "PossibleMealTagCreate",
+        "description": "Schema for creating a possible meal tag."
+      },
+      "PossibleMealTagUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "group": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group"
+          }
+        },
+        "type": "object",
+        "title": "PossibleMealTagUpdate",
+        "description": "Schema for updating a possible meal tag."
+      },
+      "TagRef": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "TagRef",
+        "description": "Reference to an existing tag by ID."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/Backend/routes/meals.py
+++ b/Backend/routes/meals.py
@@ -5,9 +5,16 @@ from sqlmodel import Session, select
 from sqlalchemy.orm import selectinload
 
 from sqlalchemy import delete
+from sqlalchemy.exc import IntegrityError
 from ..db import get_db
 from ..models import Meal, PossibleMealTag, Ingredient, MealIngredient
-from ..models.schemas import MealCreate, MealRead, MealUpdate
+from ..models.schemas import (
+    MealCreate,
+    MealRead,
+    MealUpdate,
+    PossibleMealTagCreate,
+    PossibleMealTagUpdate,
+)
 
 router = APIRouter(prefix="/meals", tags=["meals"])
 
@@ -24,6 +31,59 @@ def get_possible_meal_tags(db: Session = Depends(get_db)) -> List[PossibleMealTa
     """Return all possible meal tags ordered by name."""
     statement = select(PossibleMealTag).order_by(PossibleMealTag.name)
     return db.exec(statement).all()
+
+
+@router.post("/possible_tags", response_model=PossibleMealTag, status_code=201)
+def create_possible_meal_tag(
+    tag: PossibleMealTagCreate, db: Session = Depends(get_db)
+) -> PossibleMealTag:
+    """Create a new possible meal tag."""
+    tag_obj = PossibleMealTag.model_validate(tag.model_dump())
+    db.add(tag_obj)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Tag already exists")
+    db.refresh(tag_obj)
+    return tag_obj
+
+
+@router.put("/possible_tags/{tag_id}", response_model=PossibleMealTag)
+def update_possible_meal_tag(
+    tag_id: int, tag_data: PossibleMealTagUpdate, db: Session = Depends(get_db)
+) -> PossibleMealTag:
+    """Update an existing possible meal tag."""
+    tag = db.get(PossibleMealTag, tag_id)
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    if tag_data.name is not None:
+        tag.name = tag_data.name
+    if tag_data.group is not None:
+        tag.group = tag_data.group
+    db.add(tag)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Tag already exists")
+    db.refresh(tag)
+    return tag
+
+
+@router.delete("/possible_tags/{tag_id}")
+def delete_possible_meal_tag(tag_id: int, db: Session = Depends(get_db)) -> dict:
+    """Delete a possible meal tag if not linked."""
+    tag = db.get(PossibleMealTag, tag_id)
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    if tag.meals:
+        raise HTTPException(
+            status_code=400, detail="Tag is linked to meals and cannot be deleted"
+        )
+    db.delete(tag)
+    db.commit()
+    return {"message": "Tag deleted successfully"}
 
 
 @router.get("/{meal_id}", response_model=MealRead)

--- a/Backend/tests/test_endpoints.py
+++ b/Backend/tests/test_endpoints.py
@@ -27,19 +27,19 @@ def test_ingredient_endpoints(client: TestClient, engine, case: str) -> None:
     """Test ingredient API endpoints for various cases."""
     with Session(engine) as session:
         if case in {"list", "get", "put", "delete"}:
-            tag = PossibleIngredientTag(name="Spicy")
+            tag = PossibleIngredientTag(name="Spicy", group="Flavor")
             ingredient = Ingredient(name="Pepper", units=[], tags=[tag])
             session.add(tag)
             session.add(ingredient)
             session.commit()
             ingredient_id = ingredient.id
         elif case == "post":
-            tag = PossibleIngredientTag(name="Sweet")
+            tag = PossibleIngredientTag(name="Sweet", group="Flavor")
             session.add(tag)
             session.commit()
             tag_id = tag.id
         elif case == "possible_tags":
-            session.add(PossibleIngredientTag(name="Savory"))
+            session.add(PossibleIngredientTag(name="Savory", group="Flavor"))
             session.commit()
 
     if case == "list":
@@ -101,7 +101,7 @@ def test_meal_endpoints(client: TestClient, engine, case: str) -> None:
                 name="Rice",
                 units=[IngredientUnit(name="g", grams=1)],
             )
-            tag = PossibleMealTag(name="Dinner")
+            tag = PossibleMealTag(name="Dinner", group="Time")
             session.add_all([ingredient, tag])
             session.commit()
             ingredient_id = ingredient.id
@@ -125,14 +125,14 @@ def test_meal_endpoints(client: TestClient, engine, case: str) -> None:
                 name="Beans",
                 units=[IngredientUnit(name="g", grams=1)],
             )
-            tag = PossibleMealTag(name="Lunch")
+            tag = PossibleMealTag(name="Lunch", group="Time")
             session.add_all([ingredient, tag])
             session.commit()
             ingredient_id = ingredient.id
             unit_id = ingredient.units[0].id
             tag_id = tag.id
         elif case == "possible_tags":
-            session.add(PossibleMealTag(name="Snack"))
+            session.add(PossibleMealTag(name="Snack", group="Time"))
             session.commit()
 
     if case == "list":

--- a/Backend/tests/test_full_payloads.py
+++ b/Backend/tests/test_full_payloads.py
@@ -7,8 +7,8 @@ from Backend.models import PossibleIngredientTag, PossibleMealTag
 
 def test_full_ingredient_crud(client: TestClient, engine) -> None:
     with Session(engine) as session:
-        spicy = PossibleIngredientTag(name="Spicy")
-        sweet = PossibleIngredientTag(name="Sweet")
+        spicy = PossibleIngredientTag(name="Spicy", group="Flavor")
+        sweet = PossibleIngredientTag(name="Sweet", group="Flavor")
         session.add(spicy)
         session.add(sweet)
         session.commit()
@@ -89,9 +89,9 @@ def test_full_ingredient_crud(client: TestClient, engine) -> None:
 
 def test_full_meal_crud(client: TestClient, engine) -> None:
     with Session(engine) as session:
-        meal_tag1 = PossibleMealTag(name="Breakfast")
-        meal_tag2 = PossibleMealTag(name="Healthy")
-        ing_tag = PossibleIngredientTag(name="Vegetable")
+        meal_tag1 = PossibleMealTag(name="Breakfast", group="Time")
+        meal_tag2 = PossibleMealTag(name="Healthy", group="Health")
+        ing_tag = PossibleIngredientTag(name="Vegetable", group="Category")
         session.add_all([meal_tag1, meal_tag2, ing_tag])
         session.commit()
         meal_tag1_id = meal_tag1.id

--- a/Backend/tests/test_routes.py
+++ b/Backend/tests/test_routes.py
@@ -1,31 +1,118 @@
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
-from Backend.models import PossibleIngredientTag, PossibleMealTag
+from Backend.models import (
+    PossibleIngredientTag,
+    PossibleMealTag,
+    Ingredient,
+    Meal,
+)
 
 
 def test_get_possible_ingredient_tags(client: TestClient, engine) -> None:
     with Session(engine) as session:
-        session.add(PossibleIngredientTag(name="Spicy"))
-        session.add(PossibleIngredientTag(name="Sweet"))
+        session.add(PossibleIngredientTag(name="Spicy", group="Flavor"))
+        session.add(PossibleIngredientTag(name="Sweet", group="Flavor"))
         session.commit()
 
     response = client.get("/api/ingredients/possible_tags")
     assert response.status_code == 200
-    names = [tag["name"] for tag in response.json()]
+    data = response.json()
+    names = [tag["name"] for tag in data]
+    groups = [tag["group"] for tag in data]
     assert names == ["Spicy", "Sweet"]
+    assert groups == ["Flavor", "Flavor"]
 
 
 def test_get_possible_meal_tags(client: TestClient, engine) -> None:
     with Session(engine) as session:
-        session.add(PossibleMealTag(name="Breakfast"))
-        session.add(PossibleMealTag(name="Dinner"))
+        session.add(PossibleMealTag(name="Breakfast", group="Time"))
+        session.add(PossibleMealTag(name="Dinner", group="Time"))
         session.commit()
 
     response = client.get("/api/meals/possible_tags")
     assert response.status_code == 200
-    names = [tag["name"] for tag in response.json()]
+    data = response.json()
+    names = [tag["name"] for tag in data]
+    groups = [tag["group"] for tag in data]
     assert names == ["Breakfast", "Dinner"]
+    assert groups == ["Time", "Time"]
+
+
+def test_crud_possible_ingredient_tag(client: TestClient) -> None:
+    response = client.post(
+        "/api/ingredients/possible_tags",
+        json={"name": "Bitter", "group": "Flavor"},
+    )
+    assert response.status_code == 201
+    tag = response.json()
+    tag_id = tag["id"]
+    assert tag["group"] == "Flavor"
+
+    response = client.put(
+        f"/api/ingredients/possible_tags/{tag_id}",
+        json={"name": "Umami", "group": "Taste"},
+    )
+    assert response.status_code == 200
+    updated = response.json()
+    assert updated["name"] == "Umami"
+    assert updated["group"] == "Taste"
+
+    response = client.delete(f"/api/ingredients/possible_tags/{tag_id}")
+    assert response.status_code == 200
+    assert response.json()["message"] == "Tag deleted successfully"
+
+
+def test_delete_linked_ingredient_tag_returns_error(
+    client: TestClient, engine
+) -> None:
+    with Session(engine) as session:
+        tag = PossibleIngredientTag(name="Herb", group="Category")
+        ingredient = Ingredient(name="Basil", units=[], tags=[tag])
+        session.add(tag)
+        session.add(ingredient)
+        session.commit()
+        tag_id = tag.id
+
+    response = client.delete(f"/api/ingredients/possible_tags/{tag_id}")
+    assert response.status_code == 400
+
+
+def test_crud_possible_meal_tag(client: TestClient) -> None:
+    response = client.post(
+        "/api/meals/possible_tags",
+        json={"name": "Snack", "group": "Time"},
+    )
+    assert response.status_code == 201
+    tag = response.json()
+    tag_id = tag["id"]
+    assert tag["group"] == "Time"
+
+    response = client.put(
+        f"/api/meals/possible_tags/{tag_id}",
+        json={"name": "Brunch", "group": "Occasion"},
+    )
+    assert response.status_code == 200
+    updated = response.json()
+    assert updated["name"] == "Brunch"
+    assert updated["group"] == "Occasion"
+
+    response = client.delete(f"/api/meals/possible_tags/{tag_id}")
+    assert response.status_code == 200
+    assert response.json()["message"] == "Tag deleted successfully"
+
+
+def test_delete_linked_meal_tag_returns_error(client: TestClient, engine) -> None:
+    with Session(engine) as session:
+        tag = PossibleMealTag(name="Lunch", group="Time")
+        meal = Meal(name="Sandwich", ingredients=[], tags=[tag])
+        session.add(tag)
+        session.add(meal)
+        session.commit()
+        tag_id = tag.id
+
+    response = client.delete(f"/api/meals/possible_tags/{tag_id}")
+    assert response.status_code == 400
 
 
 def test_update_nonexistent_ingredient_returns_404(client: TestClient) -> None:

--- a/Frontend/src/api-types.ts
+++ b/Frontend/src/api-types.ts
@@ -23,6 +23,23 @@ export interface paths {
      * @description Return all possible ingredient tags ordered by name.
      */
     get: operations["get_all_possible_tags_api_ingredients_possible_tags_get"];
+    /**
+     * Create Possible Tag
+     * @description Create a new possible ingredient tag.
+     */
+    post: operations["create_possible_tag_api_ingredients_possible_tags_post"];
+  };
+  "/api/ingredients/possible_tags/{tag_id}": {
+    /**
+     * Update Possible Tag
+     * @description Update an existing possible ingredient tag.
+     */
+    put: operations["update_possible_tag_api_ingredients_possible_tags__tag_id__put"];
+    /**
+     * Delete Possible Tag
+     * @description Delete a possible ingredient tag if not linked.
+     */
+    delete: operations["delete_possible_tag_api_ingredients_possible_tags__tag_id__delete"];
   };
   "/api/ingredients/{ingredient_id}": {
     /**
@@ -59,6 +76,23 @@ export interface paths {
      * @description Return all possible meal tags ordered by name.
      */
     get: operations["get_possible_meal_tags_api_meals_possible_tags_get"];
+    /**
+     * Create Possible Meal Tag
+     * @description Create a new possible meal tag.
+     */
+    post: operations["create_possible_meal_tag_api_meals_possible_tags_post"];
+  };
+  "/api/meals/possible_tags/{tag_id}": {
+    /**
+     * Update Possible Meal Tag
+     * @description Update an existing possible meal tag.
+     */
+    put: operations["update_possible_meal_tag_api_meals_possible_tags__tag_id__put"];
+    /**
+     * Delete Possible Meal Tag
+     * @description Delete a possible meal tag if not linked.
+     */
+    delete: operations["delete_possible_meal_tag_api_meals_possible_tags__tag_id__delete"];
   };
   "/api/meals/{meal_id}": {
     /**
@@ -262,6 +296,28 @@ export interface components {
       id?: number | null;
       /** Name */
       name: string;
+      /** Group */
+      group: string;
+    };
+    /**
+     * PossibleIngredientTagCreate
+     * @description Schema for creating a possible ingredient tag.
+     */
+    PossibleIngredientTagCreate: {
+      /** Name */
+      name: string;
+      /** Group */
+      group: string;
+    };
+    /**
+     * PossibleIngredientTagUpdate
+     * @description Schema for updating a possible ingredient tag.
+     */
+    PossibleIngredientTagUpdate: {
+      /** Name */
+      name?: string | null;
+      /** Group */
+      group?: string | null;
     };
     /**
      * PossibleMealTag
@@ -272,6 +328,28 @@ export interface components {
       id?: number | null;
       /** Name */
       name: string;
+      /** Group */
+      group: string;
+    };
+    /**
+     * PossibleMealTagCreate
+     * @description Schema for creating a possible meal tag.
+     */
+    PossibleMealTagCreate: {
+      /** Name */
+      name: string;
+      /** Group */
+      group: string;
+    };
+    /**
+     * PossibleMealTagUpdate
+     * @description Schema for updating a possible meal tag.
+     */
+    PossibleMealTagUpdate: {
+      /** Name */
+      name?: string | null;
+      /** Group */
+      group?: string | null;
     };
     /**
      * TagRef
@@ -353,6 +431,88 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["PossibleIngredientTag"][];
+        };
+      };
+    };
+  };
+  /**
+   * Create Possible Tag
+   * @description Create a new possible ingredient tag.
+   */
+  create_possible_tag_api_ingredients_possible_tags_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PossibleIngredientTagCreate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["PossibleIngredientTag"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Update Possible Tag
+   * @description Update an existing possible ingredient tag.
+   */
+  update_possible_tag_api_ingredients_possible_tags__tag_id__put: {
+    parameters: {
+      path: {
+        tag_id: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PossibleIngredientTagUpdate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PossibleIngredientTag"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Possible Tag
+   * @description Delete a possible ingredient tag if not linked.
+   */
+  delete_possible_tag_api_ingredients_possible_tags__tag_id__delete: {
+    parameters: {
+      path: {
+        tag_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: unknown;
+          };
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };
@@ -488,6 +648,88 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["PossibleMealTag"][];
+        };
+      };
+    };
+  };
+  /**
+   * Create Possible Meal Tag
+   * @description Create a new possible meal tag.
+   */
+  create_possible_meal_tag_api_meals_possible_tags_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PossibleMealTagCreate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["PossibleMealTag"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Update Possible Meal Tag
+   * @description Update an existing possible meal tag.
+   */
+  update_possible_meal_tag_api_meals_possible_tags__tag_id__put: {
+    parameters: {
+      path: {
+        tag_id: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PossibleMealTagUpdate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PossibleMealTag"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Possible Meal Tag
+   * @description Delete a possible meal tag if not linked.
+   */
+  delete_possible_meal_tag_api_meals_possible_tags__tag_id__delete: {
+    parameters: {
+      path: {
+        tag_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: unknown;
+          };
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };


### PR DESCRIPTION
## Summary
- allow possible tags to be labeled by a group
- add create/update/delete endpoints for ingredient and meal possible tags
- update OpenAPI spec and frontend types
- expand tests for tag CRUD and link validation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b78499cdfc8322bffe995387f9b8cd