### PR TITLE
Add shopping list aggregation and display

### DIFF
--- a/Frontend/src/components/shopping/Shopping.tsx
+++ b/Frontend/src/components/shopping/Shopping.tsx
@@ -1,7 +1,182 @@
-import React from "react";
+import React, { useMemo } from "react";
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+
+import { useData } from "@/contexts/DataContext";
+import { useSessionStorageState } from "@/hooks/useSessionStorageState";
+import type { PlanItem } from "@/utils/planningTypes";
+import { aggregateShoppingList } from "@/utils/shopping";
+import type { ShoppingListItem } from "@/utils/shopping";
+import { formatCellNumber } from "@/utils/utils";
+
+type ActivePlanState = {
+  id: number | null;
+  label: string | null;
+  updatedAt: string | null;
+};
+
+const formatUnitLabel = (
+  units: ShoppingListItem["unitTotals"],
+  divisor = 1,
+): string => {
+  if (!units || units.length === 0) {
+    return "-";
+  }
+  const safeDivisor = divisor > 0 ? divisor : 1;
+  const labels = units
+    .map((unit) => {
+      const quantity = unit.quantity / safeDivisor;
+      if (quantity <= 0) return null;
+      const formatted = formatCellNumber(quantity);
+      const name = unit.unitName || "units";
+      return `${formatted} ${name}`;
+    })
+    .filter(Boolean) as string[];
+
+  if (labels.length === 0) {
+    return "-";
+  }
+
+  return labels.join(" + ");
+};
 
 function Shopping() {
-  return <div>Shopping coming soon...</div>;
+  const { foods, ingredients, fetching } = useData();
+  const [plan] = useSessionStorageState<PlanItem[]>("planning-plan", () => []);
+  const [days] = useSessionStorageState<number>("planning-days", 1);
+  const [activePlan] = useSessionStorageState<ActivePlanState>(
+    "planning-active-plan",
+    () => ({ id: null, label: null, updatedAt: null }),
+  );
+
+  const { items, issues } = useMemo(
+    () => aggregateShoppingList({ plan, foods, ingredients }),
+    [plan, foods, ingredients],
+  );
+
+  const planIsEmpty = !plan || plan.length === 0;
+  const totalWeight = useMemo(
+    () => items.reduce((sum, item) => sum + item.totalGrams, 0),
+    [items],
+  );
+  const normalizedDays = Number.isFinite(days) && days > 0 ? days : 1;
+  const perDayWeight = totalWeight / normalizedDays;
+  const planLabel = activePlan.label?.trim()
+    ? `Based on plan "${activePlan.label}"`
+    : "Based on current plan";
+
+  let content: React.ReactNode;
+  if (fetching) {
+    content = (
+      <Box sx={{ display: "flex", alignItems: "center", gap: 2, mt: 3 }}>
+        <CircularProgress />
+        <Typography>Loading data needed for your shopping list…</Typography>
+      </Box>
+    );
+  } else if (planIsEmpty) {
+    content = (
+      <Alert severity="info" sx={{ mt: 3 }}>
+        Build a plan in the Planning tab to see the combined shopping list here.
+      </Alert>
+    );
+  } else if (items.length === 0) {
+    content = (
+      <Alert severity="warning" sx={{ mt: 3 }}>
+        We could not build a shopping list because some ingredients or foods are
+        missing required data.
+        {issues.length > 0 && (
+          <Box component="ul" sx={{ mt: 1, pl: 3 }}>
+            {issues.map((issue, index) => (
+              <li key={`${issue.type}-${index}`}>{issue.message}</li>
+            ))}
+          </Box>
+        )}
+      </Alert>
+    );
+  } else {
+    content = (
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="subtitle1" color="text.secondary" sx={{ mb: 2 }}>
+          {items.length} unique ingredients • {normalizedDays} day
+          {normalizedDays !== 1 ? "s" : ""} • {formatCellNumber(totalWeight)} g total
+          {normalizedDays > 1
+            ? ` (${formatCellNumber(perDayWeight)} g per day)`
+            : ""}
+        </Typography>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Ingredient</TableCell>
+                <TableCell>Quantity Needed</TableCell>
+                <TableCell align="right">Weight (g)</TableCell>
+                {normalizedDays > 1 && (
+                  <TableCell align="right">Per Day (g)</TableCell>
+                )}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {items.map((item) => (
+                <TableRow key={item.ingredientId ?? item.name}>
+                  <TableCell>{item.name}</TableCell>
+                  <TableCell>
+                    <Typography>{formatUnitLabel(item.unitTotals)}</Typography>
+                    {normalizedDays > 1 && (
+                      <Typography variant="body2" color="text.secondary">
+                        {formatUnitLabel(item.unitTotals, normalizedDays)} per day
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCellNumber(item.totalGrams)}
+                  </TableCell>
+                  {normalizedDays > 1 && (
+                    <TableCell align="right">
+                      {formatCellNumber(item.totalGrams / normalizedDays)}
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" component="h1">
+        Shopping List
+      </Typography>
+      <Typography variant="subtitle1" sx={{ mt: 1 }}>
+        {planLabel}
+        {normalizedDays > 1 ? ` • ${normalizedDays} days` : ""}
+      </Typography>
+      {content}
+      {!fetching && !planIsEmpty && items.length > 0 && issues.length > 0 && (
+        <Alert severity="warning" sx={{ mt: 3 }}>
+          Some items could not be combined:
+          <Box component="ul" sx={{ mt: 1, pl: 3, mb: 0 }}>
+            {issues.map((issue, index) => (
+              <li key={`${issue.type}-${index}`}>{issue.message}</li>
+            ))}
+          </Box>
+        </Alert>
+      )}
+    </Box>
+  );
 }
 
 export default Shopping;

--- a/Frontend/src/tests/ShoppingUtils.test.ts
+++ b/Frontend/src/tests/ShoppingUtils.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { aggregateShoppingList } from "@/utils/shopping";
+import type { PlanItem } from "@/utils/planningTypes";
+import type { FoodRead, IngredientRead } from "@/utils/nutrition";
+
+const buildIngredient = (
+  overrides: Partial<IngredientRead> & { id: number; name: string },
+): IngredientRead => ({
+  nutrition: null,
+  tags: [],
+  units: [],
+  ...overrides,
+});
+
+const buildFood = (
+  overrides: Partial<FoodRead> & { id: number; name: string },
+): FoodRead => ({
+  ingredients: [],
+  tags: [],
+  ...overrides,
+});
+
+describe("aggregateShoppingList", () => {
+  it("combines ingredient rows into a single total", () => {
+    const oats: IngredientRead = buildIngredient({
+      id: 1,
+      name: "Oats",
+      units: [
+        { id: 10, ingredient_id: 1, name: "g", grams: 1 },
+        { id: 11, ingredient_id: 1, name: "cup", grams: 90 },
+      ],
+    });
+
+    const plan: PlanItem[] = [
+      { type: "ingredient", ingredientId: "1", unitId: 10, amount: 200 },
+      { type: "ingredient", ingredientId: "1", unitId: 11, amount: 1.5 },
+    ];
+
+    const { items, issues } = aggregateShoppingList({
+      plan,
+      foods: [],
+      ingredients: [oats],
+    });
+
+    expect(issues).toHaveLength(0);
+    expect(items).toHaveLength(1);
+    const [item] = items;
+    expect(item.name).toBe("Oats");
+    // 200 g + (1.5 * 90 g)
+    expect(item.totalGrams).toBeCloseTo(335);
+    expect(item.unitTotals).toHaveLength(2);
+    const cupTotal = item.unitTotals.find((u) => u.unitName === "cup");
+    expect(cupTotal?.quantity).toBeCloseTo(1.5);
+    const gramTotal = item.unitTotals.find((u) => u.unitName === "g");
+    expect(gramTotal?.quantity).toBeCloseTo(200);
+  });
+
+  it("includes food ingredients scaled by portions and overrides", () => {
+    const chicken: IngredientRead = buildIngredient({
+      id: 2,
+      name: "Chicken",
+      units: [
+        { id: 20, ingredient_id: 2, name: "g", grams: 1 },
+        { id: 21, ingredient_id: 2, name: "oz", grams: 28.35 },
+      ],
+    });
+
+    const broccoli: IngredientRead = buildIngredient({
+      id: 3,
+      name: "Broccoli",
+      units: [
+        { id: 30, ingredient_id: 3, name: "g", grams: 1 },
+      ],
+    });
+
+    const stirFry: FoodRead = buildFood({
+      id: 100,
+      name: "Chicken Stir Fry",
+      ingredients: [
+        { food_id: 100, ingredient_id: 2, unit_id: 21, unit_quantity: 5 },
+        { food_id: 100, ingredient_id: 3, unit_id: 30, unit_quantity: 120 },
+      ],
+    });
+
+    const plan: PlanItem[] = [
+      {
+        type: "food",
+        foodId: "100",
+        portions: 2,
+        overrides: {
+          "2": { unitId: 20, quantity: 150 },
+        },
+      },
+    ];
+
+    const { items, issues } = aggregateShoppingList({
+      plan,
+      foods: [stirFry],
+      ingredients: [chicken, broccoli],
+    });
+
+    expect(issues).toHaveLength(0);
+    expect(items).toHaveLength(2);
+
+    const chickenTotal = items.find((item) => item.name === "Chicken");
+    expect(chickenTotal).toBeDefined();
+    // Override uses grams: 150 g per portion * 2 portions = 300 g
+    expect(chickenTotal?.totalGrams).toBeCloseTo(300);
+
+    const broccoliTotal = items.find((item) => item.name === "Broccoli");
+    expect(broccoliTotal).toBeDefined();
+    // Default quantity 120 g per portion * 2 portions = 240 g
+    expect(broccoliTotal?.totalGrams).toBeCloseTo(240);
+  });
+
+  it("reports issues when data is missing", () => {
+    const plan: PlanItem[] = [
+      { type: "ingredient", ingredientId: "1", unitId: 99, amount: 1 },
+      { type: "food", foodId: "200", portions: 1, overrides: {} },
+    ];
+
+    const { items, issues } = aggregateShoppingList({
+      plan,
+      foods: [],
+      ingredients: [],
+    });
+
+    expect(items).toHaveLength(0);
+    expect(issues.length).toBeGreaterThanOrEqual(2);
+    expect(issues.some((issue) => issue.type === "missing-ingredient")).toBe(true);
+    expect(issues.some((issue) => issue.type === "missing-food")).toBe(true);
+  });
+});

--- a/Frontend/src/utils/shopping.ts
+++ b/Frontend/src/utils/shopping.ts
@@ -1,0 +1,337 @@
+import type { FoodRead, IngredientRead } from "@/utils/nutrition";
+import { createIngredientLookup, findIngredientInLookup } from "@/utils/nutrition";
+import type { PlanItem } from "@/utils/planningTypes";
+
+type IngredientUnit = NonNullable<IngredientRead["units"]>[number];
+
+export type ShoppingListUnitTotal = {
+  unitId: number | string | null;
+  unitName: string;
+  quantity: number;
+  gramsPerUnit: number;
+};
+
+export type ShoppingListItem = {
+  ingredientId: number | string | null;
+  ingredient: IngredientRead;
+  name: string;
+  totalGrams: number;
+  unitTotals: ShoppingListUnitTotal[];
+};
+
+export type ShoppingListIssue = {
+  type:
+    | "missing-food"
+    | "missing-ingredient"
+    | "missing-unit"
+    | "missing-quantity"
+    | "missing-grams";
+  message: string;
+};
+
+type AggregateParams = {
+  plan: PlanItem[] | null | undefined;
+  foods: FoodRead[] | null | undefined;
+  ingredients: IngredientRead[] | null | undefined;
+};
+
+type Accumulator = {
+  ingredient: IngredientRead;
+  totalGrams: number;
+  unitMap: Map<string, ShoppingListUnitTotal>;
+};
+
+const normalizeId = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  return String(value);
+};
+
+const toNumber = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+};
+
+const resolveIngredientUnit = (
+  ingredient: IngredientRead,
+  rawUnitId: unknown,
+): (IngredientUnit & { grams: number }) | undefined => {
+  const units = ingredient.units ?? [];
+  if (units.length === 0) return undefined;
+
+  const normalizedRequested = normalizeId(rawUnitId);
+  const findMatch = (target: string | null) =>
+    units.find((unit) => normalizeId(unit.id) === target);
+
+  if (normalizedRequested !== null) {
+    const directMatch = findMatch(normalizedRequested);
+    if (directMatch) {
+      return { ...directMatch, grams: toNumber(directMatch.grams) };
+    }
+
+    if (normalizedRequested === "0") {
+      const nullMatch = findMatch(null);
+      if (nullMatch) {
+        return { ...nullMatch, grams: toNumber(nullMatch.grams) };
+      }
+    }
+
+    return undefined;
+  }
+
+  const nullUnit = findMatch(null);
+  if (nullUnit) {
+    return { ...nullUnit, grams: toNumber(nullUnit.grams) };
+  }
+
+  return undefined;
+};
+
+const addContribution = (
+  totals: Map<string, Accumulator>,
+  ingredient: IngredientRead,
+  unit: IngredientUnit & { grams: number },
+  quantity: number,
+) => {
+  if (quantity <= 0) return;
+  const gramsPerUnit = unit.grams;
+  if (!Number.isFinite(gramsPerUnit) || gramsPerUnit <= 0) {
+    return;
+  }
+  const grams = gramsPerUnit * quantity;
+  if (!Number.isFinite(grams) || grams <= 0) {
+    return;
+  }
+
+  const ingredientKey = normalizeId(ingredient.id) ?? ingredient.name ?? "";
+  if (!ingredientKey) {
+    return;
+  }
+
+  let accumulator = totals.get(ingredientKey);
+  if (!accumulator) {
+    accumulator = {
+      ingredient,
+      totalGrams: 0,
+      unitMap: new Map(),
+    };
+    totals.set(ingredientKey, accumulator);
+  }
+
+  accumulator.totalGrams += grams;
+
+  const unitKey = normalizeId(unit.id) ?? "__null__";
+  const existing = accumulator.unitMap.get(unitKey);
+  if (existing) {
+    existing.quantity += quantity;
+  } else {
+    accumulator.unitMap.set(unitKey, {
+      unitId: (unit.id as number | string | null) ?? null,
+      unitName: unit.name ?? "",
+      quantity,
+      gramsPerUnit,
+    });
+  }
+};
+
+const createIssue = (type: ShoppingListIssue["type"], message: string): ShoppingListIssue => ({
+  type,
+  message,
+});
+
+export const aggregateShoppingList = ({
+  plan,
+  foods,
+  ingredients,
+}: AggregateParams): { items: ShoppingListItem[]; issues: ShoppingListIssue[] } => {
+  const safePlan = Array.isArray(plan) ? plan : [];
+  const safeFoods = Array.isArray(foods) ? foods : [];
+  const ingredientLookup = createIngredientLookup(ingredients ?? []);
+  const totals: Map<string, Accumulator> = new Map();
+  const issues: ShoppingListIssue[] = [];
+
+  safePlan.forEach((item, index) => {
+    if (!item || typeof item !== "object" || !("type" in item)) {
+      return;
+    }
+
+    if (item.type === "ingredient") {
+      const ingredient = findIngredientInLookup(ingredientLookup, item.ingredientId);
+      if (!ingredient) {
+        issues.push(
+          createIssue(
+            "missing-ingredient",
+            `Ingredient ${item.ingredientId ?? ""} could not be found for plan row ${index + 1}.`,
+          ),
+        );
+        return;
+      }
+
+      const unit = resolveIngredientUnit(ingredient, item.unitId);
+      if (!unit) {
+        issues.push(
+          createIssue(
+            "missing-unit",
+            `Ingredient "${ingredient.name}" is missing unit ${item.unitId ?? ""} required by the plan.`,
+          ),
+        );
+        return;
+      }
+
+      if (!unit.grams || unit.grams <= 0) {
+        issues.push(
+          createIssue(
+            "missing-grams",
+            `Ingredient "${ingredient.name}" unit "${unit.name}" has no gram conversion.`,
+          ),
+        );
+        return;
+      }
+
+      const amount = toNumber((item as typeof item).amount);
+      if (amount <= 0) {
+        issues.push(
+          createIssue(
+            "missing-quantity",
+            `Ingredient "${ingredient.name}" has no valid quantity in the plan.`,
+          ),
+        );
+        return;
+      }
+
+      addContribution(totals, ingredient, unit, amount);
+      return;
+    }
+
+    if (item.type === "food") {
+      const food = safeFoods.find((candidate) => normalizeId(candidate.id) === normalizeId(item.foodId));
+      if (!food) {
+        issues.push(
+          createIssue(
+            "missing-food",
+            `Food ${item.foodId ?? ""} referenced by the plan is unavailable.`,
+          ),
+        );
+        return;
+      }
+
+      const portions = toNumber(item.portions);
+      if (portions <= 0) {
+        issues.push(
+          createIssue(
+            "missing-quantity",
+            `Food "${food.name}" has no valid portion quantity in the plan.`,
+          ),
+        );
+        return;
+      }
+
+      if (!Array.isArray(food.ingredients) || food.ingredients.length === 0) {
+        issues.push(
+          createIssue(
+            "missing-ingredient",
+            `Food "${food.name}" has no ingredient details and was skipped.`,
+          ),
+        );
+        return;
+      }
+
+      food.ingredients.forEach((foodIngredient) => {
+        const ingredient = findIngredientInLookup(
+          ingredientLookup,
+          foodIngredient.ingredient_id,
+        );
+        if (!ingredient) {
+          issues.push(
+            createIssue(
+              "missing-ingredient",
+              `Ingredient ${foodIngredient.ingredient_id ?? ""} from food "${food.name}" is unavailable.`,
+            ),
+          );
+          return;
+        }
+
+        const overrideKey = foodIngredient.ingredient_id == null
+          ? null
+          : normalizeId(foodIngredient.ingredient_id);
+        const override = overrideKey ? item.overrides?.[overrideKey] : undefined;
+
+        const unit = resolveIngredientUnit(
+          ingredient,
+          override?.unitId ?? foodIngredient.unit_id,
+        );
+
+        if (!unit) {
+          issues.push(
+            createIssue(
+              "missing-unit",
+              `Ingredient "${ingredient.name}" in food "${food.name}" is missing unit ${(override?.unitId ?? foodIngredient.unit_id) ?? ""}.`,
+            ),
+          );
+          return;
+        }
+
+        if (!unit.grams || unit.grams <= 0) {
+          issues.push(
+            createIssue(
+              "missing-grams",
+              `Ingredient "${ingredient.name}" unit "${unit.name}" in food "${food.name}" has no gram conversion.`,
+            ),
+          );
+          return;
+        }
+
+        const perPortionQuantity = toNumber(
+          override?.quantity ?? foodIngredient.unit_quantity,
+        );
+        if (perPortionQuantity <= 0) {
+          issues.push(
+            createIssue(
+              "missing-quantity",
+              `Ingredient "${ingredient.name}" in food "${food.name}" has no valid quantity.`,
+            ),
+          );
+          return;
+        }
+
+        const totalQuantity = perPortionQuantity * portions;
+        if (totalQuantity <= 0) {
+          issues.push(
+            createIssue(
+              "missing-quantity",
+              `Ingredient "${ingredient.name}" in food "${food.name}" results in zero quantity after scaling portions.`,
+            ),
+          );
+          return;
+        }
+
+        addContribution(totals, ingredient, unit, totalQuantity);
+      });
+    }
+  });
+
+  const items: ShoppingListItem[] = Array.from(totals.values()).map((entry) => ({
+    ingredientId: (entry.ingredient.id as number | string | null) ?? null,
+    ingredient: entry.ingredient,
+    name: entry.ingredient.name ?? "Unnamed ingredient",
+    totalGrams: entry.totalGrams,
+    unitTotals: Array.from(entry.unitMap.values())
+      .filter((unit) => unit.quantity > 0 && unit.gramsPerUnit > 0)
+      .sort((a, b) => {
+        if (a.gramsPerUnit === b.gramsPerUnit) {
+          return a.unitName.localeCompare(b.unitName);
+        }
+        return a.gramsPerUnit - b.gramsPerUnit;
+      }),
+  }));
+
+  items.sort((a, b) => a.name.localeCompare(b.name));
+
+  return { items, issues };
+};
+
+export type { AggregateParams };


### PR DESCRIPTION
## Summary
- build reusable shopping list aggregator that merges plan ingredients, foods, and overrides
- replace the shopping route with a full shopping list UI that summarizes totals, per-day quantities, and warnings
- cover aggregation logic with targeted unit tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd778e1bec832289d675cf444f1b00