### PR TITLE
Fix macro input handling for ingredients

### DIFF
--- a/Frontend/src/components/data/ingredient/form/NutritionEdit.test.tsx
+++ b/Frontend/src/components/data/ingredient/form/NutritionEdit.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+
+import NutritionEdit from "./NutritionEdit";
+
+describe("NutritionEdit", () => {
+  const baseIngredient = {
+    id: 1,
+    name: "Test Ingredient",
+    units: [
+      {
+        id: "unit-1",
+        ingredient_id: 1,
+        name: "g",
+        grams: "1",
+      },
+    ],
+    shoppingUnitId: "unit-1",
+    nutrition: {
+      calories: 0,
+      protein: 0,
+      carbohydrates: 0,
+      fat: 0,
+      fiber: 0,
+    },
+    tags: [],
+  };
+
+  it("allows users to type into the macro fields", async () => {
+    render(
+      <NutritionEdit
+        ingredient={baseIngredient as never}
+        dispatch={vi.fn()}
+        needsClearForm={false}
+        needsFillForm={false}
+      />,
+    );
+
+    const caloriesInput = screen.getByLabelText(/calories/i) as HTMLInputElement;
+
+    await userEvent.clear(caloriesInput);
+    await userEvent.type(caloriesInput, "1");
+    expect(caloriesInput).toHaveValue("1");
+
+    await userEvent.type(caloriesInput, "2");
+    expect(caloriesInput).toHaveValue("12");
+
+    await userEvent.type(caloriesInput, "3");
+    expect(caloriesInput).toHaveValue("123");
+  });
+});

--- a/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
@@ -20,9 +20,12 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
   };
 
   const handleFieldEdit = (key, value) => {
-    // Allow empty, integers, and decimals while typing (e.g. "1.")
-    const isValidPartialNumber = value === "" || /^(\\d+)?([.,]\\d*)?$/.test(value);
-    if (!isValidPartialNumber) return;
+    const sanitizedValue = typeof value === "string" ? value.replace(",", ".") : String(value ?? "");
+    const partialNumberPattern = /^(\d+)?(\.\d*)?$/;
+    const isValidPartialNumber = sanitizedValue === "" || partialNumberPattern.test(sanitizedValue) || sanitizedValue === ".";
+    if (!isValidPartialNumber) {
+      return;
+    }
 
     setDisplayedNutrition({
       ...displayNutrition,


### PR DESCRIPTION
## Summary
- relax the ingredient nutrition input guard so decimals and digits can be entered reliably
- add a focused unit test that verifies users can type macros without values resetting

## Testing
- `pytest -vv -rd -m 'not e2e'`
- `CI=true npm --prefix Frontend test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68cf7845f6708322b513c6e67c404087