### PR TITLE
Create reusable decimal input component for planning and cooking

### DIFF
--- a/Frontend/src/components/common/DecimalInput.tsx
+++ b/Frontend/src/components/common/DecimalInput.tsx
@@ -29,21 +29,18 @@ const DecimalInput: React.FC<DecimalInputProps> = ({
   const [inputValue, setInputValue] = useState<string>(() =>
     formatDecimal(value, decimalPlaces),
   );
-  const [isFocused, setIsFocused] = useState(false);
+  const [lastEmittedValue, setLastEmittedValue] = useState<number>(value);
 
   const decimalPattern = useMemo(() => {
     return allowNegative ? /^-?\d*(\.\d*)?$/ : /^\d*(\.\d*)?$/;
   }, [allowNegative]);
 
   useEffect(() => {
-    if (isFocused) {
-      return;
+    if (!Object.is(value, lastEmittedValue)) {
+      setInputValue(formatDecimal(value, decimalPlaces));
+      setLastEmittedValue(value);
     }
-    const formatted = formatDecimal(value, decimalPlaces);
-    if (formatted !== inputValue) {
-      setInputValue(formatted);
-    }
-  }, [value, decimalPlaces, isFocused, inputValue]);
+  }, [value, decimalPlaces, lastEmittedValue]);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value: rawValue } = event.target;
@@ -52,6 +49,7 @@ const DecimalInput: React.FC<DecimalInputProps> = ({
       const parsed = Number.parseFloat(rawValue);
       if (Number.isFinite(parsed)) {
         const rounded = Number.parseFloat(parsed.toFixed(decimalPlaces));
+        setLastEmittedValue(rounded);
         onValueChange(rounded);
       }
     }
@@ -73,7 +71,7 @@ const DecimalInput: React.FC<DecimalInputProps> = ({
       }
     }
 
-    setIsFocused(false);
+    setLastEmittedValue(nextValue);
     setInputValue(formatDecimal(nextValue, decimalPlaces));
     if (!Object.is(value, nextValue)) {
       onValueChange(nextValue);
@@ -87,12 +85,11 @@ const DecimalInput: React.FC<DecimalInputProps> = ({
   return (
     <TextField
       {...textFieldProps}
-      type="text"
+      type="number"
       inputMode="decimal"
       value={inputValue}
       onChange={handleChange}
       onFocus={(event) => {
-        setIsFocused(true);
         if (onFocus) {
           onFocus(event);
         }

--- a/Frontend/src/components/common/DecimalInput.tsx
+++ b/Frontend/src/components/common/DecimalInput.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { TextField, type TextFieldProps } from "@mui/material";
+
+const formatDecimal = (value: number, decimalPlaces: number): string => {
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  const rounded = Number.parseFloat(value.toFixed(decimalPlaces));
+  const fixed = rounded.toFixed(decimalPlaces);
+  return fixed.replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+};
+
+type DecimalInputProps = Omit<TextFieldProps, "type" | "onChange" | "value" | "inputMode"> & {
+  value: number;
+  onValueChange: (value: number) => void;
+  decimalPlaces?: number;
+  allowNegative?: boolean;
+};
+
+const DecimalInput: React.FC<DecimalInputProps> = ({
+  value,
+  onValueChange,
+  decimalPlaces = 2,
+  allowNegative = false,
+  onFocus,
+  onBlur,
+  ...textFieldProps
+}) => {
+  const [inputValue, setInputValue] = useState<string>(() =>
+    formatDecimal(value, decimalPlaces),
+  );
+  const [isFocused, setIsFocused] = useState(false);
+
+  const decimalPattern = useMemo(() => {
+    return allowNegative ? /^-?\d*(\.\d*)?$/ : /^\d*(\.\d*)?$/;
+  }, [allowNegative]);
+
+  useEffect(() => {
+    if (isFocused) {
+      return;
+    }
+    const formatted = formatDecimal(value, decimalPlaces);
+    if (formatted !== inputValue) {
+      setInputValue(formatted);
+    }
+  }, [value, decimalPlaces, isFocused, inputValue]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: rawValue } = event.target;
+    if (rawValue === "" || decimalPattern.test(rawValue)) {
+      setInputValue(rawValue);
+      const parsed = Number.parseFloat(rawValue);
+      if (Number.isFinite(parsed)) {
+        const rounded = Number.parseFloat(parsed.toFixed(decimalPlaces));
+        onValueChange(rounded);
+      }
+    }
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const trimmed = event.target.value.trim();
+    let nextValue: number;
+
+    if (trimmed === "") {
+      nextValue = 0;
+    } else {
+      const parsed = Number.parseFloat(trimmed);
+      if (!Number.isFinite(parsed)) {
+        nextValue = 0;
+      } else {
+        const rounded = Number.parseFloat(parsed.toFixed(decimalPlaces));
+        nextValue = allowNegative ? rounded : Math.max(0, rounded);
+      }
+    }
+
+    setIsFocused(false);
+    setInputValue(formatDecimal(nextValue, decimalPlaces));
+    if (!Object.is(value, nextValue)) {
+      onValueChange(nextValue);
+    }
+
+    if (onBlur) {
+      onBlur(event);
+    }
+  };
+
+  return (
+    <TextField
+      {...textFieldProps}
+      type="text"
+      inputMode="decimal"
+      value={inputValue}
+      onChange={handleChange}
+      onFocus={(event) => {
+        setIsFocused(true);
+        if (onFocus) {
+          onFocus(event);
+        }
+      }}
+      onBlur={handleBlur}
+    />
+  );
+};
+
+export default DecimalInput;

--- a/Frontend/src/components/cooking/Cooking.tsx
+++ b/Frontend/src/components/cooking/Cooking.tsx
@@ -14,7 +14,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TextField,
   Typography,
 } from "@mui/material";
 import { Add, Remove } from "@mui/icons-material";
@@ -24,6 +23,7 @@ import type { StoredFoodCreate } from "@/api-extra-types";
 import FeedbackSnackbar, {
   SnackbarMessage,
 } from "@/components/common/FeedbackSnackbar";
+import DecimalInput from "@/components/common/DecimalInput";
 import { useData } from "@/contexts/DataContext";
 import { useSessionStorageState } from "@/hooks/useSessionStorageState";
 import type {
@@ -910,16 +910,13 @@ function Cooking() {
                                   >
                                     <Remove fontSize="small" />
                                   </IconButton>
-                                  <TextField
-                                    type="number"
+                                  <DecimalInput
                                     value={actualPortions}
-                                    onChange={(event) =>
+                                    onValueChange={(value) =>
                                       updateFoodPortion(
                                         foodItem,
                                         index,
-                                        clampNonNegative(
-                                          Number.parseFloat(event.target.value) || 0,
-                                        ),
+                                        clampNonNegative(value),
                                       )
                                     }
                                     sx={{ width: 100 }}
@@ -1081,22 +1078,18 @@ function Cooking() {
                                         gap: 1,
                                       }}
                                     >
-                                      <TextField
-                                        type="number"
-                                        value={measurement.quantity}
-                                        onChange={(event) => {
-                                          const parsed = Number.parseFloat(event.target.value);
-                                          updateIngredientMeasurement(
-                                            ingredientKey,
-                                            fallbackMeasurement,
-                                            {
-                                              quantity: Number.isFinite(parsed) ? parsed : 0,
-                                            },
-                                          );
-                                        }}
-                                        sx={{ width: 120 }}
-                                        inputProps={{ min: 0, step: "any" }}
-                                      />
+                                        <DecimalInput
+                                          value={measurement.quantity}
+                                          onValueChange={(value) =>
+                                            updateIngredientMeasurement(
+                                              ingredientKey,
+                                              fallbackMeasurement,
+                                              { quantity: value },
+                                            )
+                                          }
+                                          sx={{ width: 120 }}
+                                          inputProps={{ min: 0, step: "any" }}
+                                        />
                                       <Select
                                         size="small"
                                         value={measurement.unitId}
@@ -1258,22 +1251,16 @@ function Cooking() {
                               gap: 1,
                             }}
                         >
-                            <TextField
-                              type="number"
-                              value={measurement.quantity}
-                              onChange={(event) => {
-                                const parsed = Number.parseFloat(event.target.value);
-                                updateIngredientMeasurement(
-                                  ingredientKey,
-                                  fallbackMeasurement,
-                                  {
-                                    quantity: Number.isFinite(parsed) ? parsed : 0,
-                                  },
-                                );
-                              }}
-                              sx={{ width: 120 }}
-                              inputProps={{ min: 0, step: "any" }}
-                            />
+                              <DecimalInput
+                                value={measurement.quantity}
+                                onValueChange={(value) =>
+                                  updateIngredientMeasurement(ingredientKey, fallbackMeasurement, {
+                                    quantity: value,
+                                  })
+                                }
+                                sx={{ width: 120 }}
+                                inputProps={{ min: 0, step: "any" }}
+                              />
                             <Select
                               size="small"
                               value={measurement.unitId}

--- a/Frontend/src/components/planning/Planning.tsx
+++ b/Frontend/src/components/planning/Planning.tsx
@@ -48,6 +48,7 @@ import type { FoodRead, IngredientRead } from "@/utils/nutrition";
 import IngredientModal from "@/components/common/IngredientModal";
 import IngredientTable from "@/components/data/ingredient/IngredientTable";
 import FoodTable from "@/components/data/food/FoodTable";
+import DecimalInput from "@/components/common/DecimalInput";
 import useHoverable from "@/hooks/useHoverable";
 import { useSessionStorageState } from "@/hooks/useSessionStorageState";
 import type { PlanRead } from "@/utils/planApi";
@@ -155,13 +156,6 @@ function Planning() {
     ...ZERO_MACROS,
   }));
   const macroKeys = useMemo(() => Object.keys(targetMacros) as MacroKey[], [targetMacros]);
-  const [macroInputs, setMacroInputs] = useState<Record<MacroKey, string>>(() =>
-    macroKeys.reduce((acc, macro) => {
-      acc[macro] = targetMacros[macro].toString();
-      return acc;
-    }, {} as Record<MacroKey, string>),
-  );
-  const [activeMacro, setActiveMacro] = useState<MacroKey | null>(null);
   const [plan, setPlan] = useSessionStorageState<PlanItem[]>("planning-plan", () => []); // FoodPlanItem or IngredientPlanItem
   const [includeFridge, setIncludeFridge] = useSessionStorageState<boolean>(
     "planning-include-fridge",
@@ -228,31 +222,6 @@ function Planning() {
     [plan, days, targetMacros]
   );
   const canResetPlan = hasContent || activePlan.id !== null;
-
-  useEffect(() => {
-    setMacroInputs((prev) => {
-      let changed = false;
-      const next = { ...prev } as Record<MacroKey, string>;
-
-      macroKeys.forEach((macro) => {
-        if (activeMacro === macro) {
-          if (!(macro in next)) {
-            next[macro] = targetMacros[macro].toString();
-            changed = true;
-          }
-          return;
-        }
-
-        const newValue = targetMacros[macro].toString();
-        if (next[macro] !== newValue) {
-          next[macro] = newValue;
-          changed = true;
-        }
-      });
-
-      return changed ? next : prev;
-    });
-  }, [targetMacros, macroKeys, activeMacro]);
 
 
   const handleOpenIngredientEditor = (ingredientId: string) => {
@@ -845,15 +814,16 @@ function Planning() {
     };
   }, [overallTotalMacros, days]);
 
-  const handleDaysChange = (e) => {
-    const value = parseInt(e.target.value, 10);
+  const handleDaysChange = (value: number) => {
     if (!value || value < 1) {
       setDays(1);
       setDaysError(true);
-    } else {
-      setDays(value);
-      setDaysError(false);
+      return;
     }
+
+    const roundedValue = Math.round(value);
+    setDays(roundedValue);
+    setDaysError(false);
   };
 
   const handleOpenSaveDialog = () => {
@@ -987,56 +957,26 @@ function Planning() {
       {statusMessage && <Alert severity="success">{statusMessage}</Alert>}
 
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 3 }}>
-        <TextField
-          type="number"
+        <DecimalInput
           label="Days"
           value={days}
-          onChange={handleDaysChange}
+          decimalPlaces={0}
+          onValueChange={handleDaysChange}
           sx={{ width: 100 }}
           error={daysError}
           helperText={daysError ? "Days must be at least 1" : ""}
         />
         {macroKeys.map((macro) => (
-          <TextField
+          <DecimalInput
             key={macro}
-            type="number"
             label={`Target ${macro}`}
-            value={macroInputs[macro] ?? "0"}
-            onFocus={() => {
-              setActiveMacro(macro);
-              setMacroInputs((prev) => {
-                const current = prev[macro];
-                if (current === "0") {
-                  return { ...prev, [macro]: "" };
-                }
-                return prev;
-              });
-            }}
-            onChange={(e) => {
-              const { value } = e.target;
-              setMacroInputs((prev) => ({
-                ...prev,
-                [macro]: value,
-              }));
+            value={targetMacros[macro]}
+            onValueChange={(value) =>
               setTargetMacros((prev) => ({
                 ...prev,
-                [macro]: value === "" ? 0 : Number.parseFloat(value) || 0,
-              }));
-            }}
-            onBlur={() => {
-              setActiveMacro(null);
-              const currentValue = macroInputs[macro]?.trim() ?? "";
-              if (currentValue === "" || Number.isNaN(Number.parseFloat(currentValue))) {
-                setMacroInputs((prev) => ({
-                  ...prev,
-                  [macro]: "0",
-                }));
-                setTargetMacros((prev) => ({
-                  ...prev,
-                  [macro]: 0,
-                }));
-              }
-            }}
+                [macro]: value,
+              }))
+            }
           />
         ))}
       </Box>
@@ -1089,12 +1029,9 @@ function Planning() {
                     <TableCell>{food ? food.name : ""}</TableCell>
                     <TableCell>
                       <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                        <TextField
-                          type="number"
+                        <DecimalInput
                           value={item.portions}
-                          onChange={(e) =>
-                            handleQuantityChange(index, parseFloat(e.target.value) || 0)
-                          }
+                          onValueChange={(value) => handleQuantityChange(index, value)}
                           sx={{ width: 80 }}
                         />
                       </Box>
@@ -1177,15 +1114,12 @@ function Planning() {
                                   </TableCell>
                                   <TableCell>
                                     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                      <TextField
-                                        type="number"
+                                      <DecimalInput
                                         value={quantity}
-                                        onChange={(e) =>
-                                          handleQuantityChange(
-                                            index,
-                                            parseFloat(e.target.value) || 0,
-                                            { ingredientId: ingredient.ingredient_id }
-                                          )
+                                        onValueChange={(value) =>
+                                          handleQuantityChange(index, value, {
+                                            ingredientId: ingredient.ingredient_id,
+                                          })
                                         }
                                         sx={{ width: 80 }}
                                       />
@@ -1259,12 +1193,9 @@ function Planning() {
                         <Typography variant="body2" sx={{ minWidth: 90 }}>
                           Portion size
                         </Typography>
-                        <TextField
-                          type="number"
+                        <DecimalInput
                           value={item.amount}
-                          onChange={(e) =>
-                            handleQuantityChange(index, parseFloat(e.target.value) || 0)
-                          }
+                          onValueChange={(value) => handleQuantityChange(index, value)}
                           sx={{ width: 80 }}
                           inputProps={{
                             min: 0,
@@ -1305,14 +1236,10 @@ function Planning() {
                         <Typography variant="body2" sx={{ minWidth: 90 }}>
                           Portions
                         </Typography>
-                        <TextField
-                          type="number"
+                        <DecimalInput
                           value={item.portions}
-                          onChange={(e) =>
-                            handleIngredientPortionsChange(
-                              index,
-                              parseFloat(e.target.value) || 0,
-                            )
+                          onValueChange={(value) =>
+                            handleIngredientPortionsChange(index, value)
                           }
                           sx={{ width: 80 }}
                           inputProps={{


### PR DESCRIPTION
## Summary
- add a reusable DecimalInput component to handle decimal entry with deferred validation
- update planning number fields to use the shared component for portions and macro targets
- switch cooking numeric inputs to the new component for consistent behavior

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239dce1e548322ad40a305d6dfbac9)