### PR TITLE
Document API routes with /api prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ Nutrition/
 
 ## API Highlights
 
-- `GET /ingredients` / `POST /ingredients` – list and create ingredients.
-- `GET /foods` / `POST /foods` – list and create composite foods.
-- `GET /ingredients/possible_tags` / `GET /foods/possible_tags` – discover available filters.
+- `GET /api/ingredients` / `POST /api/ingredients` – list and create ingredients.
+- `GET /api/foods` / `POST /api/foods` – list and create composite foods.
+- `GET /api/ingredients/possible_tags` / `GET /api/foods/possible_tags` – discover available filters.
 
 Detailed endpoint documentation is available at `http://localhost:<DEV_BACKEND_PORT>/docs` when the backend container is running.
 


### PR DESCRIPTION
## Summary
- update README API highlights to document the full /api/... routes for core endpoints
- ensure the ingredients and foods possible_tags example also uses the /api prefix so the list is consistent

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf1f18879483228f2484faa3ad5cde