### PR TITLE
Fix React hook dependencies for lint

### DIFF
--- a/Frontend/src/components/data/food/form/FoodForm.tsx
+++ b/Frontend/src/components/data/food/form/FoodForm.tsx
@@ -147,8 +147,15 @@ function FoodForm({ foodToEditData }) {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     };
-    // eslint-disable-next-line react-hooks-exhaustive-deps
-  }, [foodToEdit, isOpen, isEditMode, hasContent]);
+  }, [
+    foodToEdit,
+    isOpen,
+    isEditMode,
+    hasContent,
+    startRequest,
+    endRequest,
+    setFoodsNeedsRefetch,
+  ]);
 
   const handleFoodDelete = () => {
     if (foodToEdit) {
@@ -212,13 +219,13 @@ function FoodForm({ foodToEditData }) {
     if (needsClearForm) {
       dispatch({ type: "SET_CLEAR_FORM", payload: false });
     }
-  }, [needsClearForm]); // Reset needsClearForm flag after it's been used
+  }, [needsClearForm, dispatch]); // Reset needsClearForm flag after it's been used
 
   useEffect(() => {
     if (needsFillForm) {
       dispatch({ type: "SET_FILL_FORM", payload: false });
     }
-  }, [needsFillForm]); // Reset needsFillForm flag after it's been used
+  }, [needsFillForm, dispatch]); // Reset needsFillForm flag after it's been used
   //#endregion Effects
 
   return (

--- a/Frontend/src/components/data/ingredient/form/IngredientForm.tsx
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.tsx
@@ -50,7 +50,7 @@ function IngredientForm({ ingredientToEditData }: IngredientFormProps) {
         }
       },
     });
-  }, [isEditMode, save]);
+  }, [isEditMode, save, setIsEditMode]);
 
   const handleIngredientDelete = useCallback(() => {
     remove({

--- a/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
+++ b/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
@@ -151,27 +151,30 @@ export const useIngredientForm = () => {
   const { setIngredientsNeedsRefetch, startRequest, endRequest } = useData();
   const [state, dispatch] = useSessionStorageReducer(reducer, createInitialState, "ingredient-form-state-v1");
 
-  const loadIngredient = useCallback((initial?: IngredientRead | null) => {
-    if (initial) {
-      dispatch({ type: "SET_INGREDIENT", payload: { ...initial } });
-      dispatch({ type: "SET_FILL_FORM", payload: true });
-    } else {
-      dispatch({ type: "SET_INGREDIENT", payload: initializeEmptyIngredient() });
-    }
-  }, []);
+  const loadIngredient = useCallback(
+    (initial?: IngredientRead | null) => {
+      if (initial) {
+        dispatch({ type: "SET_INGREDIENT", payload: { ...initial } });
+        dispatch({ type: "SET_FILL_FORM", payload: true });
+      } else {
+        dispatch({ type: "SET_INGREDIENT", payload: initializeEmptyIngredient() });
+      }
+    },
+    [dispatch],
+  );
 
   const clearForm = useCallback(() => {
     dispatch({ type: "SET_INGREDIENT", payload: initializeEmptyIngredient() });
     dispatch({ type: "SET_CLEAR_FORM", payload: true });
-  }, []);
+  }, [dispatch]);
 
   const acknowledgeClearFlag = useCallback(() => {
     dispatch({ type: "SET_CLEAR_FORM", payload: false });
-  }, []);
+  }, [dispatch]);
 
   const acknowledgeFillFlag = useCallback(() => {
     dispatch({ type: "SET_FILL_FORM", payload: false });
-  }, []);
+  }, [dispatch]);
 
   const save = useCallback(
     async ({ mode, onSaved, autoClearOnAdd = true }: SaveOptions) => {

--- a/Frontend/src/components/planning/Planning.tsx
+++ b/Frontend/src/components/planning/Planning.tsx
@@ -280,9 +280,19 @@ function Planning() {
       setIsDirty(false);
       setStatusMessage(message ?? `Loaded plan "${saved.label}"`);
       setSaveError(null);
-    },
-    [lastSavedPayloadRef, setStatusMessage]
-  );
+  }, [
+    lastSavedPayloadRef,
+    setActivePlan,
+    setDays,
+    setDaysError,
+    setIsDirty,
+    setOpen,
+    setPlan,
+    setSaveError,
+    setSaveLabel,
+    setStatusMessage,
+    setTargetMacros,
+  ]);
 
   useEffect(() => {
     const current = buildPayload();


### PR DESCRIPTION
## Summary
- include missing functions in FoodForm autosave effect dependencies and clean up flag effects
- add dispatch-aware dependencies to ingredient form hooks
- ensure Planning applySavedPlan callback lists all state setters it uses

## Testing
- `npm --prefix Frontend run lint`
- `./scripts/run-tests.sh --full`


------
https://chatgpt.com/codex/tasks/task_e_68cee3662b4c8322885e3520034e8cd9