### PR TITLE
Fix shopping plan totals label and API path

### DIFF
--- a/Frontend/src/components/shopping/Shopping.tsx
+++ b/Frontend/src/components/shopping/Shopping.tsx
@@ -269,7 +269,7 @@ function Shopping() {
       try {
         const payload = buildUpdatePayload(ingredient, parsed);
         await apiClient
-          .path(`/api/ingredients/${ingredientId}`)
+          .path("/api/ingredients/{ingredient_id}", ingredientId)
           .method("put")
           .create()({ body: payload });
         setIngredientsNeedsRefetch(true);
@@ -426,10 +426,15 @@ function Shopping() {
                     <TableCell align="right">
                       {preferredLabel ? (
                         <>
-                          <Typography component="div">{preferredLabel}</Typography>
+                          <Typography component="div">
+                            <Box component="span" sx={{ fontWeight: 600 }}>
+                              Plan totals:
+                            </Box>{" "}
+                            {preferredLabel}
+                          </Typography>
                           {normalizedDays > 1 && preferredPerDay && (
                             <Typography variant="body2" color="text.secondary">
-                              {preferredPerDay} per day
+                              Per day: {preferredPerDay}
                             </Typography>
                           )}
                         </>


### PR DESCRIPTION
## Summary
- add a "Plan totals" label to the shopping list preferred unit display
- include a "Per day" label when showing normalized per-day totals
- call the typed ingredient update endpoint with the templated path signature

## Testing
- npm test -- Shopping

------
https://chatgpt.com/codex/tasks/task_e_68cee5effe6c832294f1ea39a192ea5e