### PR TITLE
Document script catalog and update agent guidance

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -80,6 +80,7 @@ Maintenance rules:
 
 ## Script parity checks
 - Scripts in `scripts/` have PowerShell (`.ps1`) and Bash (`.sh`) variants unless noted. Keep both variants in sync when editing, and document intentional differences such as the Docker compose helpers (`compose.ps1` restores dumps; `compose.sh` seeds from CSV).
+- The `Script catalog & call graph` section in `CONTRIBUTING.md` is the canonical reference for script entry points and flags. Any script change (behavior, flags, new helper, removed helper) must update that section.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a comprehensive script catalog to CONTRIBUTING.md describing entry points, flags, and call relationships
- remind contributors via docs/AGENTS.md to keep the new catalog in sync with future script changes

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d01d419378832299495891c93c94bf