### PR TITLE
Simplify shopping list unit display

### DIFF
--- a/Frontend/src/tests/Shopping.test.tsx
+++ b/Frontend/src/tests/Shopping.test.tsx
@@ -92,7 +92,8 @@ describe("Shopping component", () => {
     render(<Shopping />);
 
     const row = await screen.findByRole("row", { name: /Oats/i });
-    expect(within(row).getByText(/Plan totals:/i)).toBeInTheDocument();
+    const cells = within(row).getAllByRole("cell");
+    expect(cells[2]).toHaveTextContent(/^1$/);
 
     const unitSelect = within(row).getByRole("combobox");
     await userEvent.click(unitSelect);


### PR DESCRIPTION
## Summary
- remove extra total weight and per-day details from the shopping list table
- show only the quantity for the resolved shopping unit, defaulting to a plan unit when no preference exists
- update the shopping list test to cover the simplified quantity display

## Testing
- npx vitest run src/tests/Shopping.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d3533898008322a604cb3f5c55cd05