### PR TITLE
feat: add tag selection for meals

### DIFF
--- a/Frontend/src/components/data/meal/form/MealForm.tsx
+++ b/Frontend/src/components/data/meal/form/MealForm.tsx
@@ -7,6 +7,7 @@ import { handleFetchRequest } from "@/utils/utils";
 
 import MealNameForm from "./MealNameForm";
 import MealIngredientsForm from "./MealIngredientsForm";
+import TagEdit from "./TagEdit";
 
 /**
  * @typedef {import("../../../../api-types").operations["add_meal_api_meals_post"]["requestBody"]["content"]["application/json"]} MealRequest
@@ -190,6 +191,11 @@ function MealForm({ mealToEditData }) {
               needsClearForm={needsClearForm}
             />
             <MealIngredientsForm
+              meal={mealToEdit}
+              dispatch={dispatch}
+              needsClearForm={needsClearForm}
+            />
+            <TagEdit
               meal={mealToEdit}
               dispatch={dispatch}
               needsClearForm={needsClearForm}

--- a/Frontend/src/components/data/meal/form/TagEdit.tsx
+++ b/Frontend/src/components/data/meal/form/TagEdit.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from "react";
+
+import TagFilter from "@/components/common/TagFilter";
+import { useData } from "@/contexts/DataContext";
+
+function TagEdit({ meal, dispatch, needsClearForm }) {
+  const { mealDietTags, mealTypeTags, mealOtherTags } = useData();
+
+  const allMealTags = [
+    ...mealDietTags.map((tag) => ({ ...tag, group: "Diet" })),
+    ...mealTypeTags.map((tag) => ({ ...tag, group: "Type" })),
+    ...mealOtherTags.map((tag) => ({ ...tag, group: "Other" })),
+  ];
+
+  const handleTagsChange = (newTags) => {
+    dispatch({ type: "SET_MEAL", payload: { ...meal, tags: newTags } });
+  };
+
+  useEffect(() => {
+    if (needsClearForm) {
+      dispatch({ type: "SET_MEAL", payload: { ...meal, tags: [] } });
+    }
+  }, [needsClearForm, meal, dispatch]);
+
+  return (
+    <div>
+      <TagFilter
+        tags={allMealTags}
+        selectedTags={meal.tags || []}
+        onChange={handleTagsChange}
+        label="Tags"
+      />
+    </div>
+  );
+}
+
+export default TagEdit;

--- a/Frontend/src/tests/MealForm.test.jsx
+++ b/Frontend/src/tests/MealForm.test.jsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import MealForm from "../components/data/meal/form/MealForm";
+import { useData } from "../contexts/DataContext";
+import { handleFetchRequest } from "../utils/utils";
+
+vi.mock("../contexts/DataContext");
+vi.mock("../utils/utils", async () => {
+  const actual = await vi.importActual("../utils/utils");
+  return {
+    ...actual,
+    handleFetchRequest: vi.fn(() => Promise.resolve()),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Provide crypto.randomUUID for components
+  if (!global.crypto) {
+    global.crypto = { randomUUID: vi.fn(() => "uuid") };
+  } else {
+    global.crypto.randomUUID = vi.fn(() => "uuid");
+  }
+});
+
+describe("MealForm tag selection", () => {
+  test("submits selected tags when creating a meal", async () => {
+    useData.mockReturnValue({
+      setMealsNeedsRefetch: vi.fn(),
+      startRequest: vi.fn(),
+      endRequest: vi.fn(),
+      mealDietTags: [{ id: 1, name: "Vegetarian" }],
+      mealTypeTags: [{ id: 2, name: "Dinner" }],
+      mealOtherTags: [{ id: 3, name: "Quick" }],
+    });
+
+    render(<MealForm />);
+
+    await userEvent.click(screen.getByText(/Add Meal/i));
+
+    await userEvent.click(screen.getByLabelText(/Tags/i));
+    await userEvent.click(screen.getByRole("option", { name: "Vegetarian" }));
+    await userEvent.click(screen.getByLabelText(/Tags/i));
+    await userEvent.click(screen.getByRole("option", { name: "Dinner" }));
+    await userEvent.click(screen.getByLabelText(/Tags/i));
+    await userEvent.click(screen.getByRole("option", { name: "Quick" }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => expect(handleFetchRequest).toHaveBeenCalled());
+    const data = handleFetchRequest.mock.calls[0][2];
+    expect(data.tags).toHaveLength(3);
+    expect(data.tags).toEqual(
+      expect.arrayContaining([{ id: 1 }, { id: 2 }, { id: 3 }])
+    );
+  });
+
+  test("retains selected tags when updating a meal", async () => {
+    useData.mockReturnValue({
+      setMealsNeedsRefetch: vi.fn(),
+      startRequest: vi.fn(),
+      endRequest: vi.fn(),
+      mealDietTags: [{ id: 1, name: "Vegetarian" }],
+      mealTypeTags: [{ id: 2, name: "Dinner" }],
+      mealOtherTags: [{ id: 3, name: "Quick" }],
+    });
+
+    const meal = {
+      id: 10,
+      name: "Existing",
+      tags: [
+        { id: 1, name: "Vegetarian" },
+        { id: 2, name: "Dinner" },
+      ],
+      ingredients: [],
+    };
+
+    const { rerender } = render(<MealForm mealToEditData={null} />);
+
+    rerender(<MealForm mealToEditData={meal} />);
+
+    await screen.findByRole("button", { name: "Update" });
+
+    await userEvent.click(screen.getByLabelText(/Tags/i));
+    await userEvent.click(screen.getByRole("option", { name: "Quick" }));
+
+    await userEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    await waitFor(() => expect(handleFetchRequest).toHaveBeenCalled());
+    const data = handleFetchRequest.mock.calls[0][2];
+    expect(data.tags).toHaveLength(3);
+    expect(data.tags).toEqual(
+      expect.arrayContaining([{ id: 1 }, { id: 2 }, { id: 3 }])
+    );
+
+    expect(screen.getByRole("button", { name: "Quick" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- allow choosing grouped tags when editing meals
- wire meal tag editing into meal form
- test tag selection for meal creation and updates

## Testing
- `npm test --prefix Frontend -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b7849cd824832288a31a3cfb509490