### PR TITLE
Add unique constraint for ingredient unit composite key

### DIFF
--- a/Backend/migrations/versions/d3f0b1c2e7ad_create_ingredient_shopping_units.py
+++ b/Backend/migrations/versions/d3f0b1c2e7ad_create_ingredient_shopping_units.py
@@ -12,6 +12,11 @@ depends_on = None
 
 def upgrade():
     """Create ingredient_shopping_units table."""
+    op.create_unique_constraint(
+        "uq_ingredient_units_ingredient_id_id",
+        "ingredient_units",
+        ["ingredient_id", "id"],
+    )
     op.create_table(
         "ingredient_shopping_units",
         sa.Column("ingredient_id", sa.Integer(), nullable=False),
@@ -38,3 +43,8 @@ def upgrade():
 def downgrade():
     """Drop ingredient_shopping_units table."""
     op.drop_table("ingredient_shopping_units")
+    op.drop_constraint(
+        "uq_ingredient_units_ingredient_id_id",
+        "ingredient_units",
+        type_="unique",
+    )

--- a/Backend/models/ingredient_unit.py
+++ b/Backend/models/ingredient_unit.py
@@ -1,13 +1,18 @@
 from typing import Optional
 
 from sqlmodel import SQLModel, Field, Relationship
-from sqlalchemy import Column, String, Numeric
+from sqlalchemy import Column, String, Numeric, UniqueConstraint
 
 
 class IngredientUnit(SQLModel, table=True):
     """Measurement unit for an ingredient."""
 
     __tablename__ = "ingredient_units"
+    __table_args__ = (
+        UniqueConstraint(
+            "ingredient_id", "id", name="uq_ingredient_units_ingredient_id_id"
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     ingredient_id: Optional[int] = Field(


### PR DESCRIPTION
## Summary
- add a unique constraint on ingredient_units.(ingredient_id, id) before declaring the composite foreign key in the ingredient_shopping_units migration
- mirror the new unique constraint in the IngredientUnit SQLModel metadata so ORM and database stay aligned

## Testing
- pytest Backend/tests/test_api.py::test_ingredient_crud

------
https://chatgpt.com/codex/tasks/task_e_68cdb7d9e15c8322ba843398794f3468