### PR TITLE
Use IngredientModal in Cooking and Logging (add 'New Ingredient' entry points)

### DIFF
--- a/Frontend/src/components/cooking/Cooking.tsx
+++ b/Frontend/src/components/cooking/Cooking.tsx
@@ -23,6 +23,7 @@ import type { StoredFoodCreate } from "@/api-extra-types";
 import FeedbackSnackbar, {
   SnackbarMessage,
 } from "@/components/common/FeedbackSnackbar";
+import IngredientModal from "@/components/common/IngredientModal";
 import DecimalInput from "@/components/common/DecimalInput";
 import { useData } from "@/contexts/DataContext";
 import { useSessionStorageState } from "@/hooks/useSessionStorageState";
@@ -398,6 +399,7 @@ function Cooking() {
   const [pendingIngredientSelections, setPendingIngredientSelections] = useState<
     Record<string, string>
   >({});
+  const [ingredientModalOpen, setIngredientModalOpen] = useState(false);
   const handleFeedbackClose = useCallback(() => {
     setFeedback(null);
   }, []);
@@ -711,6 +713,14 @@ function Cooking() {
     },
     [],
   );
+
+  const handleOpenIngredientModal = useCallback(() => {
+    setIngredientModalOpen(true);
+  }, []);
+
+  const handleCloseIngredientModal = useCallback(() => {
+    setIngredientModalOpen(false);
+  }, []);
 
   const handleAddIngredient = useCallback(
     (planKey: string) => {
@@ -1733,6 +1743,13 @@ function Cooking() {
                                   >
                                     Add
                                   </Button>
+                                  <Button
+                                    size="small"
+                                    variant="text"
+                                    onClick={handleOpenIngredientModal}
+                                  >
+                                    New Ingredient
+                                  </Button>
                                 </Box>
                               </TableCell>
                               <TableCell></TableCell>
@@ -1985,6 +2002,12 @@ function Cooking() {
           )}
         </>
       )}
+      <IngredientModal
+        open={ingredientModalOpen}
+        mode="add"
+        ingredient={null}
+        onClose={handleCloseIngredientModal}
+      />
       <FeedbackSnackbar snackbar={feedback} onClose={handleFeedbackClose} />
     </Stack>
   );

--- a/Frontend/src/components/logging/Logging.tsx
+++ b/Frontend/src/components/logging/Logging.tsx
@@ -12,6 +12,8 @@ import {
   CardHeader,
   CircularProgress,
   Dialog,
+  DialogActions,
+  DialogTitle,
   Grid,
   MenuItem,
   Paper,
@@ -34,6 +36,7 @@ import type { components } from "@/api-types";
 import FeedbackSnackbar, {
   SnackbarMessage,
 } from "@/components/common/FeedbackSnackbar";
+import IngredientModal from "@/components/common/IngredientModal";
 import IngredientTable from "@/components/data/ingredient/IngredientTable";
 import FoodTable from "@/components/data/food/FoodTable";
 import {
@@ -147,6 +150,7 @@ function Logging() {
   });
   const [ingredientPickerOpen, setIngredientPickerOpen] = useState(false);
   const [foodPickerOpen, setFoodPickerOpen] = useState(false);
+  const [ingredientModalOpen, setIngredientModalOpen] = useState(false);
   const [activeLogType, setActiveLogType] = useState<"ingredient" | "food" | null>(
     null,
   );
@@ -154,6 +158,14 @@ function Logging() {
   const [pendingFoodLog, setPendingFoodLog] = useState(false);
   const handleFeedbackClose = useCallback(() => {
     setFeedback(null);
+  }, []);
+
+  const handleOpenIngredientModal = useCallback(() => {
+    setIngredientModalOpen(true);
+  }, []);
+
+  const handleCloseIngredientModal = useCallback(() => {
+    setIngredientModalOpen(false);
   }, []);
 
   const toNumber = useCallback((value: unknown, fallback = 0): number => {
@@ -1347,11 +1359,20 @@ function Logging() {
         maxWidth="lg"
         scroll="paper"
       >
+        <DialogTitle>Select Ingredient</DialogTitle>
         <IngredientTable
           onIngredientDoubleClick={(ingredient) => {
             handleIngredientSelection(ingredient);
           }}
         />
+        <DialogActions>
+          <Button onClick={handleOpenIngredientModal}>
+            New Ingredient
+          </Button>
+          <Button onClick={() => setIngredientPickerOpen(false)}>
+            Close
+          </Button>
+        </DialogActions>
       </Dialog>
 
       <Dialog
@@ -1367,6 +1388,13 @@ function Logging() {
           }}
         />
       </Dialog>
+
+      <IngredientModal
+        open={ingredientModalOpen}
+        mode="add"
+        ingredient={null}
+        onClose={handleCloseIngredientModal}
+      />
 
       <FeedbackSnackbar
         snackbar={feedback}


### PR DESCRIPTION
### Motivation
- The cooking pane allowed selecting existing ingredients but did not provide a quick path to create a new ingredient via the shared add/edit modal. 
- The ingredient modal is already used in several data panes and should be consistently available wherever ingredients are selected or created. 
- Providing the modal in the cooking and logging flows lets users create ingredients without leaving those contexts. 

### Description
- Import `IngredientModal` and add local `ingredientModalOpen` state and `handleOpenIngredientModal`/`handleCloseIngredientModal` handlers in `Frontend/src/components/cooking/Cooking.tsx` and `Frontend/src/components/logging/Logging.tsx`.
- Add a `New Ingredient` button to the cooking add-ingredient row that opens the modal and render an `IngredientModal` instance wired to the handlers in the cooking component.
- Add a `New Ingredient` button and dialog actions to the logging ingredient picker dialog and render an `IngredientModal` instance wired to the handlers in the logging component.
- Modified files: `Frontend/src/components/cooking/Cooking.tsx` and `Frontend/src/components/logging/Logging.tsx`.

### Testing
- Installed frontend dependencies with `npm --prefix Frontend install` which completed successfully with an audit notice. 
- Launched the frontend dev server with `npm --prefix Frontend run dev` and ran a small Playwright script that navigated to `/cooking` (with sessionStorage pre-seeded) and captured a screenshot, which succeeded. 
- The dev server logs showed Vite proxy errors (`ECONNREFUSED 127.0.0.1:8000`) because the backend was not running, but the UI rendered and the Playwright navigation and screenshot completed. 
- No automated unit or integration test suites (`pwsh ./scripts/run-tests.ps1` / `pytest` / frontend tests) were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500cc8be448322a30335ca422d465f)