### PR TITLE
Fix Alembic configuration fallback and harden migration for SQLite

### DIFF
--- a/Backend/db.py
+++ b/Backend/db.py
@@ -7,10 +7,17 @@ from sqlmodel import SQLModel, Session, create_engine
 
 from Backend.settings import settings
 
+# ``DATABASE_URL`` used to be exported as a module level constant and some of
+# the auxiliary tooling (most notably the Alembic environment script) still
+# looks for it when resolving the database connection string.  Keeping the
+# constant in sync with the Settings instance ensures those legacy code paths
+# continue to work while the rest of the application relies on ``settings``.
+DATABASE_URL = settings.database_url
+
 # Create the engine and configured ``SessionLocal`` class used throughout the
 # application. ``autocommit`` and ``autoflush`` are disabled so changes are only
 # persisted when explicitly committed.
-engine = create_engine(settings.database_url)
+engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, class_=Session)
 
 # Alias ``SQLModel`` as ``Base`` to mimic the previous declarative base.
@@ -26,4 +33,4 @@ def get_db() -> Generator[Session, None, None]:
         db.close()
 
 
-__all__ = ["Base", "engine", "SessionLocal", "get_db"]
+__all__ = ["Base", "engine", "SessionLocal", "get_db", "DATABASE_URL"]

--- a/Backend/migrations/versions/3a2af5cf8e9b_rename_meal_to_food.py
+++ b/Backend/migrations/versions/3a2af5cf8e9b_rename_meal_to_food.py
@@ -11,18 +11,50 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.rename_table("meals", "foods")
-    op.rename_table("meal_ingredients", "food_ingredients")
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    tables = set(inspector.get_table_names())
+
+    if "meals" in tables and "foods" not in tables:
+        op.rename_table("meals", "foods")
+        tables.discard("meals")
+        tables.add("foods")
+
+    if "meal_ingredients" in tables and "food_ingredients" not in tables:
+        op.rename_table("meal_ingredients", "food_ingredients")
+        tables.discard("meal_ingredients")
+        tables.add("food_ingredients")
+
+    inspector = sa.inspect(connection)
     with op.batch_alter_table("food_ingredients") as batch_op:
         batch_op.alter_column("meal_id", new_column_name="food_id")
-        batch_op.drop_constraint("meal_ingredients_meal_id_fkey", type_="foreignkey")
-        batch_op.create_foreign_key(None, "foods", ["food_id"], ["id"])
-    op.rename_table("meal_tags", "food_tags")
+        fk_name = None
+        for fk in inspector.get_foreign_keys("food_ingredients"):
+            if set(fk.get("constrained_columns", [])) == {"food_id"}:
+                fk_name = fk.get("name")
+                break
+
+        if fk_name:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+            batch_op.create_foreign_key(None, "foods", ["food_id"], ["id"])
+    if "meal_tags" in tables and "food_tags" not in tables:
+        op.rename_table("meal_tags", "food_tags")
+        tables.discard("meal_tags")
+        tables.add("food_tags")
+    inspector = sa.inspect(connection)
     with op.batch_alter_table("food_tags") as batch_op:
         batch_op.alter_column("meal_id", new_column_name="food_id")
-        batch_op.drop_constraint("meal_tags_meal_id_fkey", type_="foreignkey")
-        batch_op.create_foreign_key(None, "foods", ["food_id"], ["id"])
-    op.rename_table("possible_meal_tags", "possible_food_tags")
+        fk_name = None
+        for fk in inspector.get_foreign_keys("food_tags"):
+            if set(fk.get("constrained_columns", [])) == {"food_id"}:
+                fk_name = fk.get("name")
+                break
+
+        if fk_name:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+            batch_op.create_foreign_key(None, "foods", ["food_id"], ["id"])
+    if "possible_meal_tags" in tables and "possible_food_tags" not in tables:
+        op.rename_table("possible_meal_tags", "possible_food_tags")
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
- restore a module-level `DATABASE_URL` constant so Alembic inherits the same connection string as the runtime settings
- make the meal-to-food rename migration tolerant of already-renamed tables and unnamed foreign keys when running outside Postgres

## Testing
- pytest Backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68cf2f84fbac8322864463c2df4be5d2