### PR TITLE
Support switching to remote-only branches in worktree helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
   - Call graph: relies on `scripts/lib/branch-env.*` and `scripts/lib/worktree.sh`; PowerShell version can invoke `scripts/env/activate-venv.ps1` during fixes.
 
 - `scripts/switch-worktree-branch.ps1`
-  - Purpose: interactively pick a branch, jump to its dedicated worktree (creating it if needed), optionally open VS Code, optionally start Docker Compose, and always activate the virtualenv.
+  - Purpose: interactively pick a local or remote branch, jump to its dedicated worktree (creating it if needed), optionally open VS Code, optionally start Docker Compose, and always activate the virtualenv.
   - Flags/parameters: `-Branch`, `-Remote`, `-SkipVSCode`, `-NewVSCodeWindow`, `-StartWorkspaceStack`, and `-Data <test|prod>` (required with `-StartWorkspaceStack`).
   - Call graph: invokes `scripts/env/activate-venv.ps1` and `scripts/docker/compose.ps1` when the corresponding switches are selected.
 

--- a/scripts/switch-worktree-branch.ps1
+++ b/scripts/switch-worktree-branch.ps1
@@ -214,6 +214,19 @@ Invoke-Git @('fetch',$Remote,'--prune') | Out-Null
 
 $worktreeLines = Invoke-Git @('worktree','list','--porcelain')
 $worktrees = Parse-Worktrees $worktreeLines
+$localBranches = Invoke-Git @('for-each-ref','--format=%(refname:short)','refs/heads')
+$remoteBranchRefs = Invoke-Git @('for-each-ref','--format=%(refname:short)',"refs/remotes/$Remote")
+
+$remoteBranches = @()
+foreach ($ref in $remoteBranchRefs) {
+    if (-not $ref) { continue }
+    if ($ref -eq "$Remote/HEAD") { continue }
+    if ($ref.StartsWith("$Remote/")) {
+        $remoteBranches += $ref.Substring($Remote.Length + 1)
+    }
+}
+$remoteBranches = $remoteBranches | Sort-Object -Unique
+$remoteOnlyBranches = $remoteBranches | Where-Object { $localBranches -notcontains $_ }
 
 $branchMap = @{}
 foreach ($wt in $worktrees) {
@@ -233,12 +246,30 @@ $optionIndex = 1
 foreach ($wt in $worktrees | Sort-Object Branch, Path) {
     $marker = if ($wt.Path -eq $repoRoot) { '>' } else { ' ' }
     $branchLabel = if ($wt.Branch) { $wt.Branch } else { '<detached>' }
-    Write-Host (" $marker $branchLabel -> $($wt.Path)")
+    $indexLabel = ''
+    if ($wt.Branch) {
+        $indexLabel = "[$optionIndex] "
+    }
+    Write-Host (" $marker $indexLabel$branchLabel -> $($wt.Path)")
     if ($wt.Branch) {
         $branchOptions += [pscustomobject]@{
             Index  = $optionIndex
             Branch = $wt.Branch
             Path   = $wt.Path
+        }
+        $optionIndex++
+    }
+}
+
+if ($remoteOnlyBranches.Count -gt 0) {
+    Write-Host ''
+    Write-Host "Remote branches on '$Remote' (not local):"
+    foreach ($remoteBranch in $remoteOnlyBranches) {
+        Write-Host ("  [$optionIndex] $Remote/$remoteBranch")
+        $branchOptions += [pscustomobject]@{
+            Index  = $optionIndex
+            Branch = $remoteBranch
+            Path   = $null
         }
         $optionIndex++
     }
@@ -276,6 +307,9 @@ if (-not $Branch) {
     Write-Error 'No branch supplied.'
     Set-Location $initialLocation
     exit 1
+}
+if ($Branch.StartsWith("$Remote/")) {
+    $Branch = $Branch.Substring($Remote.Length + 1)
 }
 
 $selectedOption = $null


### PR DESCRIPTION
### Motivation

- Enable switching to remote branches from the interactive worktree selector in addition to local branches.
- Let users supply a branch prefixed with the remote (e.g. `origin/feature/foo`) and have it resolved.
- Surface remote-only branches in the selection so users can create or track them in a new worktree.

### Description

- Added collection of local refs via `git for-each-ref refs/heads` and remote refs via `git for-each-ref refs/remotes/$Remote`, then computed remote-only branches.
- Appended remote-only branches to the interactive `branchOptions` list with numeric indices and `Path = $null` so they can be selected.
- Updated the displayed worktree lines to include numeric indices and normalized input by stripping a leading `$Remote/` prefix from `-Branch` values.
- Updated `CONTRIBUTING.md` to document that `scripts/switch-worktree-branch.ps1` can pick local or remote branches.

### Testing

- No automated tests were run for this change since it is a small script enhancement.
- Changes were validated via local review and committed to the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ffc24ce348322862ddc2b9e154d2e)