### PR TITLE
Ensure compose uses branch worktrees

### DIFF
--- a/scripts/docker/compose.sh
+++ b/scripts/docker/compose.sh
@@ -13,8 +13,10 @@ Subcommands:
 USAGE
 }
 
-# Load branch-specific environment variables
+# Load branch-specific environment variables and ensure a dedicated worktree
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/branch-env.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/worktree.sh"
+ensure_worktree
 branch_env_load
 
 # If a path is provided, export resolved ports for downstream scripts.

--- a/scripts/lib/worktree.sh
+++ b/scripts/lib/worktree.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# scripts/lib/worktree.sh
+# Helpers for ensuring branch-specific git worktrees exist.
+
+# ensure_worktree: guarantee a branch-specific worktree exists for the current branch.
+ensure_worktree() {
+  local root branch sanitized parent dir
+  root="$(git rev-parse --show-toplevel)"
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  sanitized="$(branch_env_sanitize_branch "$branch")"
+
+  # Is the current branch already mapped to this directory?
+  if git worktree list --porcelain | awk '
+      /^worktree /{wt=$2} /^branch /{br=$2}
+      br=="refs/heads/'"$branch"'" && wt=="'"$root"'" {found=1}
+      END{exit !found}'; then
+    return 0
+  fi
+
+  parent="$(dirname "$root")"
+  dir="$parent/nutrition-$sanitized"
+  echo "Creating worktree for $branch at $dir"
+  git worktree add "$dir" "$branch"
+  cd "$dir"
+}


### PR DESCRIPTION
## Summary
- add an `ensure_worktree` helper to create branch-specific worktrees on demand
- source the helper from `compose.sh` so the compose wrapper runs inside the branch worktree

## Testing
- bash -n scripts/docker/compose.sh
- bash -n scripts/lib/worktree.sh

------
https://chatgpt.com/codex/tasks/task_e_68c887844b88832294af57fad8f5695d