### PR TITLE
Sync remote branches to local in switch-worktree-branch.ps1 (always fetch origin)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Recommended flow when starting or updating a branch:
    pwsh ./scripts/switch-worktree-branch.ps1 feature/my-feature
    ```
 
-   The script creates `../nutrition-feature-my-feature` if needed, checks out the branch there, and optionally opens VS Code. Pass `-SkipVSCode` to stay in the terminal or `-NewVSCodeWindow` for a new window.
+   The script fetches remote refs, creates local tracking branches for any remote-only branches, then creates `../nutrition-feature-my-feature` if needed, checks out the branch there, and optionally opens VS Code. Pass `-SkipVSCode` to stay in the terminal or `-NewVSCodeWindow` for a new window.
 
 4. Verify the environment:
 
@@ -204,8 +204,8 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
   - Call graph: relies on `scripts/lib/branch-env.*` and `scripts/lib/worktree.sh`; PowerShell version can invoke `scripts/env/activate-venv.ps1` during fixes.
 
 - `scripts/switch-worktree-branch.ps1`
-  - Purpose: interactively pick a local or remote branch, jump to its dedicated worktree (creating it if needed), optionally open VS Code, optionally start Docker Compose, and always activate the virtualenv.
-  - Flags/parameters: `-Branch`, `-Remote`, `-SkipVSCode`, `-NewVSCodeWindow`, `-StartWorkspaceStack`, and `-Data <test|prod>` (required with `-StartWorkspaceStack`).
+  - Purpose: fetch remote refs, create local tracking branches for remote-only branches, then interactively pick a local branch, jump to its dedicated worktree (creating it if needed), optionally open VS Code, optionally start Docker Compose, and always activate the virtualenv.
+  - Flags/parameters: `-Branch`, `-SkipVSCode`, `-NewVSCodeWindow`, `-StartWorkspaceStack`, and `-Data <test|prod>` (required with `-StartWorkspaceStack`).
   - Call graph: invokes `scripts/env/activate-venv.ps1` and `scripts/docker/compose.ps1` when the corresponding switches are selected.
 
 ### Repository maintenance

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A full-stack nutrition planning and tracking app built with:
    ```pwsh
    pwsh ./scripts/switch-worktree-branch.ps1 feature/my-feature
    ```
-   - The script creates `../nutrition-feature-my-feature` if needed and reopens the folder in VS Code (use `-SkipVSCode` to opt out).
+   - The script fetches remote refs, creates local tracking branches for remote-only branches, then creates `../nutrition-feature-my-feature` if needed and reopens the folder in VS Code (use `-SkipVSCode` to opt out).
    - Worktrees let every branch mount its own code directory and Postgres volume, so multiple stacks can run in parallel.
 
    Bash users can run the script through `pwsh` (PowerShell 7+ is cross-platform).
@@ -64,7 +64,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 ## Key Helper Scripts
 
 - `pwsh ./scripts/repo/check.ps1`: fetch latest refs, audit worktrees, flag stale container stacks, and suggest fixes. Bash: `./scripts/repo/check.sh`.
-- `pwsh ./scripts/switch-worktree-branch.ps1`: create or hop between branch-dedicated worktrees.
+- `pwsh ./scripts/switch-worktree-branch.ps1`: fetch remote refs, sync local tracking branches, and create or hop between branch-dedicated worktrees.
 - `pwsh ./scripts/env/check.ps1 -Fix`: ensure you are inside the correct worktree with an activated virtualenv (Bash variant available).
 - `pwsh ./scripts/docker/compose.ps1 <up|down|restart>`: manage the per-branch Docker stack.
 - `pwsh ./scripts/run-tests.ps1 [-sync] [-e2e]`: run backend + frontend tests with optional API/migration sync. Bash variant: `./scripts/run-tests.sh`.
@@ -242,4 +242,3 @@ classDiagram
 ## Contributing
 
 For environment setup, migrations, API schema generation, commit checklist, and CI details, read [CONTRIBUTING.md](CONTRIBUTING.md).
-

--- a/scripts/switch-worktree-branch.ps1
+++ b/scripts/switch-worktree-branch.ps1
@@ -7,8 +7,6 @@
     the matching worktree or creates a fresh worktree for that branch.
 .PARAMETER Branch
     Optional branch name or numeric selection. If omitted the script prompts.
-.PARAMETER Remote
-    Remote name used for fetches and default tracking. Defaults to origin.
 .PARAMETER SkipVSCode
     Suppress launching VS Code after switching.
 .PARAMETER NewVSCodeWindow
@@ -23,7 +21,6 @@
 [CmdletBinding()]
 param(
     [string]$Branch,
-    [string]$Remote = 'origin',
     [switch]$SkipVSCode,
     [switch]$NewVSCodeWindow,
     [switch]$StartWorkspaceStack,
@@ -73,6 +70,26 @@ function Test-RemoteBranch {
 
     & git ls-remote --exit-code --heads $RemoteName $Name > $null 2>&1
     return ($LASTEXITCODE -eq 0)
+}
+
+function Sync-RemoteBranchesToLocal {
+    param(
+        [Parameter(Mandatory = $true)][string]$RemoteName
+    )
+
+    $remoteRefs = Invoke-Git @('for-each-ref','--format=%(refname:short)',"refs/remotes/$RemoteName")
+    foreach ($ref in $remoteRefs) {
+        if (-not $ref) { continue }
+        if ($ref -eq "$RemoteName/HEAD") { continue }
+        if (-not $ref.StartsWith("$RemoteName/")) { continue }
+
+        $branchName = $ref.Substring($RemoteName.Length + 1)
+        if (-not $branchName) { continue }
+        if (Test-LocalBranch -Name $branchName) { continue }
+
+        Write-Host "Creating local branch '$branchName' tracking '$ref'..."
+        Invoke-Git @('branch','--track',$branchName,$ref) | Out-Null
+    }
 }
 
 function Parse-Worktrees {
@@ -209,24 +226,14 @@ if (-not $repoRootRaw) {
 Set-Location $repoRootRaw
 $repoRoot = Normalize-Path $repoRootRaw
 
-Write-Host "Fetching latest refs from '$Remote'..."
-Invoke-Git @('fetch',$Remote,'--prune') | Out-Null
+$remoteName = 'origin'
+Write-Host "Fetching latest refs from '$remoteName'..."
+Invoke-Git @('fetch',$remoteName,'--prune') | Out-Null
+Sync-RemoteBranchesToLocal -RemoteName $remoteName
 
 $worktreeLines = Invoke-Git @('worktree','list','--porcelain')
 $worktrees = Parse-Worktrees $worktreeLines
 $localBranches = Invoke-Git @('for-each-ref','--format=%(refname:short)','refs/heads')
-$remoteBranchRefs = Invoke-Git @('for-each-ref','--format=%(refname:short)',"refs/remotes/$Remote")
-
-$remoteBranches = @()
-foreach ($ref in $remoteBranchRefs) {
-    if (-not $ref) { continue }
-    if ($ref -eq "$Remote/HEAD") { continue }
-    if ($ref.StartsWith("$Remote/")) {
-        $remoteBranches += $ref.Substring($Remote.Length + 1)
-    }
-}
-$remoteBranches = $remoteBranches | Sort-Object -Unique
-$remoteOnlyBranches = $remoteBranches | Where-Object { $localBranches -notcontains $_ }
 
 $branchMap = @{}
 foreach ($wt in $worktrees) {
@@ -261,14 +268,15 @@ foreach ($wt in $worktrees | Sort-Object Branch, Path) {
     }
 }
 
-if ($remoteOnlyBranches.Count -gt 0) {
+$localBranchesWithoutWorktrees = $localBranches | Where-Object { -not $branchMap.ContainsKey($_) } | Sort-Object
+if ($localBranchesWithoutWorktrees.Count -gt 0) {
     Write-Host ''
-    Write-Host "Remote branches on '$Remote' (not local):"
-    foreach ($remoteBranch in $remoteOnlyBranches) {
-        Write-Host ("  [$optionIndex] $Remote/$remoteBranch")
+    Write-Host 'Local branches (no worktree yet):'
+    foreach ($localBranch in $localBranchesWithoutWorktrees) {
+        Write-Host ("  [$optionIndex] $localBranch")
         $branchOptions += [pscustomobject]@{
             Index  = $optionIndex
-            Branch = $remoteBranch
+            Branch = $localBranch
             Path   = $null
         }
         $optionIndex++
@@ -278,16 +286,16 @@ if ($remoteOnlyBranches.Count -gt 0) {
 $currentBranch = Get-LastLine (Invoke-Git @('rev-parse','--abbrev-ref','HEAD'))
 $hasValidCurrentBranch = $currentBranch -and $currentBranch -ne 'HEAD'
 
-$defaultBase = "$Remote/main"
+$defaultBase = "$remoteName/main"
 if ($hasValidCurrentBranch) {
     $defaultBase = $currentBranch
 }
 else {
     try {
-        $remoteHead = Get-LastLine (Invoke-Git @('symbolic-ref',"refs/remotes/$Remote/HEAD"))
+        $remoteHead = Get-LastLine (Invoke-Git @('symbolic-ref',"refs/remotes/$remoteName/HEAD"))
         if ($remoteHead) {
-            $remoteHeadName = $remoteHead -replace "^refs/remotes/$Remote/", ''
-            if ($remoteHeadName) { $defaultBase = "$Remote/$remoteHeadName" }
+            $remoteHeadName = $remoteHead -replace "^refs/remotes/$remoteName/", ''
+            if ($remoteHeadName) { $defaultBase = "$remoteName/$remoteHeadName" }
         }
     } catch {
         # ignore
@@ -308,8 +316,8 @@ if (-not $Branch) {
     Set-Location $initialLocation
     exit 1
 }
-if ($Branch.StartsWith("$Remote/")) {
-    $Branch = $Branch.Substring($Remote.Length + 1)
+if ($Branch.StartsWith("$remoteName/")) {
+    $Branch = $Branch.Substring($remoteName.Length + 1)
 }
 
 $selectedOption = $null
@@ -412,30 +420,19 @@ if ($branchExists) {
     Invoke-Git @('worktree','add',$targetPath,$Branch) | Out-Null
 }
 else {
-    $remoteBranchExists = Test-RemoteBranch -RemoteName $Remote -Name $Branch
-    $remoteHasBranch = $remoteBranchExists
-    $baseRef = $null
+    $remoteBranchExists = Test-RemoteBranch -RemoteName $remoteName -Name $Branch
+    $baseRef = $defaultBase
     $useTracking = $false
     $shouldPushNewBranch = -not $remoteBranchExists
 
-    if ($remoteHasBranch) {
-        $response = Read-Host "Branch '$Branch' exists on '$Remote'. Track it in a new worktree? (Y/n)"
-        if ($response -and $response.Trim().ToLower().StartsWith('n')) {
-            $remoteHasBranch = $false
-        }
-        else {
-            $baseRef = "$Remote/$Branch"
-            $useTracking = $true
-        }
+    if ($remoteBranchExists) {
+        $baseRef = "$remoteName/$Branch"
+        $useTracking = $true
     }
-
-    if (-not $remoteHasBranch) {
-        $baseRef = $defaultBase
-        if (-not $baseRef) {
-            Write-Host 'Aborting.'
-            Set-Location $initialLocation
-            exit 1
-        }
+    elseif (-not $baseRef) {
+        Write-Host 'Aborting.'
+        Set-Location $initialLocation
+        exit 1
     }
 
     if ($useTracking) {
@@ -449,8 +446,8 @@ else {
 }
 
 if ($shouldPushNewBranch) {
-    Write-Host "Pushing new branch '$Branch' to '$Remote' and setting upstream..."
-    Invoke-Git @('-C',$targetPath,'push','--set-upstream',$Remote,$Branch) | Out-Null
+    Write-Host "Pushing new branch '$Branch' to '$remoteName' and setting upstream..."
+    Invoke-Git @('-C',$targetPath,'push','--set-upstream',$remoteName,$Branch) | Out-Null
 }
 
 Write-Host ''


### PR DESCRIPTION
### Motivation
- Ensure all remote branches are available as local options before prompting to switch or create worktrees. 
- Remove the user-configurable remote to simplify the flow and always use `origin` as the canonical upstream. 
- Make it easier to create worktrees for branches that exist only on the remote by creating local tracking branches automatically.

### Description
- Removed the `-Remote` parameter and now always fetches from `origin` before prompting for a branch. 
- Added `Sync-RemoteBranchesToLocal` which creates local tracking branches for any remote-only refs under `origin`. 
- Updated the selection list to show local branches that have no worktree (so remote branches synced locally appear as options). 
- Updated `README.md` and `CONTRIBUTING.md` to document the new behavior and parameter list for `switch-worktree-branch.ps1`.

### Testing
- Ran the repository check script `pwsh ./scripts/repo/check.ps1` in this environment which failed because `pwsh` is not available here (no PowerShell present). 
- No other automated unit or integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950013421d083229de7118e92ca1930)