### PR TITLE
Add sqlite fallback for local backend setup

### DIFF
--- a/Backend/tests/test_settings.py
+++ b/Backend/tests/test_settings.py
@@ -1,0 +1,39 @@
+import importlib
+
+
+def _reload_settings():
+    # Reload the module so the singleton picks up environment changes.
+    module = importlib.import_module("Backend.settings")
+    importlib.reload(module)
+    return module.settings
+
+
+def test_settings_fallbacks_to_sqlite(tmp_path, monkeypatch):
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_AUTO_CREATE", raising=False)
+
+    settings = _reload_settings()
+    assert settings.database_url == "sqlite:///./nutrition.db"
+    assert settings.db_auto_create is True
+
+
+def test_settings_respects_provided_database_url(monkeypatch):
+    monkeypatch.setenv(
+        "DATABASE_URL", "postgresql://nutrition_user:nutrition_pass@db:5432/nutrition"
+    )
+    monkeypatch.delenv("DB_AUTO_CREATE", raising=False)
+
+    settings = _reload_settings()
+    assert settings.database_url.endswith("@db:5432/nutrition")
+    assert settings.db_auto_create is False
+
+
+def test_db_auto_create_can_be_overridden(monkeypatch):
+    monkeypatch.delenv("SQLALCHEMY_DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("DB_AUTO_CREATE", "false")
+
+    settings = _reload_settings()
+    assert settings.database_url == "sqlite:///./nutrition.db"
+    assert settings.db_auto_create is False


### PR DESCRIPTION
## Summary
- default the backend to a local SQLite database when no DATABASE_URL variables are provided, and enable automatic schema creation for that case
- document the new precedence in settings
- add tests that exercise the fallback, environment override behaviour, and DB_AUTO_CREATE flag handling

## Testing
- pytest Backend/tests/test_settings.py -q
- pytest Backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cf2b1f776c8322a5fb276c7b0d53a9