### PR TITLE
Add USDA source selection and search to ingredient form

### DIFF
--- a/Frontend/src/components/data/ingredient/form/IngredientEditor.tsx
+++ b/Frontend/src/components/data/ingredient/form/IngredientEditor.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { Box, Button, Divider } from "@mui/material";
 
 import NameEdit from "./NameEdit";
+import SourceEdit from "./SourceEdit";
 import UnitEdit from "./UnitEdit";
 import NutritionEdit from "./NutritionEdit";
 import TagEdit from "./TagEdit";
@@ -34,6 +35,7 @@ function IngredientEditor({ mode, initial = null, onSaved, onDeleted }: Ingredie
     acknowledgeFillFlag,
     save,
     remove,
+    applyUsdaResult,
   } = useIngredientForm();
 
   useEffect(() => {
@@ -60,6 +62,7 @@ function IngredientEditor({ mode, initial = null, onSaved, onDeleted }: Ingredie
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
       <NameEdit ingredient={ingredient} dispatch={dispatch} needsClearForm={needsClearForm} />
+      <SourceEdit ingredient={ingredient} dispatch={dispatch} applyUsdaResult={applyUsdaResult} />
       <UnitEdit ingredient={ingredient} dispatch={dispatch} needsClearForm={needsClearForm} />
       <NutritionEdit
         ingredient={ingredient}

--- a/Frontend/src/components/data/ingredient/form/IngredientForm.tsx
+++ b/Frontend/src/components/data/ingredient/form/IngredientForm.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useCallback, useRef, useState } from "react";
 import { Button, Collapse, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Box } from "@mui/material";
 
 import NameEdit from "./NameEdit";
+import SourceEdit from "./SourceEdit";
 import UnitEdit from "./UnitEdit";
 import NutritionEdit from "./NutritionEdit";
 import TagEdit from "./TagEdit";
@@ -33,6 +34,7 @@ function IngredientForm({ ingredientToEditData }: IngredientFormProps) {
     acknowledgeFillFlag,
     save,
     remove,
+    applyUsdaResult,
   } = useIngredientForm();
 
   const handleClearForm = useCallback(() => {
@@ -104,6 +106,7 @@ function IngredientForm({ ingredientToEditData }: IngredientFormProps) {
         <Collapse in={isOpen}>
           <>
             <NameEdit ingredient={ingredient} dispatch={dispatch} needsClearForm={needsClearForm} />
+            <SourceEdit ingredient={ingredient} dispatch={dispatch} applyUsdaResult={applyUsdaResult} />
             <UnitEdit ingredient={ingredient} dispatch={dispatch} needsClearForm={needsClearForm} />
             <NutritionEdit
               ingredient={ingredient}
@@ -140,4 +143,3 @@ function IngredientForm({ ingredientToEditData }: IngredientFormProps) {
   );
 }
 export default IngredientForm;
-

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -1,0 +1,193 @@
+import React, { useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@mui/material";
+
+import type { IngredientSource, UsdaIngredientResult } from "./useIngredientForm";
+
+const normalizeNutritionValue = (value: unknown): number => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+};
+
+const mapUsdaResult = (item: Record<string, unknown>): UsdaIngredientResult | null => {
+  const name = String(item.name ?? item.description ?? item.label ?? "").trim();
+  if (!name) {
+    return null;
+  }
+
+  const idValue = item.id ?? item.fdcId ?? item.foodId ?? item.food_id ?? name;
+  const nutritionSource = (item.nutrition ?? item.nutrients ?? {}) as Record<string, unknown>;
+
+  return {
+    id: String(idValue),
+    name,
+    nutrition: {
+      calories: normalizeNutritionValue(nutritionSource.calories ?? nutritionSource.energy),
+      protein: normalizeNutritionValue(nutritionSource.protein),
+      carbohydrates: normalizeNutritionValue(nutritionSource.carbohydrates ?? nutritionSource.carbs),
+      fat: normalizeNutritionValue(nutritionSource.fat),
+      fiber: normalizeNutritionValue(nutritionSource.fiber),
+    },
+  };
+};
+
+const normalizeResults = (data: unknown): UsdaIngredientResult[] => {
+  if (Array.isArray(data)) {
+    return data
+      .map((item) => {
+        if (item && typeof item === "object") {
+          return mapUsdaResult(item as Record<string, unknown>);
+        }
+        return null;
+      })
+      .filter((result): result is UsdaIngredientResult => Boolean(result));
+  }
+
+  if (data && typeof data === "object") {
+    const possibleResults = (data as { results?: unknown }).results;
+    if (possibleResults) {
+      return normalizeResults(possibleResults);
+    }
+  }
+
+  return [];
+};
+
+function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<UsdaIngredientResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedSource: IngredientSource = ingredient.source ?? "manual";
+  const disabledSearch = selectedSource !== "usda";
+
+  const hasResults = results.length > 0;
+
+  const statusMessage = useMemo(() => {
+    if (isLoading) {
+      return "Searching USDA database...";
+    }
+    if (error) {
+      return error;
+    }
+    if (!query.trim()) {
+      return "Enter a name to search the USDA database.";
+    }
+    if (!hasResults) {
+      return "No USDA matches yet. Try a different search.";
+    }
+    return null;
+  }, [error, isLoading, query, hasResults]);
+
+  const handleSourceChange = (event) => {
+    const value = event.target.value as IngredientSource;
+    dispatch({
+      type: "SET_INGREDIENT",
+      payload: {
+        ...ingredient,
+        source: value,
+        sourceId: value === "manual" ? null : ingredient.sourceId ?? null,
+        sourceName: value === "manual" ? null : ingredient.sourceName ?? null,
+      },
+    });
+  };
+
+  const handleSearch = async () => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setResults([]);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/usda/search?query=${encodeURIComponent(trimmed)}`);
+      if (!response.ok) {
+        throw new Error("USDA search failed.");
+      }
+      const data = await response.json();
+      setResults(normalizeResults(data));
+    } catch (searchError) {
+      setResults([]);
+      setError("Unable to load USDA results right now.");
+      // eslint-disable-next-line no-console
+      console.error(searchError);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSelectResult = (result: UsdaIngredientResult) => {
+    applyUsdaResult(result);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <FormControl sx={{ minWidth: 200 }}>
+        <InputLabel id="ingredient-source-label">Source</InputLabel>
+        <Select
+          labelId="ingredient-source-label"
+          label="Source"
+          value={selectedSource}
+          onChange={handleSourceChange}>
+          <MenuItem value="manual">Manual</MenuItem>
+          <MenuItem value="usda">USDA</MenuItem>
+        </Select>
+      </FormControl>
+
+      {selectedSource === "usda" && (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+            <TextField
+              label="Search USDA"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              fullWidth
+            />
+            <Button variant="outlined" onClick={handleSearch} disabled={disabledSearch || isLoading}>
+              Search
+            </Button>
+          </Box>
+          {isLoading && <CircularProgress size={20} />}
+          {statusMessage && (
+            <Typography variant="body2" color={error ? "error" : "text.secondary"}>
+              {statusMessage}
+            </Typography>
+          )}
+          {hasResults && (
+            <List dense>
+              {results.map((result) => (
+                <ListItem key={result.id} disablePadding>
+                  <ListItemButton onClick={() => handleSelectResult(result)}>
+                    <ListItemText
+                      primary={result.name}
+                      secondary={`Calories ${result.nutrition.calories} · Protein ${result.nutrition.protein} · Carbs ${result.nutrition.carbohydrates} · Fat ${result.nutrition.fat}`}
+                    />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default SourceEdit;

--- a/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
+++ b/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
@@ -11,8 +11,29 @@ type IngredientUnitCreate = components["schemas"]["IngredientUnitCreate"];
 type IngredientShoppingUnitSelection = components["schemas"]["IngredientShoppingUnitSelection"];
 type IngredientRequest = operations["add_ingredient_api_ingredients__post"]["requestBody"]["content"]["application/json"];
 
+export type IngredientSource = "manual" | "usda";
+
+export type UsdaIngredientResult = {
+  id: string;
+  name: string;
+  nutrition: {
+    calories: number;
+    protein: number;
+    carbohydrates: number;
+    fat: number;
+    fiber: number;
+  };
+};
+
+type IngredientFormIngredient = IngredientRead & {
+  shoppingUnitId?: number | string | null;
+  source?: IngredientSource;
+  sourceId?: string | null;
+  sourceName?: string | null;
+};
+
 type IngredientFormState = {
-  ingredient: IngredientRead & { shoppingUnitId?: number | string | null };
+  ingredient: IngredientFormIngredient;
   needsClearForm: boolean;
   needsFillForm: boolean;
 };
@@ -52,6 +73,9 @@ const initializeEmptyIngredient = (): IngredientFormState["ingredient"] => ({
   },
   tags: [],
   shoppingUnitId: "0",
+  source: "manual",
+  sourceId: null,
+  sourceName: null,
 });
 
 const createInitialState = (): IngredientFormState => ({
@@ -90,6 +114,9 @@ const buildRequestPayload = (ingredient: IngredientFormState["ingredient"]): Ing
 
   // Remove local-only helper property
   delete (payload as { shoppingUnitId?: unknown }).shoppingUnitId;
+  delete (payload as { source?: unknown }).source;
+  delete (payload as { sourceId?: unknown }).sourceId;
+  delete (payload as { sourceName?: unknown }).sourceName;
 
   const normalizeShoppingUnitId = (value: unknown): number | null => {
     if (value === null || value === undefined) return null;
@@ -151,16 +178,26 @@ export const useIngredientForm = () => {
   const { setIngredientsNeedsRefetch, startRequest, endRequest } = useData();
   const [state, dispatch] = useSessionStorageReducer(reducer, createInitialState, "ingredient-form-state-v1");
 
+  const applyIngredientDefaults = useCallback((ingredient: IngredientRead): IngredientFormState["ingredient"] => {
+    const maybeIngredient = ingredient as IngredientFormState["ingredient"];
+    return {
+      ...ingredient,
+      source: maybeIngredient.source ?? "manual",
+      sourceId: maybeIngredient.sourceId ?? null,
+      sourceName: maybeIngredient.sourceName ?? null,
+    };
+  }, []);
+
   const loadIngredient = useCallback(
     (initial?: IngredientRead | null) => {
       if (initial) {
-        dispatch({ type: "SET_INGREDIENT", payload: { ...initial } });
+        dispatch({ type: "SET_INGREDIENT", payload: applyIngredientDefaults(initial) });
         dispatch({ type: "SET_FILL_FORM", payload: true });
       } else {
         dispatch({ type: "SET_INGREDIENT", payload: initializeEmptyIngredient() });
       }
     },
-    [dispatch],
+    [dispatch, applyIngredientDefaults],
   );
 
   const clearForm = useCallback(() => {
@@ -227,6 +264,31 @@ export const useIngredientForm = () => {
     [state.ingredient.id, startRequest, endRequest, setIngredientsNeedsRefetch],
   );
 
+  const applyUsdaResult = useCallback(
+    (result: UsdaIngredientResult) => {
+      const updatedNutrition = {
+        calories: result.nutrition.calories ?? 0,
+        protein: result.nutrition.protein ?? 0,
+        carbohydrates: result.nutrition.carbohydrates ?? 0,
+        fat: result.nutrition.fat ?? 0,
+        fiber: result.nutrition.fiber ?? 0,
+      };
+
+      dispatch({
+        type: "SET_INGREDIENT",
+        payload: {
+          ...state.ingredient,
+          name: result.name,
+          nutrition: updatedNutrition,
+          source: "usda",
+          sourceId: result.id,
+          sourceName: result.name,
+        },
+      });
+    },
+    [dispatch, state.ingredient],
+  );
+
   return {
     ingredient: state.ingredient,
     needsClearForm: state.needsClearForm,
@@ -238,8 +300,7 @@ export const useIngredientForm = () => {
     acknowledgeFillFlag,
     save,
     remove,
+    applyUsdaResult,
   };
 };
-
-
 


### PR DESCRIPTION
### Motivation
- Provide an optional USDA source to populate ingredient name and nutrition to speed data entry.
- Keep the existing manual entry flow as the default while enabling external lookup when desired.
- Track source metadata on ingredients so imported data can be distinguished from manual edits.

### Description
- Add a new `SourceEdit` UI (`Frontend/src/components/data/ingredient/form/SourceEdit.tsx`) with a `GET /api/usda/search?query=...` fetch, result normalization, and a selectable results list.
- Extend the ingredient form state in `useIngredientForm.ts` to include `source`, `sourceId`, and `sourceName`, ensure these local-only fields are stripped before sending payloads, and add `applyUsdaResult` to populate name and nutrition from USDA results.
- Wire the `SourceEdit` component into both `IngredientForm.tsx` and `IngredientEditor.tsx` and expose `applyUsdaResult` from `useIngredientForm` for selection handling.
- Preserve manual flow as the default by initializing `source` to `"manual"` and only showing the search UI when `source` is `usda`.

### Testing
- No automated test suite was executed as part of this change.
- Attempted to run the repository check `pwsh ./scripts/repo/check.ps1`, but PowerShell was not available in the environment so the command failed.
- Attempted to run the shell helper `./scripts/repo/check.sh`, but execution failed due to permission errors on helper scripts.
- Linting/build/test commands (`pwsh ./scripts/run-tests.ps1 -full`, `npm --prefix Frontend run dev`) were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504a0db954832298c85820b132d605)