### PR TITLE
Handle existing plans table in migration

### DIFF
--- a/Backend/migrations/versions/1a2b3c4d5e66_add_plans_table.py
+++ b/Backend/migrations/versions/1a2b3c4d5e66_add_plans_table.py
@@ -12,26 +12,39 @@ depends_on = None
 
 def upgrade():
     """Create plans table."""
-    op.create_table(
-        "plans",
-        sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("label", sa.String(length=255), nullable=False),
-        sa.Column("payload", sa.JSON(), nullable=False),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.func.now(),
-            nullable=False,
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(timezone=True),
-            server_default=sa.func.now(),
-            nullable=False,
-        ),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index("ix_plans_label", "plans", ["label"], unique=False)
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    table_exists = inspector.has_table("plans")
+
+    if not table_exists:
+        op.create_table(
+            "plans",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("label", sa.String(length=255), nullable=False),
+            sa.Column("payload", sa.JSON(), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    indexes = {index["name"] for index in inspector.get_indexes("plans")} if table_exists else set()
+    if table_exists and "ix_plans_label" in indexes:
+        return
+
+    # Create the label index when missing (or immediately after creating the table above).
+    if "ix_plans_label" not in indexes:
+        op.create_index("ix_plans_label", "plans", ["label"], unique=False)
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- prevent the plans migration from attempting to recreate the table when it already exists
- ensure the plans label index is created only when missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf52396cd4832299b1abf8df9950bd