### PR TITLE
Clarify docker compose down customization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,9 @@ pwsh ./scripts/docker/compose.ps1 down
 # add `type -test` to target the test stack
 ```
 
-`down` removes branch-specific volumes by default for clean isolation. Pass `-- [compose args]` if you need custom Docker flags.
+`down` removes branch-specific volumes by default for clean isolation. The wrapper does not forward extra Docker Compose flags for
+this subcommand—if you need a different teardown (for example, keeping volumes or removing additional resources) run `docker
+compose` directly with the branch project name that `up` prints (e.g. `docker compose -p nutrition-my-branch down`).
 
 Restart services:
 


### PR DESCRIPTION
## Summary
- update the Docker workflow docs to explain that the wrapper does not pass additional flags to docker compose down
- document that contributors should run raw docker compose commands when they need alternative teardown behavior

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68cf13134c048322b951bb83eb665927