### PR TITLE
Add hydration state to data context

### DIFF
--- a/Frontend/src/components/shopping/Shopping.tsx
+++ b/Frontend/src/components/shopping/Shopping.tsx
@@ -123,6 +123,7 @@ function Shopping() {
     foods,
     ingredients,
     fetching,
+    hydrating,
     setIngredients,
     setIngredientsNeedsRefetch,
     startRequest,
@@ -294,7 +295,7 @@ function Shopping() {
     : "Based on current plan";
 
   let content: React.ReactNode;
-  if (fetching) {
+  if (hydrating) {
     content = (
       <Box sx={{ display: "flex", alignItems: "center", gap: 2, mt: 3 }}>
         <CircularProgress />
@@ -426,7 +427,7 @@ function Shopping() {
         {normalizedDays > 1 ? ` • ${normalizedDays} days` : ""}
       </Typography>
       {content}
-      {!fetching && !planIsEmpty && items.length > 0 && issues.length > 0 && (
+      {!hydrating && !planIsEmpty && items.length > 0 && issues.length > 0 && (
         <Alert severity="warning" sx={{ mt: 3 }}>
           Some items could not be combined:
           <Box component="ul" sx={{ mt: 1, pl: 3, mb: 0 }}>

--- a/Frontend/src/tests/Shopping.test.tsx
+++ b/Frontend/src/tests/Shopping.test.tsx
@@ -75,6 +75,8 @@ describe("Shopping component", () => {
       ingredients: [baseIngredient],
       foods: [],
       fetching: false,
+      hydrating: false,
+      hydrated: true,
       setIngredients: vi.fn(),
       setIngredientsNeedsRefetch,
       startRequest,


### PR DESCRIPTION
## Summary
- add hydrating/hydrated state to the shared data context so callers can distinguish first-load hydration from later requests
- gate the shopping list's blocking spinner on the new hydration flag while leaving background refetches visible
- adjust the shopping unit test to the expanded context surface

## Testing
- npm --prefix Frontend test -- Shopping

------
https://chatgpt.com/codex/tasks/task_e_68d357deb7108322b9ac73882ca3171b