### PR TITLE
Use IngredientModal for Add/Edit on Ingredients page

### DIFF
--- a/Frontend/src/components/data/ingredient/IngredientData.tsx
+++ b/Frontend/src/components/data/ingredient/IngredientData.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
+import { Box, Button } from "@mui/material";
 
 import IngredientTable from "./IngredientTable";
-import IngredientForm from "./form/IngredientForm";
+import IngredientModal from "@/components/common/IngredientModal";
 import type { IngredientRead } from "@/utils/nutrition";
 
 type IngredientDataProps = {
@@ -9,19 +10,43 @@ type IngredientDataProps = {
 };
 
 function IngredientData({ handleAddIngredientToPlan }: IngredientDataProps) {
-  const [editingIngredient, setEditingIngredient] = useState(null);
+  const [ingredientModalOpen, setIngredientModalOpen] = useState(false);
+  const [editorIngredient, setEditorIngredient] = useState<IngredientRead | null>(null);
+  const [ingredientModalMode, setIngredientModalMode] = useState<"add" | "edit">("add");
 
-  const handleAddIngredientToEdit = (ingredientToEdit) => {
-    setEditingIngredient(null);
-    setEditingIngredient(ingredientToEdit);
+  const handleOpenAddIngredient = () => {
+    setIngredientModalMode("add");
+    setEditorIngredient(null);
+    setIngredientModalOpen(true);
+  };
+
+  const handleOpenIngredientToEdit = (ingredientToEdit: IngredientRead) => {
+    setIngredientModalMode("edit");
+    setEditorIngredient(ingredientToEdit);
+    setIngredientModalOpen(true);
+  };
+
+  const handleCloseIngredientModal = () => {
+    setIngredientModalOpen(false);
+    setEditorIngredient(null);
   };
 
   return (
     <div>
-      <IngredientForm ingredientToEditData={editingIngredient} />
+      <Box sx={{ display: "flex", justifyContent: "center", mb: 2 }}>
+        <Button variant="contained" onClick={handleOpenAddIngredient}>
+          Add Ingredient
+        </Button>
+      </Box>
       <IngredientTable
         onIngredientDoubleClick={handleAddIngredientToPlan}
-        onIngredientCtrlClick={handleAddIngredientToEdit}
+        onIngredientCtrlClick={handleOpenIngredientToEdit}
+      />
+      <IngredientModal
+        open={ingredientModalOpen}
+        mode={ingredientModalMode}
+        ingredient={editorIngredient}
+        onClose={handleCloseIngredientModal}
       />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Replace the inline collapsible ingredient form with the shared modal to provide a consistent UX across the app.
- Reuse the existing `IngredientModal`/`IngredientEditor` components instead of duplicating form UI.
- Make the Add and Edit flows uniform so editing from tables opens the same modal used elsewhere.

### Description
- Removed the inline `IngredientForm` from `IngredientData.tsx` and added a centered `Add Ingredient` `Button` that opens the shared `IngredientModal`.
- Added local state `ingredientModalOpen`, `editorIngredient`, and `ingredientModalMode` in `IngredientData.tsx` to control the modal.
- Wired table edit actions to open the modal in `edit` mode via the `onIngredientCtrlClick` callback and set `ingredient`/`mode` props on `IngredientModal`.
- Kept `onIngredientDoubleClick` behavior for adding ingredients to plans unchanged.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950079fdb5c832286803fa004e1cb19)