### PR TITLE
Add USDA FoodData Central integration and .env-backed API key

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+# USDA FoodData Central API key
+USDA_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.pyd
 .env
 .env.*
+!.env.template
 *.sqlite3
 instance/
 *.log

--- a/Backend/backend.py
+++ b/Backend/backend.py
@@ -12,6 +12,7 @@ from Backend.routes import (
     plans_router,
     stored_food_router,
     logs_router,
+    usda_router,
 )
 from Backend.settings import settings
 
@@ -42,7 +43,7 @@ app.include_router(foods_router, prefix="/api")
 app.include_router(plans_router, prefix="/api")
 app.include_router(stored_food_router, prefix="/api")
 app.include_router(logs_router, prefix="/api")
+app.include_router(usda_router, prefix="/api")
 
 
 __all__ = ["app"]
-

--- a/Backend/routes/__init__.py
+++ b/Backend/routes/__init__.py
@@ -5,6 +5,7 @@ from .foods import router as foods_router
 from .plans import router as plans_router
 from .stored_food import router as stored_food_router
 from .logs import router as logs_router
+from .usda import router as usda_router
 
 __all__ = [
     "ingredients_router",
@@ -12,4 +13,5 @@ __all__ = [
     "plans_router",
     "stored_food_router",
     "logs_router",
+    "usda_router",
 ]

--- a/Backend/routes/usda.py
+++ b/Backend/routes/usda.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+
+from Backend.settings import settings
+
+router = APIRouter(prefix="/usda", tags=["usda"])
+
+_BASE_URL = "https://api.nal.usda.gov/fdc/v1"
+_MACRO_NAMES = {
+    "energy": "calories",
+    "protein": "protein_g",
+    "total lipid (fat)": "fat_g",
+    "carbohydrate, by difference": "carbs_g",
+}
+
+
+def _require_api_key() -> str:
+    if not settings.usda_api_key:
+        raise HTTPException(
+            status_code=503,
+            detail="USDA API key is not configured. Set USDA_API_KEY in .env.",
+        )
+    return settings.usda_api_key
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_name(raw: str | None) -> str:
+    return (raw or "").strip().lower()
+
+
+def _extract_nutrient_name(entry: dict[str, Any]) -> str:
+    name = entry.get("nutrientName")
+    if name:
+        return str(name)
+    nutrient = entry.get("nutrient") or {}
+    return str(nutrient.get("name") or "")
+
+
+def _extract_nutrient_value(entry: dict[str, Any]) -> float | None:
+    return _coerce_float(entry.get("value", entry.get("amount")))
+
+
+def _trim_nutrients(food_nutrients: Iterable[dict[str, Any]]) -> dict[str, float | None]:
+    macros: dict[str, float | None] = {value: None for value in _MACRO_NAMES.values()}
+    for nutrient in food_nutrients:
+        name = _normalize_name(_extract_nutrient_name(nutrient))
+        if name in _MACRO_NAMES:
+            macros[_MACRO_NAMES[name]] = _extract_nutrient_value(nutrient)
+    return macros
+
+
+def _trim_food_payload(food: dict[str, Any]) -> dict[str, Any]:
+    nutrients = _trim_nutrients(food.get("foodNutrients", []))
+    return {
+        "fdc_id": food.get("fdcId"),
+        "name": food.get("description"),
+        "nutrients": nutrients,
+    }
+
+
+@router.get("/search")
+async def search_foods(query: str = Query(..., min_length=1)) -> dict[str, Any]:
+    api_key = _require_api_key()
+    params = {"query": query, "pageSize": 25, "api_key": api_key}
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            response = await client.get(f"{_BASE_URL}/foods/search", params=params)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=502, detail=f"USDA API request failed: {exc}"
+            ) from exc
+
+    payload = response.json()
+    foods = [_trim_food_payload(food) for food in payload.get("foods", [])]
+    return {"foods": foods}
+
+
+@router.get("/foods/{fdc_id}")
+async def get_food_details(fdc_id: int) -> dict[str, Any]:
+    api_key = _require_api_key()
+    params = {"api_key": api_key}
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            response = await client.get(f"{_BASE_URL}/food/{fdc_id}", params=params)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=502, detail=f"USDA API request failed: {exc}"
+            ) from exc
+
+    return _trim_food_payload(response.json())

--- a/Backend/settings.py
+++ b/Backend/settings.py
@@ -8,6 +8,7 @@ attributes instead of reading environment variables directly.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from dataclasses import dataclass
 
 
@@ -15,6 +16,28 @@ def _to_bool(value: str | None, default: bool = False) -> bool:
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
+def _load_dotenv() -> None:
+    env_path = Path(__file__).resolve().parents[1] / ".env"
+    if not env_path.exists():
+        return
+
+    for line in env_path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        key, separator, value = stripped.partition("=")
+        if not separator:
+            continue
+
+        key = key.strip()
+        if not key or key in os.environ:
+            continue
+
+        value = value.strip().strip('"').strip("'")
+        os.environ[key] = value
 
 
 @dataclass(frozen=True)
@@ -31,8 +54,12 @@ class Settings:
     # CORS configuration (kept permissive for dev by default).
     allow_origins: list[str]
 
+    # USDA FoodData Central API key.
+    usda_api_key: str | None
+
     @staticmethod
     def load() -> "Settings":
+        _load_dotenv()
         db_url = os.getenv("SQLALCHEMY_DATABASE_URI") or os.getenv("DATABASE_URL")
 
         if not db_url:
@@ -58,6 +85,7 @@ class Settings:
             database_url=db_url,
             db_auto_create=auto_create,
             allow_origins=origins,
+            usda_api_key=os.getenv("USDA_API_KEY"),
         )
 
 
@@ -65,4 +93,3 @@ class Settings:
 settings = Settings.load()
 
 __all__ = ["settings", "Settings"]
-


### PR DESCRIPTION
### Motivation
- Add the ability to look up foods and core macro nutrients from USDA FoodData Central to enrich ingredient data.
- Allow an API key to be configured via a local `.env` file while keeping secrets out of the repository.
- Provide a minimal, focused API surface for search and details that returns only the fields needed by the app (name, `fdc_id`, and macros).
- Fail gracefully with clear errors when the USDA API key is missing or external requests fail.

### Description
- Added `_load_dotenv()` to `Backend/settings.py`, wired it into `Settings.load()`, and added a typed `usda_api_key: str | None` field that reads `USDA_API_KEY` from environment.
- Implemented `Backend/routes/usda.py` with `GET /api/usda/search?query=...` and `GET /api/usda/foods/{fdc_id}` using `httpx` to call USDA and returning a trimmed payload of `fdc_id`, `name`, and macro nutrients (`calories`, `protein_g`, `fat_g`, `carbs_g`).
- Registered the new router by exporting `usda_router` in `Backend/routes/__init__.py` and including it in `Backend/backend.py` under the `/api` prefix.
- Added `.env.template` (tracked) and updated `.gitignore` to keep `.env` ignored so keys live in local `.env` files only.

### Testing
- No automated tests were executed for this change.
- To validate locally, run the project and then exercise the endpoints with a populated `.env` (example: `USDA_API_KEY=...`) or run the full test suite with `pwsh ./scripts/run-tests.ps1 -full` (or `./scripts/run-tests.sh`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695052186e948322a30eac0f45fad087)