### PR TITLE
Align frontend diagram with PossibleFoodTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,15 @@ erDiagram
 
 </details>
 
+Frontend state mirrors the API schema, so food tags reference the shared `PossibleFoodTag` definitions surfaced by `/api/foods/possible_tags`.
+
 <details>
 <summary>Frontend Structures (Mermaid)</summary>
 
 ```mermaid
 classDiagram
   class Ingredient { id; name; Nutrition nutrition; IngredientUnit[] units }
-  class Food { id; name; FoodIngredient[] ingredients; FoodTag[] tags }
+  class Food { id; name; FoodIngredient[] ingredients; PossibleFoodTag[] tags }
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- document that frontend food tags reuse PossibleFoodTag records surfaced by the API
- update the frontend Mermaid diagram so Food.tags uses PossibleFoodTag[]

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf20f487688322bf014ad8bbbd8d80