### PR TITLE
Update README contexts path

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Nutrition/
 ## Core Concepts
 
 - **Backend** – FastAPI routes under `Backend/routes`, models in `Backend/models`, migrations in `Backend/migrations`.
-- **Frontend** – React application under `Frontend/` with shared state in `Frontend/src/context`.
+- **Frontend** – React application under `Frontend/` with shared state in `Frontend/src/contexts`.
 - **Database** – Postgres schema managed by Alembic; branch scripts seed either test or production-style fixtures.
 - **Automation** – Helper scripts keep API artifacts (OpenAPI + TypeScript types) and migrations in sync.
 


### PR DESCRIPTION
## Summary
- update the Core Concepts description to reference the pluralized `Frontend/src/contexts` directory
- ensure the README no longer mentions the outdated `Frontend/src/context` path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf13064bdc8322a698d9ef3bb42d51