### PR TITLE
Fix unused fetching variable in Shopping component

### DIFF
--- a/Frontend/src/components/shopping/Shopping.tsx
+++ b/Frontend/src/components/shopping/Shopping.tsx
@@ -122,7 +122,6 @@ function Shopping() {
   const {
     foods,
     ingredients,
-    fetching,
     hydrating,
     setIngredients,
     setIngredientsNeedsRefetch,


### PR DESCRIPTION
## Summary
- remove the unused `fetching` value from the Shopping component's data context destructuring to satisfy eslint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6cc7b60008322bf6f13893a1e1268