### PR TITLE
Ensure worktree helpers prefer dedicated directory

### DIFF
--- a/scripts/env/check.sh
+++ b/scripts/env/check.sh
@@ -46,9 +46,9 @@ if [[ "$branch" == "$base" ]]; then
 else
   if [[ "$repo_root" != "$desired" ]]; then
     if [[ ! -d "$desired" ]]; then
-      # If the branch already has a worktree elsewhere, prefer using it.
+      # If the branch already has a worktree at the desired path, prefer using it.
       existing="$(_wt_find_for_branch "$branch" 2>/dev/null || true)"
-      if [[ -n "$existing" ]]; then
+      if [[ -n "$existing" && "$existing" == "$desired" ]]; then
         info "Found existing worktree for '$branch' at: $existing"
         if $FIX; then
           info "Run: cd '$existing'"

--- a/scripts/lib/worktree.sh
+++ b/scripts/lib/worktree.sh
@@ -54,9 +54,9 @@ ensure_worktree() {
     return 0
   fi
 
-  # If a worktree already exists for this branch, use it.
+  # If a worktree already exists for this branch at the desired location, use it.
   if existing="$(_wt_find_for_branch "$branch")"; then
-    if [[ -n "$existing" ]]; then
+    if [[ -n "$existing" && "$existing" == "$desired" ]]; then
       cd "$existing"
       return 0
     fi


### PR DESCRIPTION
## Summary
- ensure `ensure_worktree` only reuses an existing worktree when it already lives in the expected `../nutrition-<branch>` directory
- treat mismatched worktree locations as missing in `scripts/env/check.sh` so `--fix` creates or switches to the dedicated path

## Testing
- `bash ./scripts/env/check.sh --fix`
- `bash ./scripts/docker/compose.sh up type -dev data -test` *(fails: docker is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c650e0f883228cce0c34d0e7db27