### PR TITLE
Refine shopping list display

### DIFF
--- a/Frontend/src/components/shopping/Shopping.tsx
+++ b/Frontend/src/components/shopping/Shopping.tsx
@@ -324,7 +324,10 @@ function Shopping() {
   } else {
     content = (
       <Box sx={{ mt: 3 }}>
-        <TableContainer component={Paper}>
+        <TableContainer
+          component={Paper}
+          sx={{ width: { xs: "100%", sm: "fit-content" }, maxWidth: "100%", mx: "auto" }}
+        >
           <Table>
             <TableHead>
               <TableRow>
@@ -359,8 +362,11 @@ function Shopping() {
                   item.preferredUnitTotal ??
                   item.unitTotals[0] ??
                   null;
+                const displayUnitName = displayUnitTotal?.unitName?.trim() ?? "";
                 const quantityLabel = displayUnitTotal
-                  ? formatCellNumber(displayUnitTotal.quantity)
+                  ? displayUnitName
+                    ? `${formatCellNumber(displayUnitTotal.quantity)} ${displayUnitName}`
+                    : `${formatCellNumber(displayUnitTotal.quantity)}`
                   : "—";
 
                 return (
@@ -386,16 +392,12 @@ function Shopping() {
                         <MenuItem value={CLEAR_SELECTION_VALUE}>No preference</MenuItem>
                         {(contextIngredient.units ?? []).map((unit) => {
                           const optionValue = toOptionValue(unit.id);
-                          const grams = Number(unit.grams);
-                          const gramsLabel = Number.isFinite(grams)
-                            ? formatCellNumber(grams)
-                            : unit.grams;
                           return (
                             <MenuItem
                               key={`${optionValue}-${unit.name}`}
                               value={optionValue}
                             >
-                              {unit.name} ({gramsLabel} g)
+                              {unit.name}
                             </MenuItem>
                           );
                         })}

--- a/Frontend/src/tests/Shopping.test.tsx
+++ b/Frontend/src/tests/Shopping.test.tsx
@@ -93,7 +93,7 @@ describe("Shopping component", () => {
 
     const row = await screen.findByRole("row", { name: /Oats/i });
     const cells = within(row).getAllByRole("cell");
-    expect(cells[2]).toHaveTextContent(/^1$/);
+    expect(cells[2]).toHaveTextContent(/^1 g$/);
 
     const unitSelect = within(row).getByRole("combobox");
     await userEvent.click(unitSelect);


### PR DESCRIPTION
## Summary
- adjust the shopping list table container so it fits the content instead of spanning the full width
- remove gram counts from the unit selector options and show the unit name beside the quantity to buy

## Testing
- npm --prefix Frontend test -- --run Shopping

------
https://chatgpt.com/codex/tasks/task_e_68d3552624d88322a3de48221ba557b5