### PR TITLE
Fix ingredient shopping unit serialization

### DIFF
--- a/Backend/tests/test_api.py
+++ b/Backend/tests/test_api.py
@@ -38,6 +38,56 @@ def test_ingredient_crud(client: TestClient) -> None:
     assert response.status_code == 404
 
 
+def test_ingredient_update_with_shopping_unit_id_only(client: TestClient) -> None:
+    """Selecting a preferred unit by id should not require the relationship to be loaded."""
+
+    create_payload = {
+        "name": "Rolled Oats",
+        "nutrition": None,
+        "units": [
+            {"name": "cup", "grams": 85},
+            {"name": "g", "grams": 1},
+        ],
+        "tags": [],
+    }
+    response = client.post("/api/ingredients/", json=create_payload)
+    assert response.status_code == 201
+    ingredient = response.json()
+
+    gram_unit = next(unit for unit in ingredient["units"] if unit["name"] == "g")
+    update_payload = {
+        "name": ingredient["name"],
+        "nutrition": None,
+        "units": [
+            {
+                "id": unit["id"],
+                "name": unit["name"],
+                "grams": unit["grams"],
+            }
+            for unit in ingredient["units"]
+            if unit["name"] != "g"
+        ],
+        "tags": [],
+        "shopping_unit": {
+            "unit_id": gram_unit["id"],
+            "name": gram_unit["name"],
+            "grams": gram_unit["grams"],
+        },
+    }
+
+    response = client.put(f"/api/ingredients/{ingredient['id']}", json=update_payload)
+    assert response.status_code == 200
+    updated = response.json()
+    assert updated["shopping_unit_id"] == gram_unit["id"]
+    assert updated["shopping_unit"]["name"] == "g"
+
+    response = client.get("/api/ingredients/")
+    assert response.status_code == 200
+    fetched = next(item for item in response.json() if item["id"] == ingredient["id"])
+    assert fetched["shopping_unit_id"] == gram_unit["id"]
+    assert fetched["shopping_unit"]["name"] == "g"
+
+
 def test_food_crud(client: TestClient) -> None:
     response = client.post(
         "/api/foods",


### PR DESCRIPTION
## Summary
- build IngredientRead responses with a sanitized shopping unit payload so validation never fails when the relationship is unloaded
- add a regression test to cover selecting the gram unit with only an id in the update request

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce06957d088322b3cc3c11243f870f