### PR TITLE
Disable unit grams input for derived units

### DIFF
--- a/Frontend/src/components/data/ingredient/form/UnitEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/UnitEdit.tsx
@@ -213,11 +213,14 @@ function UnitDialog({ open, mode, initialUnit = null, units, onClose, onSubmit }
           }
           onChange={(e) => setUnitGrams(e.target.value)}
           InputProps={{ readOnly: unitMode === "unit" }}
+          disabled={unitMode === "unit"}
           error={Boolean(validationError && validationError.includes("grams"))}
           helperText={
             validationError && validationError.includes("grams")
               ? validationError
-              : "Enter a number up to 4 decimal places"
+              : unitMode === "unit"
+                ? "Calculated from the base unit"
+                : "Enter a number up to 4 decimal places"
           }
           fullWidth
           margin="dense"


### PR DESCRIPTION
### Motivation
- When a unit is defined "by another unit" its grams value should be computed and not appear editable to avoid user confusion.
- Make the final grams visually and functionally non-editable (grayed out) when in the derived-unit mode.
- Clarify the helper text so users understand the grams are computed from the chosen base unit.

### Description
- Added `disabled={unitMode === "unit"}` to the `Unit grams` `TextField` so the input is non-interactive when the unit is derived.
- Kept the existing `InputProps={{ readOnly: unitMode === "unit" }}` and also updated the helper text to show `"Calculated from the base unit"` when in derived mode.
- The change is localized to `Frontend/src/components/data/ingredient/form/UnitEdit.tsx` and does not alter submission logic for either mode.

### Testing
- Ran `pwsh ./scripts/repo/check.ps1`, which failed because `pwsh` was not available in the environment (failed).
- Ran `./scripts/repo/check.sh` and `bash ./scripts/repo/check.sh`, which failed due to permission errors on helper scripts (failed).
- Attempted a Playwright screenshot to verify the UI change, but the browser launch crashed in the container (failed).
- No frontend or backend test suites were executed successfully in this environment; changes are minimal and primarily UI behavior only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69502fabf7a4832284306a78ac5cf673)