### PR TITLE
Fix lint error in NutritionEdit partial input handling

### DIFF
--- a/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
@@ -30,6 +30,9 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
   const handleFieldEdit = (key, value) => {
     // Allow empty, integers, and decimals while typing (e.g. "1.")
     const isValidPartialNumber = value === "" || /^(\d+)?([.,]\d*)?$/.test(value);
+    if (!isValidPartialNumber) {
+      return;
+    }
 
     setDisplayedNutrition({
       ...displayNutrition,


### PR DESCRIPTION
## Summary
- prevent invalid characters from updating the nutrition edit fields by ignoring non-numeric input while typing

## Testing
- npm --prefix Frontend run lint

------
https://chatgpt.com/codex/tasks/task_e_68d04b855c0483228cbe2c3e23b6ba60