### PR TITLE
Clear zero macro fields on focus

### DIFF
--- a/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
@@ -27,6 +27,43 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
     },
   };
 
+  const shouldClearOnFocus = (value: unknown) => {
+    if (value === "" || value == null) {
+      return false;
+    }
+
+    if (typeof value === "number") {
+      return value === 0;
+    }
+
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed === "") {
+        return false;
+      }
+
+      const normalized = trimmed.replace(",", ".");
+      const parsed = Number.parseFloat(normalized);
+      return !Number.isNaN(parsed) && parsed === 0;
+    }
+
+    return false;
+  };
+
+  const handleFieldFocus = (key) => {
+    setDisplayedNutrition((prev) => {
+      const current = prev[key];
+      if (!shouldClearOnFocus(current)) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [key]: "",
+      };
+    });
+  };
+
   const handleFieldEdit = (key, value) => {
     // Allow empty, integers, and decimals while typing (e.g. "1.")
     const isValidPartialNumber = value === "" || /^(\d+)?([.,]\d*)?$/.test(value);
@@ -133,6 +170,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
       <TextField
         label="Calories"
         value={displayNutrition.calories}
+        onFocus={() => handleFieldFocus("calories")}
         onChange={(e) => handleFieldEdit("calories", e.target.value)}
         onBlur={handleFieldEditFinish}
         variant="outlined"
@@ -145,6 +183,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
       <TextField
         label="Protein"
         value={displayNutrition.protein}
+        onFocus={() => handleFieldFocus("protein")}
         onChange={(e) => handleFieldEdit("protein", e.target.value)}
         onBlur={handleFieldEditFinish}
         variant="outlined"
@@ -157,6 +196,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
       <TextField
         label="Carbs"
         value={displayNutrition.carbohydrates}
+        onFocus={() => handleFieldFocus("carbohydrates")}
         onChange={(e) => handleFieldEdit("carbohydrates", e.target.value)}
         onBlur={handleFieldEditFinish}
         variant="outlined"
@@ -169,6 +209,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
       <TextField
         label="Fat"
         value={displayNutrition.fat}
+        onFocus={() => handleFieldFocus("fat")}
         onChange={(e) => handleFieldEdit("fat", e.target.value)}
         onBlur={handleFieldEditFinish}
         variant="outlined"
@@ -181,6 +222,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
       <TextField
         label="Fiber"
         value={displayNutrition.fiber}
+        onFocus={() => handleFieldFocus("fiber")}
         onChange={(e) => handleFieldEdit("fiber", e.target.value)}
         onBlur={handleFieldEditFinish}
         variant="outlined"

--- a/Frontend/src/tests/NutritionEdit.test.tsx
+++ b/Frontend/src/tests/NutritionEdit.test.tsx
@@ -44,4 +44,34 @@ describe("NutritionEdit", () => {
 
     expect(caloriesInput).toHaveValue("123");
   });
+
+  it("clears default zero values when a macro field receives focus", async () => {
+    const dispatch = vi.fn();
+    const zeroIngredient = {
+      ...buildIngredient(),
+      nutrition: {
+        calories: 0,
+        protein: 0,
+        carbohydrates: 0,
+        fat: 0,
+        fiber: 0,
+      },
+    };
+
+    render(
+      <NutritionEdit
+        ingredient={zeroIngredient}
+        dispatch={dispatch}
+        needsClearForm={false}
+        needsFillForm={false}
+      />,
+    );
+
+    const proteinInput = screen.getByLabelText(/Protein/i);
+    expect(proteinInput).toHaveValue("0");
+
+    await userEvent.click(proteinInput);
+
+    expect(proteinInput).toHaveValue("");
+  });
 });


### PR DESCRIPTION
## Summary
- clear default macro values when focusing edit inputs so the placeholder zero goes away immediately
- add a helper to detect zero values across string/number states and apply it to every macro field
- cover the focus-clearing behavior with a NutritionEdit component test

## Testing
- npm --prefix Frontend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d06eca4bd0832286f0cc889b57ab91