### PR TITLE
Add stored-food deletion coverage for food-backed logs

### DIFF
--- a/Backend/tests/test_stored_food.py
+++ b/Backend/tests/test_stored_food.py
@@ -3,7 +3,7 @@ from datetime import date
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from Backend.models import DailyLogEntry, Ingredient, StoredFood
+from Backend.models import DailyLogEntry, Food, Ingredient, StoredFood
 
 
 def _create_ingredient(session: Session, name: str = "Ingredient") -> Ingredient:
@@ -12,6 +12,14 @@ def _create_ingredient(session: Session, name: str = "Ingredient") -> Ingredient
     session.commit()
     session.refresh(ingredient)
     return ingredient
+
+
+def _create_food(session: Session, name: str = "Food") -> Food:
+    food = Food(name=name)
+    session.add(food)
+    session.commit()
+    session.refresh(food)
+    return food
 
 
 def test_create_stored_food_entry(client: TestClient, engine) -> None:
@@ -351,6 +359,54 @@ def test_delete_stored_food_preserves_daily_logs(client: TestClient, engine) -> 
         assert entry.stored_food_id is None
         assert entry.ingredient_id == ingredient.id
         assert entry.food_id is None
+
+
+def test_delete_stored_food_preserves_daily_logs_for_food(
+    client: TestClient, engine
+) -> None:
+    with Session(engine) as session:
+        food = _create_food(session, "Chicken Stir Fry")
+
+    stored_payload = {
+        "user_id": "user-log-retain-food",
+        "food_id": food.id,
+        "prepared_portions": 4,
+        "per_portion_calories": 420,
+        "per_portion_protein": 28,
+        "per_portion_carbohydrates": 35,
+        "per_portion_fat": 14,
+        "per_portion_fiber": 6,
+    }
+
+    stored_response = client.post("/api/stored_food/", json=stored_payload)
+    assert stored_response.status_code == 201
+    stored_id = stored_response.json()["id"]
+
+    log_payload = {
+        "user_id": stored_payload["user_id"],
+        "log_date": "2024-01-16",
+        "stored_food_id": stored_id,
+        "portions_consumed": 1,
+        "calories": stored_payload["per_portion_calories"],
+        "protein": stored_payload["per_portion_protein"],
+        "carbohydrates": stored_payload["per_portion_carbohydrates"],
+        "fat": stored_payload["per_portion_fat"],
+        "fiber": stored_payload["per_portion_fiber"],
+    }
+
+    log_response = client.post("/api/logs/", json=log_payload)
+    assert log_response.status_code == 201
+    log_id = log_response.json()["id"]
+
+    delete_response = client.delete(f"/api/stored_food/{stored_id}")
+    assert delete_response.status_code == 204
+
+    with Session(engine) as session:
+        entry = session.get(DailyLogEntry, log_id)
+        assert entry is not None
+        assert entry.stored_food_id is None
+        assert entry.food_id == food.id
+        assert entry.ingredient_id is None
 
 
 def test_clear_stored_food(client: TestClient, engine) -> None:


### PR DESCRIPTION
### Motivation
- Ensure that deleting a `StoredFood` entry preserves related `DailyLogEntry` rows and migrates the reference to the underlying `food_id` when the stored food was food-backed.
- Prevent regressions where log entries could lose both `stored_food_id` and the original `food_id` after stored-food deletion.

### Description
- Add a helper ` _create_food` and import `Food` in `Backend/tests/test_stored_food.py` to create food-backed stored food test fixtures.
- Add `test_delete_stored_food_preserves_daily_logs_for_food` which creates a food-backed stored-food entry, creates a daily log referencing `stored_food_id`, deletes the stored food via the API, and asserts the log keeps `stored_food_id = None` while `food_id` is populated.
- Keep existing ingredient-backed coverage in `test_delete_stored_food_preserves_daily_logs` and adjust imports accordingly.

### Testing
- No automated test suite was executed as part of this change (`pytest`/`pwsh ./scripts/run-tests.ps1 -full` were not run).
- The new test is an addition to the existing unit tests and will run under the repository's normal `pytest` run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501f2d2ae88322a05e396d986a8657)