### PR TITLE
Clarify Docker `data` flag seeding behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Options:
 
 - Add `type -test` to run on the dedicated test ports (`TEST_*`). Useful for end-to-end runs that should not collide with your dev stack.
 - Append service names (e.g. `frontend backend`) to limit which containers start.
-- The script waits for PostgreSQL, ensures the backend dependencies are present, runs Alembic migrations inside the container, and seeds data based on the `data` flag.
+- The script waits for PostgreSQL, ensures the backend dependencies are present, runs Alembic migrations inside the container, then seeds data: `data -test` loads test CSV fixtures; `data -prod` restores the latest branch dump in PowerShell and seeds production CSV fixtures in Bash.
 
 Stop services:
 


### PR DESCRIPTION
### Motivation

- Make the `Docker Workflows` section explicit about what `data -test` and `data -prod` do when starting the branch-aware compose stacks. 
- Ensure the wording matches the existing "Script catalog & call graph" explanation for parity between PowerShell and Bash flows. 
- Keep the guidance concise and developer-facing as required by the documentation maintenance rules.

### Description

- Replaced the generic sentence about seeding with a concise explanation in `CONTRIBUTING.md` that details `data -test` and `data -prod` behavior. 
- The new line states that the wrapper waits for Postgres and migrations, then seeds data: `data -test` loads test CSV fixtures and `data -prod` restores the latest branch dump in PowerShell while Bash seeds production CSV fixtures. 
- Only `CONTRIBUTING.md` was modified.

### Testing

- No automated tests were run because this is a documentation-only change. 
- There were no test failures reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501f2986288322a4f1a75eeb7d1ca0)