### PR TITLE
Fix shopping unit update path

### DIFF
--- a/Frontend/src/components/data/food/form/FoodForm.tsx
+++ b/Frontend/src/components/data/food/form/FoodForm.tsx
@@ -132,9 +132,9 @@ function FoodForm({ foodToEditData }) {
       try {
         const payload = buildFoodPayload(foodToEdit);
         await apiClient
-          .path("/api/foods/{food_id}")
+          .path(`/api/foods/${foodToEdit.id}`)
           .method("put")
-          .create()({ path: { food_id: foodToEdit.id }, body: payload });
+          .create()({ body: payload });
         setFoodsNeedsRefetch(true);
       } catch (e) {
         console.error("Autosave error:", e);

--- a/Frontend/src/components/shopping/Shopping.tsx
+++ b/Frontend/src/components/shopping/Shopping.tsx
@@ -269,7 +269,7 @@ function Shopping() {
       try {
         const payload = buildUpdatePayload(ingredient, parsed);
         await apiClient
-          .path("/api/ingredients/{ingredient_id}", ingredientId)
+          .path(`/api/ingredients/${ingredientId}`)
           .method("put")
           .create()({ body: payload });
         setIngredientsNeedsRefetch(true);

--- a/Frontend/src/tests/Shopping.test.tsx
+++ b/Frontend/src/tests/Shopping.test.tsx
@@ -99,10 +99,7 @@ describe("Shopping component", () => {
     await userEvent.click(screen.getByRole("option", { name: /cup/i }));
 
     await waitFor(() => {
-      expect(mockedClient.path).toHaveBeenCalledWith(
-        "/api/ingredients/{ingredient_id}",
-        1,
-      );
+      expect(mockedClient.path).toHaveBeenCalledWith("/api/ingredients/1");
       expect(mockedClient.method).toHaveBeenCalledWith("put");
       expect(mockedClient.create).toHaveBeenCalled();
       expect(startRequest).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- update shopping list unit change requests to target the concrete ingredient ID
- align the food autosave flow with direct resource URLs instead of templated paths
- refresh the Shopping component test expectation for the new path shape

## Testing
- npm --prefix Frontend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d348dde4208322a03a4523e81afac5