### PR TITLE
Add preferred shopping unit selection support

### DIFF
--- a/Backend/migrations/versions/d3f0b1c2e7ad_create_ingredient_shopping_units.py
+++ b/Backend/migrations/versions/d3f0b1c2e7ad_create_ingredient_shopping_units.py
@@ -1,0 +1,40 @@
+"""Create table for preferred ingredient shopping units."""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "d3f0b1c2e7ad"
+down_revision = "1a2b3c4d5e66"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Create ingredient_shopping_units table."""
+    op.create_table(
+        "ingredient_shopping_units",
+        sa.Column("ingredient_id", sa.Integer(), nullable=False),
+        sa.Column("unit_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["ingredient_id"],
+            ["ingredients.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["unit_id"],
+            ["ingredient_units.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["ingredient_id", "unit_id"],
+            ["ingredient_units.ingredient_id", "ingredient_units.id"],
+            name="fk_shopping_unit_matches_ingredient",
+        ),
+        sa.PrimaryKeyConstraint("ingredient_id"),
+    )
+
+
+def downgrade():
+    """Drop ingredient_shopping_units table."""
+    op.drop_table("ingredient_shopping_units")

--- a/Backend/models/__init__.py
+++ b/Backend/models/__init__.py
@@ -1,4 +1,5 @@
 from .ingredient import Ingredient
+from .ingredient_shopping_unit import IngredientShoppingUnit
 from .ingredient_unit import IngredientUnit
 from .nutrition import Nutrition
 from .possible_ingredient_tag import PossibleIngredientTag
@@ -27,6 +28,7 @@ from .schemas import (
 __all__ = [
     "Ingredient",
     "IngredientUnit",
+    "IngredientShoppingUnit",
     "Nutrition",
     "PossibleIngredientTag",
     "PossibleFoodTag",

--- a/Backend/models/ingredient.py
+++ b/Backend/models/ingredient.py
@@ -10,6 +10,7 @@ from .ingredient_tag import IngredientTagLink
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
     from .schemas import IngredientCreate
+    from .ingredient_shopping_unit import IngredientShoppingUnit
 
 
 class Ingredient(SQLModel, table=True):
@@ -27,6 +28,13 @@ class Ingredient(SQLModel, table=True):
     units: List[IngredientUnit] = Relationship(
         back_populates="ingredient",
         sa_relationship_kwargs={"cascade": "all, delete-orphan"},
+    )
+    shopping_unit: Optional["IngredientShoppingUnit"] = Relationship(
+        back_populates="ingredient",
+        sa_relationship_kwargs={
+            "cascade": "all, delete-orphan",
+            "uselist": False,
+        },
     )
     tags: List[PossibleIngredientTag] = Relationship(
         back_populates="ingredients", link_model=IngredientTagLink

--- a/Backend/models/ingredient_shopping_unit.py
+++ b/Backend/models/ingredient_shopping_unit.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import Column, ForeignKey, ForeignKeyConstraint, Integer
+from sqlmodel import Field, Relationship, SQLModel
+
+from .ingredient import Ingredient
+from .ingredient_unit import IngredientUnit
+
+
+class IngredientShoppingUnit(SQLModel, table=True):
+    """Preferred shopping unit for an ingredient."""
+
+    __tablename__ = "ingredient_shopping_units"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["ingredient_id", "unit_id"],
+            ["ingredient_units.ingredient_id", "ingredient_units.id"],
+            name="fk_shopping_unit_matches_ingredient",
+        ),
+    )
+
+    ingredient_id: int = Field(
+        sa_column=Column(
+            Integer,
+            ForeignKey("ingredients.id", ondelete="CASCADE"),
+            primary_key=True,
+        )
+    )
+    unit_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column(
+            Integer,
+            ForeignKey("ingredient_units.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+    ingredient: Ingredient = Relationship(back_populates="shopping_unit")
+    unit: IngredientUnit = Relationship(
+        sa_relationship_kwargs={"foreign_keys": "IngredientShoppingUnit.unit_id"}
+    )
+
+
+__all__ = ["IngredientShoppingUnit"]

--- a/Backend/models/schemas.py
+++ b/Backend/models/schemas.py
@@ -36,6 +36,14 @@ class IngredientUnitUpdate(SQLModel):
     grams: float
 
 
+class IngredientShoppingUnitSelection(SQLModel):
+    """Payload for selecting a preferred shopping unit."""
+
+    unit_id: Optional[int] = None
+    name: Optional[str] = None
+    grams: Optional[float] = None
+
+
 class FoodIngredientCreate(SQLModel):
     """Schema for creating food ingredient linkage."""
 
@@ -57,6 +65,8 @@ class IngredientCreate(SQLModel):
     nutrition: Optional[NutritionCreate] = None
     units: List[IngredientUnitCreate] = Field(default_factory=list)
     tags: List[TagRef] = Field(default_factory=list)
+    shopping_unit_id: Optional[int] = None
+    shopping_unit: Optional[IngredientShoppingUnitSelection] = None
 
 
 class IngredientUpdate(SQLModel):
@@ -67,6 +77,8 @@ class IngredientUpdate(SQLModel):
     # Accept units with optional id for proper upsert behavior
     units: List[IngredientUnitUpdate] = Field(default_factory=list)
     tags: List[TagRef] = Field(default_factory=list)
+    shopping_unit_id: Optional[int] = None
+    shopping_unit: Optional[IngredientShoppingUnitSelection] = None
 
 
 class IngredientRead(SQLModel):
@@ -79,6 +91,8 @@ class IngredientRead(SQLModel):
     nutrition: Optional[Nutrition] = None
     units: List[IngredientUnit] = Field(default_factory=list)
     tags: List[PossibleIngredientTag] = Field(default_factory=list)
+    shopping_unit_id: Optional[int] = None
+    shopping_unit: Optional[IngredientUnit] = None
 
 
 class FoodCreate(SQLModel):
@@ -135,6 +149,7 @@ class PlanRead(SQLModel):
 __all__ = [
     "NutritionCreate",
     "IngredientUnitCreate",
+    "IngredientShoppingUnitSelection",
     "FoodIngredientCreate",
     "TagRef",
     "IngredientCreate",

--- a/Backend/openapi.json
+++ b/Backend/openapi.json
@@ -1,37 +1,786 @@
 {
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/ingredients/": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get All Ingredients",
+        "description": "Return all ingredients.",
+        "operationId": "get_all_ingredients_api_ingredients__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/IngredientRead"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Ingredients Api Ingredients  Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Add Ingredient",
+        "description": "Create a new ingredient.",
+        "operationId": "add_ingredient_api_ingredients__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngredientCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ingredients/possible_tags": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get All Possible Tags",
+        "description": "Return all possible ingredient tags ordered by name.",
+        "operationId": "get_all_possible_tags_api_ingredients_possible_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PossibleIngredientTag"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Possible Tags Api Ingredients Possible Tags Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Add Possible Tag",
+        "description": "Create a new possible ingredient tag, or return existing on duplicate name.",
+        "operationId": "add_possible_tag_api_ingredients_possible_tags_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PossibleIngredientTag"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ingredients/{ingredient_id}": {
+      "get": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Get Ingredient",
+        "description": "Retrieve a single ingredient by ID.",
+        "operationId": "get_ingredient_api_ingredients__ingredient_id__get",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Update Ingredient",
+        "description": "Update an existing ingredient.\n\nImportant: Avoid deleting existing units on update to preserve referential\nintegrity for rows in food_ingredients that reference them. Instead,\nupsert provided units (update by id or insert new). Existing units not in\nthe payload are left unchanged.",
+        "operationId": "update_ingredient_api_ingredients__ingredient_id__put",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngredientUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngredientRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ingredients"
+        ],
+        "summary": "Delete Ingredient",
+        "description": "Delete an ingredient.",
+        "operationId": "delete_ingredient_api_ingredients__ingredient_id__delete",
+        "parameters": [
+          {
+            "name": "ingredient_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Ingredient Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Ingredient Api Ingredients  Ingredient Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/foods/": {
+      "get": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Get All Foods",
+        "description": "Return all foods.",
+        "operationId": "get_all_foods_api_foods__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoodRead"
+                  },
+                  "type": "array",
+                  "title": "Response Get All Foods Api Foods  Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Add Food",
+        "description": "Create a new food.",
+        "operationId": "add_food_api_foods__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoodCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoodRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/foods/possible_tags": {
+      "get": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Get Possible Food Tags",
+        "description": "Return all possible food tags ordered by name.",
+        "operationId": "get_possible_food_tags_api_foods_possible_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PossibleFoodTag"
+                  },
+                  "type": "array",
+                  "title": "Response Get Possible Food Tags Api Foods Possible Tags Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Add Possible Food Tag",
+        "description": "Create a new possible food tag, or return existing on duplicate name.",
+        "operationId": "add_possible_food_tag_api_foods_possible_tags_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PossibleFoodTag"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/foods/{food_id}": {
+      "get": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Get Food",
+        "description": "Retrieve a single food by ID.",
+        "operationId": "get_food_api_foods__food_id__get",
+        "parameters": [
+          {
+            "name": "food_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Food Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoodRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Update Food",
+        "description": "Update an existing food.",
+        "operationId": "update_food_api_foods__food_id__put",
+        "parameters": [
+          {
+            "name": "food_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Food Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoodUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoodRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "foods"
+        ],
+        "summary": "Delete Food",
+        "description": "Delete a food.",
+        "operationId": "delete_food_api_foods__food_id__delete",
+        "parameters": [
+          {
+            "name": "food_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Food Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Delete Food Api Foods  Food Id  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/plans/": {
+      "get": {
+        "tags": [
+          "plans"
+        ],
+        "summary": "List Plans",
+        "description": "Return all saved plans ordered by last update descending.",
+        "operationId": "list_plans_api_plans__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PlanRead"
+                  },
+                  "type": "array",
+                  "title": "Response List Plans Api Plans  Get"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "plans"
+        ],
+        "summary": "Create Plan",
+        "description": "Persist a new plan payload.",
+        "operationId": "create_plan_api_plans__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/plans/{plan_id}": {
+      "get": {
+        "tags": [
+          "plans"
+        ],
+        "summary": "Get Plan",
+        "description": "Retrieve a single plan by ID.",
+        "operationId": "get_plan_api_plans__plan_id__get",
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Plan Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "plans"
+        ],
+        "summary": "Update Plan",
+        "description": "Update an existing plan.",
+        "operationId": "update_plan_api_plans__plan_id__put",
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Plan Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "plans"
+        ],
+        "summary": "Delete Plan",
+        "description": "Delete an existing plan.",
+        "operationId": "delete_plan_api_plans__plan_id__delete",
+        "parameters": [
+          {
+            "name": "plan_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Plan Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "components": {
     "schemas": {
       "FoodCreate": {
-        "description": "Schema for creating a food.",
         "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "ingredients": {
             "items": {
               "$ref": "#/components/schemas/FoodIngredientCreate"
             },
-            "title": "Ingredients",
-            "type": "array"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "array",
+            "title": "Ingredients"
           },
           "tags": {
             "items": {
               "$ref": "#/components/schemas/TagRef"
             },
-            "title": "Tags",
-            "type": "array"
+            "type": "array",
+            "title": "Tags"
           }
         },
+        "type": "object",
         "required": [
           "name"
         ],
         "title": "FoodCreate",
-        "type": "object"
+        "description": "Schema for creating a food."
       },
       "FoodIngredient": {
-        "description": "Link between a food and an ingredient with quantity information.",
         "properties": {
+          "ingredient_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingredient Id"
+          },
           "food_id": {
             "anyOf": [
               {
@@ -43,7 +792,7 @@
             ],
             "title": "Food Id"
           },
-          "ingredient_id": {
+          "unit_id": {
             "anyOf": [
               {
                 "type": "integer"
@@ -52,6 +801,28 @@
                 "type": "null"
               }
             ],
+            "title": "Unit Id"
+          },
+          "unit_quantity": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Quantity"
+          }
+        },
+        "type": "object",
+        "title": "FoodIngredient",
+        "description": "Link between a food and an ingredient with quantity information."
+      },
+      "FoodIngredientCreate": {
+        "properties": {
+          "ingredient_id": {
+            "type": "integer",
             "title": "Ingredient Id"
           },
           "unit_id": {
@@ -77,105 +848,73 @@
             "title": "Unit Quantity"
           }
         },
-        "title": "FoodIngredient",
-        "type": "object"
-      },
-      "FoodIngredientCreate": {
-        "description": "Schema for creating food ingredient linkage.",
-        "properties": {
-          "ingredient_id": {
-            "title": "Ingredient Id",
-            "type": "integer"
-          },
-          "unit_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit Id"
-          },
-          "unit_quantity": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Unit Quantity"
-          }
-        },
+        "type": "object",
         "required": [
           "ingredient_id"
         ],
         "title": "FoodIngredientCreate",
-        "type": "object"
+        "description": "Schema for creating food ingredient linkage."
       },
       "FoodRead": {
-        "description": "Schema for reading food data.",
         "properties": {
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
           },
           "ingredients": {
             "items": {
               "$ref": "#/components/schemas/FoodIngredient"
             },
-            "title": "Ingredients",
-            "type": "array"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "array",
+            "title": "Ingredients"
           },
           "tags": {
             "items": {
               "$ref": "#/components/schemas/PossibleFoodTag"
             },
-            "title": "Tags",
-            "type": "array"
+            "type": "array",
+            "title": "Tags"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "name"
         ],
         "title": "FoodRead",
-        "type": "object"
+        "description": "Schema for reading food data."
       },
       "FoodUpdate": {
-        "description": "Schema for updating a food.",
         "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
           "ingredients": {
             "items": {
               "$ref": "#/components/schemas/FoodIngredientCreate"
             },
-            "title": "Ingredients",
-            "type": "array"
-          },
-          "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "array",
+            "title": "Ingredients"
           },
           "tags": {
             "items": {
               "$ref": "#/components/schemas/TagRef"
             },
-            "title": "Tags",
-            "type": "array"
+            "type": "array",
+            "title": "Tags"
           }
         },
+        "type": "object",
         "required": [
           "name"
         ],
         "title": "FoodUpdate",
-        "type": "object"
+        "description": "Schema for updating a food."
       },
       "HTTPValidationError": {
         "properties": {
@@ -183,19 +922,18 @@
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             },
-            "title": "Detail",
-            "type": "array"
+            "type": "array",
+            "title": "Detail"
           }
         },
-        "title": "HTTPValidationError",
-        "type": "object"
+        "type": "object",
+        "title": "HTTPValidationError"
       },
       "IngredientCreate": {
-        "description": "Schema for creating an ingredient.",
         "properties": {
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
           },
           "nutrition": {
             "anyOf": [
@@ -207,37 +945,58 @@
               }
             ]
           },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/TagRef"
-            },
-            "title": "Tags",
-            "type": "array"
-          },
           "units": {
             "items": {
               "$ref": "#/components/schemas/IngredientUnitCreate"
             },
-            "title": "Units",
-            "type": "array"
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "shopping_unit_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shopping Unit Id"
+          },
+          "shopping_unit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IngredientShoppingUnitSelection"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
+        "type": "object",
         "required": [
           "name"
         ],
         "title": "IngredientCreate",
-        "type": "object"
+        "description": "Schema for creating an ingredient."
       },
       "IngredientRead": {
-        "description": "Schema for reading ingredient data.",
         "properties": {
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
           },
           "nutrition": {
             "anyOf": [
@@ -249,35 +1008,92 @@
               }
             ]
           },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/PossibleIngredientTag"
-            },
-            "title": "Tags",
-            "type": "array"
-          },
           "units": {
             "items": {
               "$ref": "#/components/schemas/IngredientUnit"
             },
-            "title": "Units",
-            "type": "array"
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/PossibleIngredientTag"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "shopping_unit_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shopping Unit Id"
+          },
+          "shopping_unit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IngredientUnit"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
+        "type": "object",
         "required": [
           "id",
           "name"
         ],
         "title": "IngredientRead",
-        "type": "object"
+        "description": "Schema for reading ingredient data."
+      },
+      "IngredientShoppingUnitSelection": {
+        "properties": {
+          "unit_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unit Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "grams": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grams"
+          }
+        },
+        "type": "object",
+        "title": "IngredientShoppingUnitSelection",
+        "description": "Payload for selecting a preferred shopping unit."
       },
       "IngredientUnit": {
-        "description": "Measurement unit for an ingredient.",
         "properties": {
-          "grams": {
-            "title": "Grams",
-            "type": "number"
-          },
           "id": {
             "anyOf": [
               {
@@ -301,43 +1117,43 @@
             "title": "Ingredient Id"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
+          },
+          "grams": {
+            "type": "number",
+            "title": "Grams"
           }
         },
+        "type": "object",
         "required": [
           "name",
           "grams"
         ],
         "title": "IngredientUnit",
-        "type": "object"
+        "description": "Measurement unit for an ingredient."
       },
       "IngredientUnitCreate": {
-        "description": "Schema for creating ingredient unit data.",
         "properties": {
-          "grams": {
-            "title": "Grams",
-            "type": "number"
-          },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
+          },
+          "grams": {
+            "type": "number",
+            "title": "Grams"
           }
         },
+        "type": "object",
         "required": [
           "name",
           "grams"
         ],
         "title": "IngredientUnitCreate",
-        "type": "object"
+        "description": "Schema for creating ingredient unit data."
       },
       "IngredientUnitUpdate": {
-        "description": "Schema for updating ingredient unit data (allows id for upsert).",
         "properties": {
-          "grams": {
-            "title": "Grams",
-            "type": "number"
-          },
           "id": {
             "anyOf": [
               {
@@ -350,23 +1166,27 @@
             "title": "Id"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
+          },
+          "grams": {
+            "type": "number",
+            "title": "Grams"
           }
         },
+        "type": "object",
         "required": [
           "name",
           "grams"
         ],
         "title": "IngredientUnitUpdate",
-        "type": "object"
+        "description": "Schema for updating ingredient unit data (allows id for upsert)."
       },
       "IngredientUpdate": {
-        "description": "Schema for updating an ingredient.",
         "properties": {
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
           },
           "nutrition": {
             "anyOf": [
@@ -378,46 +1198,51 @@
               }
             ]
           },
-          "tags": {
-            "items": {
-              "$ref": "#/components/schemas/TagRef"
-            },
-            "title": "Tags",
-            "type": "array"
-          },
           "units": {
             "items": {
               "$ref": "#/components/schemas/IngredientUnitUpdate"
             },
-            "title": "Units",
-            "type": "array"
+            "type": "array",
+            "title": "Units"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagRef"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "shopping_unit_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Shopping Unit Id"
+          },
+          "shopping_unit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IngredientShoppingUnitSelection"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
+        "type": "object",
         "required": [
           "name"
         ],
         "title": "IngredientUpdate",
-        "type": "object"
+        "description": "Schema for updating an ingredient."
       },
       "Nutrition": {
-        "description": "Nutritional information for a single ingredient.",
         "properties": {
-          "calories": {
-            "title": "Calories",
-            "type": "number"
-          },
-          "carbohydrates": {
-            "title": "Carbohydrates",
-            "type": "number"
-          },
-          "fat": {
-            "title": "Fat",
-            "type": "number"
-          },
-          "fiber": {
-            "title": "Fiber",
-            "type": "number"
-          },
           "id": {
             "anyOf": [
               {
@@ -440,11 +1265,28 @@
             ],
             "title": "Ingredient Id"
           },
+          "calories": {
+            "type": "number",
+            "title": "Calories"
+          },
+          "fat": {
+            "type": "number",
+            "title": "Fat"
+          },
+          "carbohydrates": {
+            "type": "number",
+            "title": "Carbohydrates"
+          },
           "protein": {
-            "title": "Protein",
-            "type": "number"
+            "type": "number",
+            "title": "Protein"
+          },
+          "fiber": {
+            "type": "number",
+            "title": "Fiber"
           }
         },
+        "type": "object",
         "required": [
           "calories",
           "fat",
@@ -453,32 +1295,32 @@
           "fiber"
         ],
         "title": "Nutrition",
-        "type": "object"
+        "description": "Nutritional information for a single ingredient."
       },
       "NutritionCreate": {
-        "description": "Schema for creating nutrition data.",
         "properties": {
           "calories": {
-            "title": "Calories",
-            "type": "number"
-          },
-          "carbohydrates": {
-            "title": "Carbohydrates",
-            "type": "number"
+            "type": "number",
+            "title": "Calories"
           },
           "fat": {
-            "title": "Fat",
-            "type": "number"
+            "type": "number",
+            "title": "Fat"
           },
-          "fiber": {
-            "title": "Fiber",
-            "type": "number"
+          "carbohydrates": {
+            "type": "number",
+            "title": "Carbohydrates"
           },
           "protein": {
-            "title": "Protein",
-            "type": "number"
+            "type": "number",
+            "title": "Protein"
+          },
+          "fiber": {
+            "type": "number",
+            "title": "Fiber"
           }
         },
+        "type": "object",
         "required": [
           "calories",
           "fat",
@@ -487,55 +1329,55 @@
           "fiber"
         ],
         "title": "NutritionCreate",
-        "type": "object"
+        "description": "Schema for creating nutrition data."
       },
       "PlanCreate": {
-        "description": "Payload required to persist a plan.",
         "properties": {
           "label": {
-            "title": "Label",
-            "type": "string"
+            "type": "string",
+            "title": "Label"
           },
           "payload": {
             "additionalProperties": true,
-            "title": "Payload",
-            "type": "object"
+            "type": "object",
+            "title": "Payload"
           }
         },
+        "type": "object",
         "required": [
           "label",
           "payload"
         ],
         "title": "PlanCreate",
-        "type": "object"
+        "description": "Payload required to persist a plan."
       },
       "PlanRead": {
-        "description": "Representation of a saved plan returned from the API.",
         "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
           },
           "label": {
-            "title": "Label",
-            "type": "string"
+            "type": "string",
+            "title": "Label"
           },
           "payload": {
             "additionalProperties": true,
-            "title": "Payload",
-            "type": "object"
+            "type": "object",
+            "title": "Payload"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
           },
           "updated_at": {
+            "type": "string",
             "format": "date-time",
-            "title": "Updated At",
-            "type": "string"
+            "title": "Updated At"
           }
         },
+        "type": "object",
         "required": [
           "id",
           "label",
@@ -544,10 +1386,9 @@
           "updated_at"
         ],
         "title": "PlanRead",
-        "type": "object"
+        "description": "Representation of a saved plan returned from the API."
       },
       "PlanUpdate": {
-        "description": "Fields allowed when updating a persisted plan.",
         "properties": {
           "label": {
             "anyOf": [
@@ -573,11 +1414,11 @@
             "title": "Payload"
           }
         },
+        "type": "object",
         "title": "PlanUpdate",
-        "type": "object"
+        "description": "Fields allowed when updating a persisted plan."
       },
       "PossibleFoodTag": {
-        "description": "Tag that can be associated with a food.",
         "properties": {
           "id": {
             "anyOf": [
@@ -591,18 +1432,18 @@
             "title": "Id"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
           }
         },
+        "type": "object",
         "required": [
           "name"
         ],
         "title": "PossibleFoodTag",
-        "type": "object"
+        "description": "Tag that can be associated with a food."
       },
       "PossibleIngredientTag": {
-        "description": "Tag that can be associated with an ingredient.",
         "properties": {
           "id": {
             "anyOf": [
@@ -616,43 +1457,44 @@
             "title": "Id"
           },
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
           }
         },
+        "type": "object",
         "required": [
           "name"
         ],
         "title": "PossibleIngredientTag",
-        "type": "object"
+        "description": "Tag that can be associated with an ingredient."
       },
       "TagCreate": {
-        "description": "Schema for creating a new possible tag by name.",
         "properties": {
           "name": {
-            "title": "Name",
-            "type": "string"
+            "type": "string",
+            "title": "Name"
           }
         },
+        "type": "object",
         "required": [
           "name"
         ],
         "title": "TagCreate",
-        "type": "object"
+        "description": "Schema for creating a new possible tag by name."
       },
       "TagRef": {
-        "description": "Reference to an existing tag by ID.",
         "properties": {
           "id": {
-            "title": "Id",
-            "type": "integer"
+            "type": "integer",
+            "title": "Id"
           }
         },
+        "type": "object",
         "required": [
           "id"
         ],
         "title": "TagRef",
-        "type": "object"
+        "description": "Reference to an existing tag by ID."
       },
       "ValidationError": {
         "properties": {
@@ -667,764 +1509,25 @@
                 }
               ]
             },
-            "title": "Location",
-            "type": "array"
+            "type": "array",
+            "title": "Location"
           },
           "msg": {
-            "title": "Message",
-            "type": "string"
+            "type": "string",
+            "title": "Message"
           },
           "type": {
-            "title": "Error Type",
-            "type": "string"
+            "type": "string",
+            "title": "Error Type"
           }
         },
+        "type": "object",
         "required": [
           "loc",
           "msg",
           "type"
         ],
-        "title": "ValidationError",
-        "type": "object"
-      }
-    }
-  },
-  "info": {
-    "title": "FastAPI",
-    "version": "0.1.0"
-  },
-  "openapi": "3.1.0",
-  "paths": {
-    "/api/foods/": {
-      "get": {
-        "description": "Return all foods.",
-        "operationId": "get_all_foods_api_foods__get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/FoodRead"
-                  },
-                  "title": "Response Get All Foods Api Foods  Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get All Foods",
-        "tags": [
-          "foods"
-        ]
-      },
-      "post": {
-        "description": "Create a new food.",
-        "operationId": "add_food_api_foods__post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FoodCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoodRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Add Food",
-        "tags": [
-          "foods"
-        ]
-      }
-    },
-    "/api/foods/possible_tags": {
-      "get": {
-        "description": "Return all possible food tags ordered by name.",
-        "operationId": "get_possible_food_tags_api_foods_possible_tags_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/PossibleFoodTag"
-                  },
-                  "title": "Response Get Possible Food Tags Api Foods Possible Tags Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Possible Food Tags",
-        "tags": [
-          "foods"
-        ]
-      },
-      "post": {
-        "description": "Create a new possible food tag, or return existing on duplicate name.",
-        "operationId": "add_possible_food_tag_api_foods_possible_tags_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TagCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PossibleFoodTag"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Add Possible Food Tag",
-        "tags": [
-          "foods"
-        ]
-      }
-    },
-    "/api/foods/{food_id}": {
-      "delete": {
-        "description": "Delete a food.",
-        "operationId": "delete_food_api_foods__food_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "food_id",
-            "required": true,
-            "schema": {
-              "title": "Food Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Delete Food Api Foods  Food Id  Delete",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Food",
-        "tags": [
-          "foods"
-        ]
-      },
-      "get": {
-        "description": "Retrieve a single food by ID.",
-        "operationId": "get_food_api_foods__food_id__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "food_id",
-            "required": true,
-            "schema": {
-              "title": "Food Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoodRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Food",
-        "tags": [
-          "foods"
-        ]
-      },
-      "put": {
-        "description": "Update an existing food.",
-        "operationId": "update_food_api_foods__food_id__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "food_id",
-            "required": true,
-            "schema": {
-              "title": "Food Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FoodUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FoodRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Food",
-        "tags": [
-          "foods"
-        ]
-      }
-    },
-    "/api/ingredients/": {
-      "get": {
-        "description": "Return all ingredients.",
-        "operationId": "get_all_ingredients_api_ingredients__get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/IngredientRead"
-                  },
-                  "title": "Response Get All Ingredients Api Ingredients  Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get All Ingredients",
-        "tags": [
-          "ingredients"
-        ]
-      },
-      "post": {
-        "description": "Create a new ingredient.",
-        "operationId": "add_ingredient_api_ingredients__post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IngredientCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IngredientRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Add Ingredient",
-        "tags": [
-          "ingredients"
-        ]
-      }
-    },
-    "/api/ingredients/possible_tags": {
-      "get": {
-        "description": "Return all possible ingredient tags ordered by name.",
-        "operationId": "get_all_possible_tags_api_ingredients_possible_tags_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/PossibleIngredientTag"
-                  },
-                  "title": "Response Get All Possible Tags Api Ingredients Possible Tags Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get All Possible Tags",
-        "tags": [
-          "ingredients"
-        ]
-      },
-      "post": {
-        "description": "Create a new possible ingredient tag, or return existing on duplicate name.",
-        "operationId": "add_possible_tag_api_ingredients_possible_tags_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TagCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PossibleIngredientTag"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Add Possible Tag",
-        "tags": [
-          "ingredients"
-        ]
-      }
-    },
-    "/api/ingredients/{ingredient_id}": {
-      "delete": {
-        "description": "Delete an ingredient.",
-        "operationId": "delete_ingredient_api_ingredients__ingredient_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "ingredient_id",
-            "required": true,
-            "schema": {
-              "title": "Ingredient Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Delete Ingredient Api Ingredients  Ingredient Id  Delete",
-                  "type": "object"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Ingredient",
-        "tags": [
-          "ingredients"
-        ]
-      },
-      "get": {
-        "description": "Retrieve a single ingredient by ID.",
-        "operationId": "get_ingredient_api_ingredients__ingredient_id__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "ingredient_id",
-            "required": true,
-            "schema": {
-              "title": "Ingredient Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IngredientRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Ingredient",
-        "tags": [
-          "ingredients"
-        ]
-      },
-      "put": {
-        "description": "Update an existing ingredient.\n\nImportant: Avoid deleting existing units on update to preserve referential\nintegrity for rows in food_ingredients that reference them. Instead,\nupsert provided units (update by id or insert new). Existing units not in\nthe payload are left unchanged.",
-        "operationId": "update_ingredient_api_ingredients__ingredient_id__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "ingredient_id",
-            "required": true,
-            "schema": {
-              "title": "Ingredient Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IngredientUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IngredientRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Ingredient",
-        "tags": [
-          "ingredients"
-        ]
-      }
-    },
-    "/api/plans/": {
-      "get": {
-        "description": "Return all saved plans ordered by last update descending.",
-        "operationId": "list_plans_api_plans__get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/PlanRead"
-                  },
-                  "title": "Response List Plans Api Plans  Get",
-                  "type": "array"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "List Plans",
-        "tags": [
-          "plans"
-        ]
-      },
-      "post": {
-        "description": "Persist a new plan payload.",
-        "operationId": "create_plan_api_plans__post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlanCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlanRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Plan",
-        "tags": [
-          "plans"
-        ]
-      }
-    },
-    "/api/plans/{plan_id}": {
-      "delete": {
-        "description": "Delete an existing plan.",
-        "operationId": "delete_plan_api_plans__plan_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "plan_id",
-            "required": true,
-            "schema": {
-              "title": "Plan Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Delete Plan",
-        "tags": [
-          "plans"
-        ]
-      },
-      "get": {
-        "description": "Retrieve a single plan by ID.",
-        "operationId": "get_plan_api_plans__plan_id__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "plan_id",
-            "required": true,
-            "schema": {
-              "title": "Plan Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlanRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Plan",
-        "tags": [
-          "plans"
-        ]
-      },
-      "put": {
-        "description": "Update an existing plan.",
-        "operationId": "update_plan_api_plans__plan_id__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "plan_id",
-            "required": true,
-            "schema": {
-              "title": "Plan Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PlanUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PlanRead"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Plan",
-        "tags": [
-          "plans"
-        ]
+        "title": "ValidationError"
       }
     }
   }

--- a/Backend/routes/ingredients.py
+++ b/Backend/routes/ingredients.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.exc import IntegrityError
@@ -6,11 +6,18 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 
 from ..db import get_db
-from ..models import Ingredient, IngredientUnit, Nutrition, PossibleIngredientTag
+from ..models import (
+    Ingredient,
+    IngredientShoppingUnit,
+    IngredientUnit,
+    Nutrition,
+    PossibleIngredientTag,
+)
 from ..models.schemas import (
     IngredientCreate,
     IngredientRead,
     IngredientUpdate,
+    IngredientShoppingUnitSelection,
 )
 from sqlmodel import SQLModel
 
@@ -22,6 +29,13 @@ class TagCreate(SQLModel):
 
 router = APIRouter(prefix="/ingredients", tags=["ingredients"])
 
+INGREDIENT_LOAD_OPTIONS = [
+    selectinload(Ingredient.nutrition),
+    selectinload(Ingredient.units),
+    selectinload(Ingredient.tags),
+    selectinload(Ingredient.shopping_unit).selectinload(IngredientShoppingUnit.unit),
+]
+
 
 def ingredient_to_read(ingredient: Ingredient) -> IngredientRead:
     """Convert an Ingredient to IngredientRead and ensure base 'g' unit is visible.
@@ -31,6 +45,27 @@ def ingredient_to_read(ingredient: Ingredient) -> IngredientRead:
       in the response so the UI always sees it on initial load.
     """
     read = IngredientRead.model_validate(ingredient)
+
+    read.shopping_unit = None
+    read.shopping_unit_id = None
+    if ingredient.shopping_unit:
+        selected_unit = ingredient.shopping_unit.unit
+        selected_unit_id = ingredient.shopping_unit.unit_id
+        if selected_unit is None and selected_unit_id is not None:
+            selected_unit = next(
+                (
+                    unit
+                    for unit in (ingredient.units or [])
+                    if unit.id == selected_unit_id
+                ),
+                None,
+            )
+        if selected_unit is not None:
+            read.shopping_unit = IngredientUnit.model_validate(selected_unit)
+            read.shopping_unit_id = selected_unit.id
+        else:
+            read.shopping_unit_id = selected_unit_id
+
     has_g = any((getattr(u, "name", None) == "g") for u in (read.units or []))
     if not has_g:
         # Append a synthetic base unit; id is None since it may not exist yet in DB
@@ -55,10 +90,116 @@ def ensure_g_unit_present(ingredient_obj: Ingredient) -> None:
     ingredient_obj.units = units
 
 
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None
+        try:
+            return int(candidate)
+        except ValueError:
+            return None
+    return None
+
+
+def _resolve_shopping_unit(
+    ingredient: Ingredient,
+    requested_id: Optional[Any],
+    payload: Optional[IngredientShoppingUnitSelection],
+) -> Optional[IngredientUnit]:
+    units = list(ingredient.units or [])
+    if not units:
+        if requested_id is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Preferred shopping unit must reference an existing unit.",
+            )
+        return None
+
+    def match_by_id(raw_id: Any) -> Optional[IngredientUnit]:
+        normalized = _coerce_optional_int(raw_id)
+        if normalized is None:
+            return None
+        match = next((unit for unit in units if unit.id == normalized), None)
+        if match is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Preferred shopping unit must belong to the ingredient.",
+            )
+        return match
+
+    unit = match_by_id(requested_id)
+    if unit is not None:
+        return unit
+
+    payload_obj: Optional[IngredientShoppingUnitSelection]
+    if payload is not None and not isinstance(payload, IngredientShoppingUnitSelection):
+        payload_obj = IngredientShoppingUnitSelection.model_validate(payload)
+    else:
+        payload_obj = payload
+
+    if payload_obj is not None:
+        candidate = match_by_id(
+            getattr(payload_obj, "unit_id", None) or getattr(payload_obj, "id", None)
+        )
+        if candidate is not None:
+            return candidate
+
+        name = getattr(payload_obj, "name", None)
+        grams = getattr(payload_obj, "grams", None)
+        normalized_name = name.strip().lower() if isinstance(name, str) else None
+        grams_value: Optional[float] = None
+        if grams is not None:
+            try:
+                grams_value = float(grams)
+            except (TypeError, ValueError):
+                grams_value = None
+
+        if normalized_name:
+            matching = [
+                unit
+                for unit in units
+                if (unit.name or "").strip().lower() == normalized_name
+            ]
+            if grams_value is not None:
+                matching = [
+                    unit
+                    for unit in matching
+                    if unit.grams is not None
+                    and abs(float(unit.grams) - grams_value) < 1e-9
+                ]
+            if matching:
+                return matching[0]
+
+    return None
+
+
+def apply_shopping_unit_selection(
+    ingredient: Ingredient,
+    requested_id: Optional[Any],
+    payload: Optional[IngredientShoppingUnitSelection],
+) -> None:
+    unit = _resolve_shopping_unit(ingredient, requested_id, payload)
+    if unit is None:
+        ingredient.shopping_unit = None
+        return
+
+    if ingredient.shopping_unit is None:
+        ingredient.shopping_unit = IngredientShoppingUnit(unit=unit)
+    else:
+        ingredient.shopping_unit.unit = unit
+        ingredient.shopping_unit.unit_id = unit.id
+
+
 @router.get("/", response_model=List[IngredientRead])
 def get_all_ingredients(db: Session = Depends(get_db)) -> List[IngredientRead]:
     """Return all ingredients."""
-    ingredients = db.exec(select(Ingredient)).all()
+    statement = select(Ingredient).options(*INGREDIENT_LOAD_OPTIONS)
+    ingredients = db.exec(statement).all()
     return [ingredient_to_read(ing) for ing in ingredients]
 
 
@@ -93,7 +234,10 @@ def add_possible_tag(tag: TagCreate, db: Session = Depends(get_db)) -> PossibleI
 @router.get("/{ingredient_id}", response_model=IngredientRead)
 def get_ingredient(ingredient_id: int, db: Session = Depends(get_db)) -> IngredientRead:
     """Retrieve a single ingredient by ID."""
-    ingredient = db.get(Ingredient, ingredient_id)
+    statement = select(Ingredient).options(*INGREDIENT_LOAD_OPTIONS).where(
+        Ingredient.id == ingredient_id
+    )
+    ingredient = db.exec(statement).one_or_none()
     if not ingredient:
         raise HTTPException(status_code=404, detail="Ingredient not found")
     return ingredient_to_read(ingredient)
@@ -114,17 +258,19 @@ def add_ingredient(
     db.add(ingredient_obj)
 
     try:
+        db.flush()
+        apply_shopping_unit_selection(
+            ingredient_obj,
+            ingredient.shopping_unit_id,
+            ingredient.shopping_unit,
+        )
         db.commit()
     except IntegrityError:
         # Likely a unique constraint violation on name; return the existing record
         db.rollback()
         statement = (
             select(Ingredient)
-            .options(
-                selectinload(Ingredient.nutrition),
-                selectinload(Ingredient.units),
-                selectinload(Ingredient.tags),
-            )
+            .options(*INGREDIENT_LOAD_OPTIONS)
             .where(Ingredient.name == ingredient_obj.name)
         )
         existing = db.exec(statement).one()
@@ -132,11 +278,7 @@ def add_ingredient(
 
     statement = (
         select(Ingredient)
-        .options(
-            selectinload(Ingredient.nutrition),
-            selectinload(Ingredient.units),
-            selectinload(Ingredient.tags),
-        )
+        .options(*INGREDIENT_LOAD_OPTIONS)
         .where(Ingredient.id == ingredient_obj.id)
     )
     ingredient_obj = db.exec(statement).one()
@@ -157,14 +299,8 @@ def update_ingredient(
     the payload are left unchanged.
     """
     # Load ingredient with related collections for safe updates
-    statement = (
-        select(Ingredient)
-        .options(
-            selectinload(Ingredient.nutrition),
-            selectinload(Ingredient.units),
-            selectinload(Ingredient.tags),
-        )
-        .where(Ingredient.id == ingredient_id)
+    statement = select(Ingredient).options(*INGREDIENT_LOAD_OPTIONS).where(
+        Ingredient.id == ingredient_id
     )
     ingredient = db.exec(statement).one_or_none()
     if not ingredient:
@@ -224,20 +360,22 @@ def update_ingredient(
 
     try:
         db.add(ingredient)
+        db.flush()
+        payload_fields = ingredient_data.model_dump(exclude_unset=True)
+        if "shopping_unit_id" in payload_fields or "shopping_unit" in payload_fields:
+            apply_shopping_unit_selection(
+                ingredient,
+                ingredient_data.shopping_unit_id,
+                ingredient_data.shopping_unit,
+            )
         db.commit()
     except IntegrityError as exc:
         db.rollback()
         raise HTTPException(status_code=400, detail=str(exc))
 
     # Re-load to include related fields
-    statement = (
-        select(Ingredient)
-        .options(
-            selectinload(Ingredient.nutrition),
-            selectinload(Ingredient.units),
-            selectinload(Ingredient.tags),
-        )
-        .where(Ingredient.id == ingredient.id)
+    statement = select(Ingredient).options(*INGREDIENT_LOAD_OPTIONS).where(
+        Ingredient.id == ingredient.id
     )
     ingredient = db.exec(statement).one()
     return ingredient_to_read(ingredient)

--- a/Frontend/src/api-types.ts
+++ b/Frontend/src/api-types.ts
@@ -3,1060 +3,880 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
-    "/api/foods/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get All Foods
-         * @description Return all foods.
-         */
-        get: operations["get_all_foods_api_foods__get"];
-        put?: never;
-        /**
-         * Add Food
-         * @description Create a new food.
-         */
-        post: operations["add_food_api_foods__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/foods/possible_tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Possible Food Tags
-         * @description Return all possible food tags ordered by name.
-         */
-        get: operations["get_possible_food_tags_api_foods_possible_tags_get"];
-        put?: never;
-        /**
-         * Add Possible Food Tag
-         * @description Create a new possible food tag, or return existing on duplicate name.
-         */
-        post: operations["add_possible_food_tag_api_foods_possible_tags_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/foods/{food_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Food
-         * @description Retrieve a single food by ID.
-         */
-        get: operations["get_food_api_foods__food_id__get"];
-        /**
-         * Update Food
-         * @description Update an existing food.
-         */
-        put: operations["update_food_api_foods__food_id__put"];
-        post?: never;
-        /**
-         * Delete Food
-         * @description Delete a food.
-         */
-        delete: operations["delete_food_api_foods__food_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/ingredients/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get All Ingredients
-         * @description Return all ingredients.
-         */
-        get: operations["get_all_ingredients_api_ingredients__get"];
-        put?: never;
-        /**
-         * Add Ingredient
-         * @description Create a new ingredient.
-         */
-        post: operations["add_ingredient_api_ingredients__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/ingredients/possible_tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get All Possible Tags
-         * @description Return all possible ingredient tags ordered by name.
-         */
-        get: operations["get_all_possible_tags_api_ingredients_possible_tags_get"];
-        put?: never;
-        /**
-         * Add Possible Tag
-         * @description Create a new possible ingredient tag, or return existing on duplicate name.
-         */
-        post: operations["add_possible_tag_api_ingredients_possible_tags_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/ingredients/{ingredient_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Ingredient
-         * @description Retrieve a single ingredient by ID.
-         */
-        get: operations["get_ingredient_api_ingredients__ingredient_id__get"];
-        /**
-         * Update Ingredient
-         * @description Update an existing ingredient.
-         *
-         *     Important: Avoid deleting existing units on update to preserve referential
-         *     integrity for rows in food_ingredients that reference them. Instead,
-         *     upsert provided units (update by id or insert new). Existing units not in
-         *     the payload are left unchanged.
-         */
-        put: operations["update_ingredient_api_ingredients__ingredient_id__put"];
-        post?: never;
-        /**
-         * Delete Ingredient
-         * @description Delete an ingredient.
-         */
-        delete: operations["delete_ingredient_api_ingredients__ingredient_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/plans/": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Plans
-         * @description Return all saved plans ordered by last update descending.
-         */
-        get: operations["list_plans_api_plans__get"];
-        put?: never;
-        /**
-         * Create Plan
-         * @description Persist a new plan payload.
-         */
-        post: operations["create_plan_api_plans__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/plans/{plan_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Plan
-         * @description Retrieve a single plan by ID.
-         */
-        get: operations["get_plan_api_plans__plan_id__get"];
-        /**
-         * Update Plan
-         * @description Update an existing plan.
-         */
-        put: operations["update_plan_api_plans__plan_id__put"];
-        post?: never;
-        /**
-         * Delete Plan
-         * @description Delete an existing plan.
-         */
-        delete: operations["delete_plan_api_plans__plan_id__delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+  "/api/ingredients/": {
+    /**
+     * Get All Ingredients
+     * @description Return all ingredients.
+     */
+    get: operations["get_all_ingredients_api_ingredients__get"];
+    /**
+     * Add Ingredient
+     * @description Create a new ingredient.
+     */
+    post: operations["add_ingredient_api_ingredients__post"];
+  };
+  "/api/ingredients/possible_tags": {
+    /**
+     * Get All Possible Tags
+     * @description Return all possible ingredient tags ordered by name.
+     */
+    get: operations["get_all_possible_tags_api_ingredients_possible_tags_get"];
+    /**
+     * Add Possible Tag
+     * @description Create a new possible ingredient tag, or return existing on duplicate name.
+     */
+    post: operations["add_possible_tag_api_ingredients_possible_tags_post"];
+  };
+  "/api/ingredients/{ingredient_id}": {
+    /**
+     * Get Ingredient
+     * @description Retrieve a single ingredient by ID.
+     */
+    get: operations["get_ingredient_api_ingredients__ingredient_id__get"];
+    /**
+     * Update Ingredient
+     * @description Update an existing ingredient.
+     *
+     * Important: Avoid deleting existing units on update to preserve referential
+     * integrity for rows in food_ingredients that reference them. Instead,
+     * upsert provided units (update by id or insert new). Existing units not in
+     * the payload are left unchanged.
+     */
+    put: operations["update_ingredient_api_ingredients__ingredient_id__put"];
+    /**
+     * Delete Ingredient
+     * @description Delete an ingredient.
+     */
+    delete: operations["delete_ingredient_api_ingredients__ingredient_id__delete"];
+  };
+  "/api/foods/": {
+    /**
+     * Get All Foods
+     * @description Return all foods.
+     */
+    get: operations["get_all_foods_api_foods__get"];
+    /**
+     * Add Food
+     * @description Create a new food.
+     */
+    post: operations["add_food_api_foods__post"];
+  };
+  "/api/foods/possible_tags": {
+    /**
+     * Get Possible Food Tags
+     * @description Return all possible food tags ordered by name.
+     */
+    get: operations["get_possible_food_tags_api_foods_possible_tags_get"];
+    /**
+     * Add Possible Food Tag
+     * @description Create a new possible food tag, or return existing on duplicate name.
+     */
+    post: operations["add_possible_food_tag_api_foods_possible_tags_post"];
+  };
+  "/api/foods/{food_id}": {
+    /**
+     * Get Food
+     * @description Retrieve a single food by ID.
+     */
+    get: operations["get_food_api_foods__food_id__get"];
+    /**
+     * Update Food
+     * @description Update an existing food.
+     */
+    put: operations["update_food_api_foods__food_id__put"];
+    /**
+     * Delete Food
+     * @description Delete a food.
+     */
+    delete: operations["delete_food_api_foods__food_id__delete"];
+  };
+  "/api/plans/": {
+    /**
+     * List Plans
+     * @description Return all saved plans ordered by last update descending.
+     */
+    get: operations["list_plans_api_plans__get"];
+    /**
+     * Create Plan
+     * @description Persist a new plan payload.
+     */
+    post: operations["create_plan_api_plans__post"];
+  };
+  "/api/plans/{plan_id}": {
+    /**
+     * Get Plan
+     * @description Retrieve a single plan by ID.
+     */
+    get: operations["get_plan_api_plans__plan_id__get"];
+    /**
+     * Update Plan
+     * @description Update an existing plan.
+     */
+    put: operations["update_plan_api_plans__plan_id__put"];
+    /**
+     * Delete Plan
+     * @description Delete an existing plan.
+     */
+    delete: operations["delete_plan_api_plans__plan_id__delete"];
+  };
 }
+
 export type webhooks = Record<string, never>;
+
 export interface components {
-    schemas: {
-        /**
-         * FoodCreate
-         * @description Schema for creating a food.
-         */
-        FoodCreate: {
-            /** Ingredients */
-            ingredients?: components["schemas"]["FoodIngredientCreate"][];
-            /** Name */
-            name: string;
-            /** Tags */
-            tags?: components["schemas"]["TagRef"][];
-        };
-        /**
-         * FoodIngredient
-         * @description Link between a food and an ingredient with quantity information.
-         */
-        FoodIngredient: {
-            /** Food Id */
-            food_id?: number | null;
-            /** Ingredient Id */
-            ingredient_id?: number | null;
-            /** Unit Id */
-            unit_id?: number | null;
-            /** Unit Quantity */
-            unit_quantity?: number | null;
-        };
-        /**
-         * FoodIngredientCreate
-         * @description Schema for creating food ingredient linkage.
-         */
-        FoodIngredientCreate: {
-            /** Ingredient Id */
-            ingredient_id: number;
-            /** Unit Id */
-            unit_id?: number | null;
-            /** Unit Quantity */
-            unit_quantity?: number | null;
-        };
-        /**
-         * FoodRead
-         * @description Schema for reading food data.
-         */
-        FoodRead: {
-            /** Id */
-            id: number;
-            /** Ingredients */
-            ingredients?: components["schemas"]["FoodIngredient"][];
-            /** Name */
-            name: string;
-            /** Tags */
-            tags?: components["schemas"]["PossibleFoodTag"][];
-        };
-        /**
-         * FoodUpdate
-         * @description Schema for updating a food.
-         */
-        FoodUpdate: {
-            /** Ingredients */
-            ingredients?: components["schemas"]["FoodIngredientCreate"][];
-            /** Name */
-            name: string;
-            /** Tags */
-            tags?: components["schemas"]["TagRef"][];
-        };
-        /** HTTPValidationError */
-        HTTPValidationError: {
-            /** Detail */
-            detail?: components["schemas"]["ValidationError"][];
-        };
-        /**
-         * IngredientCreate
-         * @description Schema for creating an ingredient.
-         */
-        IngredientCreate: {
-            /** Name */
-            name: string;
-            nutrition?: components["schemas"]["NutritionCreate"] | null;
-            /** Tags */
-            tags?: components["schemas"]["TagRef"][];
-            /** Units */
-            units?: components["schemas"]["IngredientUnitCreate"][];
-        };
-        /**
-         * IngredientRead
-         * @description Schema for reading ingredient data.
-         */
-        IngredientRead: {
-            /** Id */
-            id: number;
-            /** Name */
-            name: string;
-            nutrition?: components["schemas"]["Nutrition"] | null;
-            /** Tags */
-            tags?: components["schemas"]["PossibleIngredientTag"][];
-            /** Units */
-            units?: components["schemas"]["IngredientUnit"][];
-        };
-        /**
-         * IngredientUnit
-         * @description Measurement unit for an ingredient.
-         */
-        IngredientUnit: {
-            /** Grams */
-            grams: number;
-            /** Id */
-            id?: number | null;
-            /** Ingredient Id */
-            ingredient_id?: number | null;
-            /** Name */
-            name: string;
-        };
-        /**
-         * IngredientUnitCreate
-         * @description Schema for creating ingredient unit data.
-         */
-        IngredientUnitCreate: {
-            /** Grams */
-            grams: number;
-            /** Name */
-            name: string;
-        };
-        /**
-         * IngredientUnitUpdate
-         * @description Schema for updating ingredient unit data (allows id for upsert).
-         */
-        IngredientUnitUpdate: {
-            /** Grams */
-            grams: number;
-            /** Id */
-            id?: number | null;
-            /** Name */
-            name: string;
-        };
-        /**
-         * IngredientUpdate
-         * @description Schema for updating an ingredient.
-         */
-        IngredientUpdate: {
-            /** Name */
-            name: string;
-            nutrition?: components["schemas"]["NutritionCreate"] | null;
-            /** Tags */
-            tags?: components["schemas"]["TagRef"][];
-            /** Units */
-            units?: components["schemas"]["IngredientUnitUpdate"][];
-        };
-        /**
-         * Nutrition
-         * @description Nutritional information for a single ingredient.
-         */
-        Nutrition: {
-            /** Calories */
-            calories: number;
-            /** Carbohydrates */
-            carbohydrates: number;
-            /** Fat */
-            fat: number;
-            /** Fiber */
-            fiber: number;
-            /** Id */
-            id?: number | null;
-            /** Ingredient Id */
-            ingredient_id?: number | null;
-            /** Protein */
-            protein: number;
-        };
-        /**
-         * NutritionCreate
-         * @description Schema for creating nutrition data.
-         */
-        NutritionCreate: {
-            /** Calories */
-            calories: number;
-            /** Carbohydrates */
-            carbohydrates: number;
-            /** Fat */
-            fat: number;
-            /** Fiber */
-            fiber: number;
-            /** Protein */
-            protein: number;
-        };
-        /**
-         * PlanCreate
-         * @description Payload required to persist a plan.
-         */
-        PlanCreate: {
-            /** Label */
-            label: string;
-            /** Payload */
-            payload: {
-                [key: string]: unknown;
-            };
-        };
-        /**
-         * PlanRead
-         * @description Representation of a saved plan returned from the API.
-         */
-        PlanRead: {
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Id */
-            id: number;
-            /** Label */
-            label: string;
-            /** Payload */
-            payload: {
-                [key: string]: unknown;
-            };
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
-        };
-        /**
-         * PlanUpdate
-         * @description Fields allowed when updating a persisted plan.
-         */
-        PlanUpdate: {
-            /** Label */
-            label?: string | null;
-            /** Payload */
-            payload?: {
-                [key: string]: unknown;
-            } | null;
-        };
-        /**
-         * PossibleFoodTag
-         * @description Tag that can be associated with a food.
-         */
-        PossibleFoodTag: {
-            /** Id */
-            id?: number | null;
-            /** Name */
-            name: string;
-        };
-        /**
-         * PossibleIngredientTag
-         * @description Tag that can be associated with an ingredient.
-         */
-        PossibleIngredientTag: {
-            /** Id */
-            id?: number | null;
-            /** Name */
-            name: string;
-        };
-        /**
-         * TagCreate
-         * @description Schema for creating a new possible tag by name.
-         */
-        TagCreate: {
-            /** Name */
-            name: string;
-        };
-        /**
-         * TagRef
-         * @description Reference to an existing tag by ID.
-         */
-        TagRef: {
-            /** Id */
-            id: number;
-        };
-        /** ValidationError */
-        ValidationError: {
-            /** Location */
-            loc: (string | number)[];
-            /** Message */
-            msg: string;
-            /** Error Type */
-            type: string;
-        };
+  schemas: {
+    /**
+     * FoodCreate
+     * @description Schema for creating a food.
+     */
+    FoodCreate: {
+      /** Name */
+      name: string;
+      /** Ingredients */
+      ingredients?: components["schemas"]["FoodIngredientCreate"][];
+      /** Tags */
+      tags?: components["schemas"]["TagRef"][];
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    /**
+     * FoodIngredient
+     * @description Link between a food and an ingredient with quantity information.
+     */
+    FoodIngredient: {
+      /** Ingredient Id */
+      ingredient_id?: number | null;
+      /** Food Id */
+      food_id?: number | null;
+      /** Unit Id */
+      unit_id?: number | null;
+      /** Unit Quantity */
+      unit_quantity?: number | null;
+    };
+    /**
+     * FoodIngredientCreate
+     * @description Schema for creating food ingredient linkage.
+     */
+    FoodIngredientCreate: {
+      /** Ingredient Id */
+      ingredient_id: number;
+      /** Unit Id */
+      unit_id?: number | null;
+      /** Unit Quantity */
+      unit_quantity?: number | null;
+    };
+    /**
+     * FoodRead
+     * @description Schema for reading food data.
+     */
+    FoodRead: {
+      /** Id */
+      id: number;
+      /** Name */
+      name: string;
+      /** Ingredients */
+      ingredients?: components["schemas"]["FoodIngredient"][];
+      /** Tags */
+      tags?: components["schemas"]["PossibleFoodTag"][];
+    };
+    /**
+     * FoodUpdate
+     * @description Schema for updating a food.
+     */
+    FoodUpdate: {
+      /** Name */
+      name: string;
+      /** Ingredients */
+      ingredients?: components["schemas"]["FoodIngredientCreate"][];
+      /** Tags */
+      tags?: components["schemas"]["TagRef"][];
+    };
+    /** HTTPValidationError */
+    HTTPValidationError: {
+      /** Detail */
+      detail?: components["schemas"]["ValidationError"][];
+    };
+    /**
+     * IngredientCreate
+     * @description Schema for creating an ingredient.
+     */
+    IngredientCreate: {
+      /** Name */
+      name: string;
+      nutrition?: components["schemas"]["NutritionCreate"] | null;
+      /** Units */
+      units?: components["schemas"]["IngredientUnitCreate"][];
+      /** Tags */
+      tags?: components["schemas"]["TagRef"][];
+      /** Shopping Unit Id */
+      shopping_unit_id?: number | null;
+      shopping_unit?: components["schemas"]["IngredientShoppingUnitSelection"] | null;
+    };
+    /**
+     * IngredientRead
+     * @description Schema for reading ingredient data.
+     */
+    IngredientRead: {
+      /** Id */
+      id: number;
+      /** Name */
+      name: string;
+      nutrition?: components["schemas"]["Nutrition"] | null;
+      /** Units */
+      units?: components["schemas"]["IngredientUnit"][];
+      /** Tags */
+      tags?: components["schemas"]["PossibleIngredientTag"][];
+      /** Shopping Unit Id */
+      shopping_unit_id?: number | null;
+      shopping_unit?: components["schemas"]["IngredientUnit"] | null;
+    };
+    /**
+     * IngredientShoppingUnitSelection
+     * @description Payload for selecting a preferred shopping unit.
+     */
+    IngredientShoppingUnitSelection: {
+      /** Unit Id */
+      unit_id?: number | null;
+      /** Name */
+      name?: string | null;
+      /** Grams */
+      grams?: number | null;
+    };
+    /**
+     * IngredientUnit
+     * @description Measurement unit for an ingredient.
+     */
+    IngredientUnit: {
+      /** Id */
+      id?: number | null;
+      /** Ingredient Id */
+      ingredient_id?: number | null;
+      /** Name */
+      name: string;
+      /** Grams */
+      grams: number;
+    };
+    /**
+     * IngredientUnitCreate
+     * @description Schema for creating ingredient unit data.
+     */
+    IngredientUnitCreate: {
+      /** Name */
+      name: string;
+      /** Grams */
+      grams: number;
+    };
+    /**
+     * IngredientUnitUpdate
+     * @description Schema for updating ingredient unit data (allows id for upsert).
+     */
+    IngredientUnitUpdate: {
+      /** Id */
+      id?: number | null;
+      /** Name */
+      name: string;
+      /** Grams */
+      grams: number;
+    };
+    /**
+     * IngredientUpdate
+     * @description Schema for updating an ingredient.
+     */
+    IngredientUpdate: {
+      /** Name */
+      name: string;
+      nutrition?: components["schemas"]["NutritionCreate"] | null;
+      /** Units */
+      units?: components["schemas"]["IngredientUnitUpdate"][];
+      /** Tags */
+      tags?: components["schemas"]["TagRef"][];
+      /** Shopping Unit Id */
+      shopping_unit_id?: number | null;
+      shopping_unit?: components["schemas"]["IngredientShoppingUnitSelection"] | null;
+    };
+    /**
+     * Nutrition
+     * @description Nutritional information for a single ingredient.
+     */
+    Nutrition: {
+      /** Id */
+      id?: number | null;
+      /** Ingredient Id */
+      ingredient_id?: number | null;
+      /** Calories */
+      calories: number;
+      /** Fat */
+      fat: number;
+      /** Carbohydrates */
+      carbohydrates: number;
+      /** Protein */
+      protein: number;
+      /** Fiber */
+      fiber: number;
+    };
+    /**
+     * NutritionCreate
+     * @description Schema for creating nutrition data.
+     */
+    NutritionCreate: {
+      /** Calories */
+      calories: number;
+      /** Fat */
+      fat: number;
+      /** Carbohydrates */
+      carbohydrates: number;
+      /** Protein */
+      protein: number;
+      /** Fiber */
+      fiber: number;
+    };
+    /**
+     * PlanCreate
+     * @description Payload required to persist a plan.
+     */
+    PlanCreate: {
+      /** Label */
+      label: string;
+      /** Payload */
+      payload: {
+        [key: string]: unknown;
+      };
+    };
+    /**
+     * PlanRead
+     * @description Representation of a saved plan returned from the API.
+     */
+    PlanRead: {
+      /** Id */
+      id: number;
+      /** Label */
+      label: string;
+      /** Payload */
+      payload: {
+        [key: string]: unknown;
+      };
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      /**
+       * Updated At
+       * Format: date-time
+       */
+      updated_at: string;
+    };
+    /**
+     * PlanUpdate
+     * @description Fields allowed when updating a persisted plan.
+     */
+    PlanUpdate: {
+      /** Label */
+      label?: string | null;
+      /** Payload */
+      payload?: {
+        [key: string]: unknown;
+      } | null;
+    };
+    /**
+     * PossibleFoodTag
+     * @description Tag that can be associated with a food.
+     */
+    PossibleFoodTag: {
+      /** Id */
+      id?: number | null;
+      /** Name */
+      name: string;
+    };
+    /**
+     * PossibleIngredientTag
+     * @description Tag that can be associated with an ingredient.
+     */
+    PossibleIngredientTag: {
+      /** Id */
+      id?: number | null;
+      /** Name */
+      name: string;
+    };
+    /**
+     * TagCreate
+     * @description Schema for creating a new possible tag by name.
+     */
+    TagCreate: {
+      /** Name */
+      name: string;
+    };
+    /**
+     * TagRef
+     * @description Reference to an existing tag by ID.
+     */
+    TagRef: {
+      /** Id */
+      id: number;
+    };
+    /** ValidationError */
+    ValidationError: {
+      /** Location */
+      loc: (string | number)[];
+      /** Message */
+      msg: string;
+      /** Error Type */
+      type: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
+
 export type $defs = Record<string, never>;
+
+export type external = Record<string, never>;
+
 export interface operations {
-    get_all_foods_api_foods__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+
+  /**
+   * Get All Ingredients
+   * @description Return all ingredients.
+   */
+  get_all_ingredients_api_ingredients__get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["IngredientRead"][];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoodRead"][];
-                };
-            };
-        };
+      };
     };
-    add_food_api_foods__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FoodCreate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoodRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Add Ingredient
+   * @description Create a new ingredient.
+   */
+  add_ingredient_api_ingredients__post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["IngredientCreate"];
+      };
     };
-    get_possible_food_tags_api_foods_possible_tags_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["IngredientRead"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PossibleFoodTag"][];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
+      };
     };
-    add_possible_food_tag_api_foods_possible_tags_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+  };
+  /**
+   * Get All Possible Tags
+   * @description Return all possible ingredient tags ordered by name.
+   */
+  get_all_possible_tags_api_ingredients_possible_tags_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PossibleIngredientTag"][];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TagCreate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PossibleFoodTag"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    get_food_api_foods__food_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                food_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoodRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Add Possible Tag
+   * @description Create a new possible ingredient tag, or return existing on duplicate name.
+   */
+  add_possible_tag_api_ingredients_possible_tags_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["TagCreate"];
+      };
     };
-    update_food_api_foods__food_id__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                food_id: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["PossibleIngredientTag"];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["FoodUpdate"];
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["FoodRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    delete_food_api_foods__food_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                food_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Get Ingredient
+   * @description Retrieve a single ingredient by ID.
+   */
+  get_ingredient_api_ingredients__ingredient_id__get: {
+    parameters: {
+      path: {
+        ingredient_id: number;
+      };
     };
-    get_all_ingredients_api_ingredients__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["IngredientRead"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IngredientRead"][];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
+      };
     };
-    add_ingredient_api_ingredients__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["IngredientCreate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IngredientRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Update Ingredient
+   * @description Update an existing ingredient.
+   *
+   * Important: Avoid deleting existing units on update to preserve referential
+   * integrity for rows in food_ingredients that reference them. Instead,
+   * upsert provided units (update by id or insert new). Existing units not in
+   * the payload are left unchanged.
+   */
+  update_ingredient_api_ingredients__ingredient_id__put: {
+    parameters: {
+      path: {
+        ingredient_id: number;
+      };
     };
-    get_all_possible_tags_api_ingredients_possible_tags_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PossibleIngredientTag"][];
-                };
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["IngredientUpdate"];
+      };
     };
-    add_possible_tag_api_ingredients_possible_tags_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["IngredientRead"];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["TagCreate"];
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PossibleIngredientTag"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    get_ingredient_api_ingredients__ingredient_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ingredient_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IngredientRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Delete Ingredient
+   * @description Delete an ingredient.
+   */
+  delete_ingredient_api_ingredients__ingredient_id__delete: {
+    parameters: {
+      path: {
+        ingredient_id: number;
+      };
     };
-    update_ingredient_api_ingredients__ingredient_id__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ingredient_id: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: unknown;
+          };
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["IngredientUpdate"];
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["IngredientRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    delete_ingredient_api_ingredients__ingredient_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                ingredient_id: number;
-            };
-            cookie?: never;
+  };
+  /**
+   * Get All Foods
+   * @description Return all foods.
+   */
+  get_all_foods_api_foods__get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["FoodRead"][];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    list_plans_api_plans__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PlanRead"][];
-                };
-            };
-        };
+  };
+  /**
+   * Add Food
+   * @description Create a new food.
+   */
+  add_food_api_foods__post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["FoodCreate"];
+      };
     };
-    create_plan_api_plans__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["FoodRead"];
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PlanCreate"];
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PlanRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    get_plan_api_plans__plan_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plan_id: number;
-            };
-            cookie?: never;
+  };
+  /**
+   * Get Possible Food Tags
+   * @description Return all possible food tags ordered by name.
+   */
+  get_possible_food_tags_api_foods_possible_tags_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PossibleFoodTag"][];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PlanRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+      };
     };
-    update_plan_api_plans__plan_id__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plan_id: number;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PlanUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PlanRead"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
+  };
+  /**
+   * Add Possible Food Tag
+   * @description Create a new possible food tag, or return existing on duplicate name.
+   */
+  add_possible_food_tag_api_foods_possible_tags_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["TagCreate"];
+      };
     };
-    delete_plan_api_plans__plan_id__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plan_id: number;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["PossibleFoodTag"];
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
+      };
     };
+  };
+  /**
+   * Get Food
+   * @description Retrieve a single food by ID.
+   */
+  get_food_api_foods__food_id__get: {
+    parameters: {
+      path: {
+        food_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["FoodRead"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Update Food
+   * @description Update an existing food.
+   */
+  update_food_api_foods__food_id__put: {
+    parameters: {
+      path: {
+        food_id: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["FoodUpdate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["FoodRead"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Food
+   * @description Delete a food.
+   */
+  delete_food_api_foods__food_id__delete: {
+    parameters: {
+      path: {
+        food_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: unknown;
+          };
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * List Plans
+   * @description Return all saved plans ordered by last update descending.
+   */
+  list_plans_api_plans__get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PlanRead"][];
+        };
+      };
+    };
+  };
+  /**
+   * Create Plan
+   * @description Persist a new plan payload.
+   */
+  create_plan_api_plans__post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PlanCreate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["PlanRead"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Plan
+   * @description Retrieve a single plan by ID.
+   */
+  get_plan_api_plans__plan_id__get: {
+    parameters: {
+      path: {
+        plan_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PlanRead"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Update Plan
+   * @description Update an existing plan.
+   */
+  update_plan_api_plans__plan_id__put: {
+    parameters: {
+      path: {
+        plan_id: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PlanUpdate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PlanRead"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Plan
+   * @description Delete an existing plan.
+   */
+  delete_plan_api_plans__plan_id__delete: {
+    parameters: {
+      path: {
+        plan_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        content: never;
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
 }

--- a/Frontend/src/components/data/food/form/FoodIngredientsForm.tsx
+++ b/Frontend/src/components/data/food/form/FoodIngredientsForm.tsx
@@ -80,7 +80,7 @@ function FoodIngredientsForm({ food, dispatch, needsClearForm }) {
     return {
       ingredient_id: ingredient.id,
       food_id: food.id,
-      unit_id: ingredient.selectedUnitId ?? null,
+      unit_id: ingredient.shoppingUnitId ?? null,
       unit_quantity: 1,
     };
   };

--- a/Frontend/src/components/data/ingredient/IngredientTable.tsx
+++ b/Frontend/src/components/data/ingredient/IngredientTable.tsx
@@ -52,13 +52,13 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
 
   const handleUnitChange = (event, ingredientId) => {
     const rawValue = event.target.value;
-    let selectedUnitId = null;
+    let shoppingUnitId: number | string | null = null;
     if (rawValue !== "" && rawValue !== null && rawValue !== undefined) {
       if (typeof rawValue === "number") {
-        selectedUnitId = rawValue;
+        shoppingUnitId = rawValue;
       } else {
         const parsed = Number(rawValue);
-        selectedUnitId = Number.isNaN(parsed) ? null : parsed;
+        shoppingUnitId = Number.isNaN(parsed) ? rawValue : parsed;
       }
     }
     setIngredients((prevIngredients) =>
@@ -66,7 +66,7 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
         ingredient.id === ingredientId
           ? {
               ...ingredient,
-              selectedUnitId,
+              shoppingUnitId,
             }
           : ingredient
       )
@@ -85,7 +85,7 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
     if (!ingredient.units || ingredient.units.length === 0) {
       return null;
     }
-    const selectedId = ingredient.selectedUnitId;
+    const selectedId = ingredient.shoppingUnitId;
     if (selectedId === null || selectedId === undefined || selectedId === "") {
       return (
         ingredient.units.find((unit) => unit.name === "g" && unit.grams === 1) ||
@@ -215,7 +215,7 @@ function IngredientTable({ onIngredientDoubleClick = () => {}, onIngredientCtrlC
                   <TableCell>{ingredient.name}</TableCell>
                   <TableCell>
                     <Select
-                      value={ingredient.selectedUnitId ?? ""}
+          value={ingredient.shoppingUnitId ?? ""}
                       size="small"
                       displayEmpty
                       renderValue={() => selectedUnit?.name ?? ""}

--- a/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
@@ -55,7 +55,16 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
     if (!ingredient) return;
 
     const units = ingredient.units || [];
-    const selectedUnit = units.find((unit) => unit.id === ingredient.selectedUnitId) || units[0];
+    const selectedUnit =
+      units.find((unit) => {
+        const target = ingredient.shoppingUnitId;
+        if (target == null) return false;
+        if (unit.id == null) return false;
+        if (typeof target === "string" && !Number.isNaN(Number(target))) {
+          return Number(unit.id) === Number(target);
+        }
+        return String(unit.id) === String(target);
+      }) || units[0];
     const parsedGrams = parseFloat(String(selectedUnit?.grams ?? 1));
     const safeMultiplier = Number.isFinite(parsedGrams) && parsedGrams > 0 ? parsedGrams : 1;
 

--- a/Frontend/src/components/data/ingredient/form/UnitEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/UnitEdit.tsx
@@ -74,8 +74,10 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }) {
           if (unit.id == null || normalizedValue == null) return false;
           return String(unit.id) === String(normalizedValue);
         }) || null;
-      const updatedUnitId = matchingUnit ? matchingUnit.id ?? null : normalizedValue;
-      dispatch({ type: "SET_INGREDIENT", payload: { ...ingredient, selectedUnitId: updatedUnitId } });
+      const updatedUnitId = matchingUnit
+        ? matchingUnit.id ?? normalizedValue
+        : normalizedValue;
+      dispatch({ type: "SET_INGREDIENT", payload: { ...ingredient, shoppingUnitId: updatedUnitId } });
     },
     [ingredient, dispatch]
   );
@@ -89,14 +91,24 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }) {
         name: name.trim(),
         grams: grams,
       };
-      dispatch({ type: "SET_INGREDIENT", payload: { ...ingredient, units: [...ingredient.units, newUnit], selectedUnitId: tempId } });
+      dispatch({
+        type: "SET_INGREDIENT",
+        payload: {
+          ...ingredient,
+          units: [...ingredient.units, newUnit],
+          shoppingUnitId: tempId,
+        },
+      });
     },
     [dispatch, ingredient]
   );
 
   useEffect(() => {
     if (needsClearForm) {
-      dispatch({ type: "SET_INGREDIENT", payload: { ...ingredient, units: [], selectedUnitId: null } });
+      dispatch({
+        type: "SET_INGREDIENT",
+        payload: { ...ingredient, units: [], shoppingUnitId: null },
+      });
     }
   }, [needsClearForm, dispatch, ingredient]);
 
@@ -107,7 +119,11 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }) {
           style={{ textAlign: "center" }}
           labelId="unit-select-label"
           id="unit-select"
-          value={ingredient.selectedUnitId == null ? NULL_UNIT_VALUE : String(ingredient.selectedUnitId)}
+          value={
+            ingredient.shoppingUnitId == null
+              ? NULL_UNIT_VALUE
+              : String(ingredient.shoppingUnitId)
+          }
           onChange={handleSelectedUnitChange}>
           {ingredient.units &&
             ingredient.units.map((unit) => (

--- a/Frontend/src/tests/Planning.test.tsx
+++ b/Frontend/src/tests/Planning.test.tsx
@@ -46,7 +46,7 @@ describe("Planning - ingredient editing updates macros", () => {
         { id: 11, ingredient_id: 1, name: "cup", grams: 100 },
       ],
       tags: [],
-      selectedUnitId: 10,
+      shoppingUnitId: 10,
     },
   ];
 

--- a/Frontend/src/tests/Shopping.test.tsx
+++ b/Frontend/src/tests/Shopping.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, type Mock } from "vitest";
+
+import Shopping from "@/components/shopping/Shopping";
+import { useData } from "@/contexts/DataContext";
+
+vi.mock("@/contexts/DataContext");
+vi.mock("@/components/common/IngredientModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/apiClient", () => ({
+  __esModule: true,
+  default: {
+    path: vi.fn().mockReturnThis(),
+    method: vi.fn().mockReturnThis(),
+    create: vi.fn(),
+  },
+}));
+
+import apiClient from "@/apiClient";
+const mockedClient = vi.mocked(apiClient, true);
+
+const mockUseSessionStorageState = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useSessionStorageState", () => ({
+  __esModule: true,
+  useSessionStorageState: mockUseSessionStorageState,
+}));
+
+describe("Shopping component", () => {
+  const baseIngredient = {
+    id: 1,
+    name: "Oats",
+    units: [
+      { id: 10, ingredient_id: 1, name: "g", grams: 1 },
+      { id: 11, ingredient_id: 1, name: "cup", grams: 90 },
+    ],
+    tags: [],
+    nutrition: null,
+    shoppingUnitId: 10,
+  };
+  let setIngredientsNeedsRefetch: Mock;
+  let startRequest: Mock;
+  let endRequest: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedClient.path.mockReturnThis();
+    mockedClient.method.mockReturnThis();
+    mockedClient.create.mockReturnValue(() => Promise.resolve({}));
+
+    setIngredientsNeedsRefetch = vi.fn();
+    startRequest = vi.fn();
+    endRequest = vi.fn();
+
+    mockUseSessionStorageState.mockImplementation((key: string, initial: unknown) => {
+      if (key === "planning-plan") {
+        return [[{ type: "ingredient", ingredientId: "1", unitId: 10, amount: 1 }], vi.fn()];
+      }
+      if (key === "planning-days") {
+        return [1, vi.fn()];
+      }
+      if (key === "planning-active-plan") {
+        return [{ id: null, label: null, updatedAt: null }, vi.fn()];
+      }
+      const value = typeof initial === "function" ? (initial as () => unknown)() : initial;
+      return [value, vi.fn()];
+    });
+
+    (useData as unknown as Mock).mockReturnValue({
+      ingredients: [baseIngredient],
+      foods: [],
+      fetching: false,
+      setIngredients: vi.fn(),
+      setIngredientsNeedsRefetch,
+      startRequest,
+      endRequest,
+      ingredientProcessingTags: [],
+      ingredientGroupTags: [],
+      ingredientOtherTags: [],
+      foodDietTags: [],
+      foodTypeTags: [],
+      foodOtherTags: [],
+    });
+  });
+
+  it("renders preferred units and updates selection", async () => {
+    render(<Shopping />);
+
+    const row = await screen.findByRole("row", { name: /Oats/i });
+    expect(within(row).getByText(/Plan totals:/i)).toBeInTheDocument();
+
+    const unitSelect = within(row).getByRole("combobox");
+    await userEvent.click(unitSelect);
+    await userEvent.click(screen.getByRole("option", { name: /cup/i }));
+
+    await waitFor(() => {
+      expect(mockedClient.path).toHaveBeenCalledWith(
+        "/api/ingredients/{ingredient_id}",
+        1,
+      );
+      expect(mockedClient.method).toHaveBeenCalledWith("put");
+      expect(mockedClient.create).toHaveBeenCalled();
+      expect(startRequest).toHaveBeenCalled();
+      expect(endRequest).toHaveBeenCalled();
+      expect(setIngredientsNeedsRefetch).toHaveBeenCalledWith(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add SQLModel, schema, and migration support for storing an ingredient's preferred shopping unit
- propagate the preferred unit through the API client, data context, and shopping utilities so totals convert automatically
- update shopping UI and ingredient forms to select the preferred unit and cover the new flows with tests

## Testing
- pytest
- npx --prefix Frontend vitest run


------
https://chatgpt.com/codex/tasks/task_e_68cd8f1173848322b84fa58c1bf34754