### PR TITLE
Add ingredient source fields (source, source_id) with frontend support and migration

### DIFF
--- a/Backend/migrations/versions/e1f2a3b4c5d6_add_ingredient_source_fields.py
+++ b/Backend/migrations/versions/e1f2a3b4c5d6_add_ingredient_source_fields.py
@@ -1,0 +1,32 @@
+"""add_ingredient_source_fields
+
+Revision ID: e1f2a3b4c5d6
+Revises: c9271ea398b2
+Create Date: 2025-09-19 17:45:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e1f2a3b4c5d6"
+down_revision = "c9271ea398b2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "ingredients",
+        sa.Column("source", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "ingredients",
+        sa.Column("source_id", sa.String(length=100), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("ingredients", "source_id")
+    op.drop_column("ingredients", "source")

--- a/Backend/models/ingredient.py
+++ b/Backend/models/ingredient.py
@@ -21,6 +21,12 @@ class Ingredient(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(sa_column=Column(String(100), unique=True, nullable=False))
+    source: Optional[str] = Field(
+        default=None, sa_column=Column(String(50), nullable=True)
+    )
+    source_id: Optional[str] = Field(
+        default=None, sa_column=Column(String(100), nullable=True)
+    )
 
     nutrition: Optional[Nutrition] = Relationship(
         back_populates="ingredient",
@@ -46,7 +52,7 @@ class Ingredient(SQLModel, table=True):
     def from_create(cls, data: "IngredientCreate") -> "Ingredient":
         """Create an :class:`Ingredient` ORM object from an ``IngredientCreate`` schema."""
 
-        ingredient = cls(name=data.name)
+        ingredient = cls(name=data.name, source=data.source, source_id=data.source_id)
 
         if data.nutrition:
             ingredient.nutrition = Nutrition.model_validate(

--- a/Backend/models/schemas.py
+++ b/Backend/models/schemas.py
@@ -62,6 +62,8 @@ class IngredientCreate(SQLModel):
     """Schema for creating an ingredient."""
 
     name: str
+    source: Optional[str] = None
+    source_id: Optional[str] = None
     nutrition: Optional[NutritionCreate] = None
     units: List[IngredientUnitCreate] = Field(default_factory=list)
     tags: List[TagRef] = Field(default_factory=list)
@@ -73,6 +75,8 @@ class IngredientUpdate(SQLModel):
     """Schema for updating an ingredient."""
 
     name: str
+    source: Optional[str] = None
+    source_id: Optional[str] = None
     nutrition: Optional[NutritionCreate] = None
     # Accept units with optional id for proper upsert behavior
     units: List[IngredientUnitUpdate] = Field(default_factory=list)
@@ -88,6 +92,8 @@ class IngredientRead(SQLModel):
 
     id: int
     name: str
+    source: Optional[str] = None
+    source_id: Optional[str] = None
     nutrition: Optional[Nutrition] = None
     units: List[IngredientUnit] = Field(default_factory=list)
     tags: List[PossibleIngredientTag] = Field(default_factory=list)

--- a/Backend/routes/ingredients.py
+++ b/Backend/routes/ingredients.py
@@ -58,6 +58,8 @@ def ingredient_to_read(ingredient: Ingredient) -> IngredientRead:
     payload = {
         "id": ingredient.id,
         "name": ingredient.name,
+        "source": ingredient.source,
+        "source_id": ingredient.source_id,
         "nutrition": ingredient.nutrition,
         "units": list(ingredient.units or []),
         "tags": list(ingredient.tags or []),
@@ -312,7 +314,13 @@ def update_ingredient(
     if not ingredient:
         raise HTTPException(status_code=404, detail="Ingredient not found")
 
+    payload_fields = ingredient_data.model_dump(exclude_unset=True)
+
     ingredient.name = ingredient_data.name
+    if "source" in payload_fields:
+        ingredient.source = ingredient_data.source
+    if "source_id" in payload_fields:
+        ingredient.source_id = ingredient_data.source_id
 
     # Upsert nutrition
     if ingredient_data.nutrition:
@@ -367,7 +375,6 @@ def update_ingredient(
     try:
         db.add(ingredient)
         db.flush()
-        payload_fields = ingredient_data.model_dump(exclude_unset=True)
         if "shopping_unit_id" in payload_fields or "shopping_unit" in payload_fields:
             apply_shopping_unit_selection(
                 ingredient,

--- a/Frontend/src/api-types.ts
+++ b/Frontend/src/api-types.ts
@@ -329,6 +329,10 @@ export interface components {
     IngredientCreate: {
       /** Name */
       name: string;
+      /** Source */
+      source?: string | null;
+      /** Source Id */
+      source_id?: string | null;
       nutrition?: components["schemas"]["NutritionCreate"] | null;
       /** Units */
       units?: components["schemas"]["IngredientUnitCreate"][];
@@ -347,6 +351,10 @@ export interface components {
       id: number;
       /** Name */
       name: string;
+      /** Source */
+      source?: string | null;
+      /** Source Id */
+      source_id?: string | null;
       nutrition?: components["schemas"]["Nutrition"] | null;
       /** Units */
       units?: components["schemas"]["IngredientUnit"][];
@@ -411,6 +419,10 @@ export interface components {
     IngredientUpdate: {
       /** Name */
       name: string;
+      /** Source */
+      source?: string | null;
+      /** Source Id */
+      source_id?: string | null;
       nutrition?: components["schemas"]["NutritionCreate"] | null;
       /** Units */
       units?: components["schemas"]["IngredientUnitUpdate"][];

--- a/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { TextField } from "@mui/material";
+import { TextField, Typography } from "@mui/material";
 
 const roundToTwoDecimalPlaces = (value: number): number => {
   if (!Number.isFinite(value)) {
@@ -18,6 +18,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
     fat: 0,
     fiber: 0,
   });
+  const isUsdaSource = ingredient?.source === "usda";
 
   const inputStyle = {
     width: "15ch",
@@ -166,7 +167,13 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
   }, [needsFillForm, ingredient, multiplier, getRoundedDisplayNutrition]); // Fills the form on needsFillForm
 
   return (
-    <div style={{ display: "flex", flexDirection: "row", alignItems: "center" }}>
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+      {isUsdaSource && (
+        <Typography variant="caption" color="text.secondary" sx={{ mx: 1 }}>
+          USDA-sourced nutrition is read-only.
+        </Typography>
+      )}
+      <div style={{ display: "flex", flexDirection: "row", alignItems: "center" }}>
       <TextField
         label="Calories"
         value={displayNutrition.calories}
@@ -175,6 +182,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
         onBlur={handleFieldEditFinish}
         variant="outlined"
         sx={inputStyle}
+        disabled={isUsdaSource}
         inputProps={{
           sx: inputStyle["& input"],
           inputMode: "decimal",
@@ -188,6 +196,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
         onBlur={handleFieldEditFinish}
         variant="outlined"
         sx={inputStyle}
+        disabled={isUsdaSource}
         inputProps={{
           sx: inputStyle["& input"],
           inputMode: "decimal",
@@ -201,6 +210,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
         onBlur={handleFieldEditFinish}
         variant="outlined"
         sx={inputStyle}
+        disabled={isUsdaSource}
         inputProps={{
           sx: inputStyle["& input"],
           inputMode: "decimal",
@@ -214,6 +224,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
         onBlur={handleFieldEditFinish}
         variant="outlined"
         sx={inputStyle}
+        disabled={isUsdaSource}
         inputProps={{
           sx: inputStyle["& input"],
           inputMode: "decimal",
@@ -227,17 +238,18 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
         onBlur={handleFieldEditFinish}
         variant="outlined"
         sx={inputStyle}
+        disabled={isUsdaSource}
         inputProps={{
           sx: inputStyle["& input"],
           inputMode: "decimal",
         }}
       />
+      </div>
     </div>
   );
 }
 
 export default NutritionEdit;
-
 
 
 

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -100,7 +100,7 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
       payload: {
         ...ingredient,
         source: value,
-        sourceId: value === "manual" ? null : ingredient.sourceId ?? null,
+        source_id: value === "manual" ? null : ingredient.source_id ?? null,
         sourceName: value === "manual" ? null : ingredient.sourceName ?? null,
       },
     });

--- a/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
+++ b/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
@@ -28,7 +28,7 @@ export type UsdaIngredientResult = {
 type IngredientFormIngredient = IngredientRead & {
   shoppingUnitId?: number | string | null;
   source?: IngredientSource;
-  sourceId?: string | null;
+  source_id?: string | null;
   sourceName?: string | null;
 };
 
@@ -74,7 +74,7 @@ const initializeEmptyIngredient = (): IngredientFormState["ingredient"] => ({
   tags: [],
   shoppingUnitId: "0",
   source: "manual",
-  sourceId: null,
+  source_id: null,
   sourceName: null,
 });
 
@@ -114,8 +114,6 @@ const buildRequestPayload = (ingredient: IngredientFormState["ingredient"]): Ing
 
   // Remove local-only helper property
   delete (payload as { shoppingUnitId?: unknown }).shoppingUnitId;
-  delete (payload as { source?: unknown }).source;
-  delete (payload as { sourceId?: unknown }).sourceId;
   delete (payload as { sourceName?: unknown }).sourceName;
 
   const normalizeShoppingUnitId = (value: unknown): number | null => {
@@ -183,7 +181,7 @@ export const useIngredientForm = () => {
     return {
       ...ingredient,
       source: maybeIngredient.source ?? "manual",
-      sourceId: maybeIngredient.sourceId ?? null,
+      source_id: maybeIngredient.source_id ?? null,
       sourceName: maybeIngredient.sourceName ?? null,
     };
   }, []);
@@ -281,7 +279,7 @@ export const useIngredientForm = () => {
           name: result.name,
           nutrition: updatedNutrition,
           source: "usda",
-          sourceId: result.id,
+          source_id: result.id,
           sourceName: result.name,
         },
       });
@@ -303,4 +301,3 @@ export const useIngredientForm = () => {
     applyUsdaResult,
   };
 };
-


### PR DESCRIPTION
### Motivation

- Record provenance for ingredients (e.g. USDA vs manual) by adding `source` and `source_id` to the ingredient model so external references like USDA FDC IDs can be stored.
- Keep existing data valid by making the new columns nullable and adding a migration that can be applied without data changes.
- Surface source metadata in API responses and persist it from frontend ingredient forms so UI workflows can use the information (e.g. disable edits for USDA-sourced nutrition).
- Provide a UX signal that USDA-sourced nutrition is authoritative by making nutrition fields read-only and showing a small warning.

### Description

- Added `source: Optional[str]` and `source_id: Optional[str]` columns to `Backend/models/ingredient.py` and wired them into `Ingredient.from_create`.
- Updated Pydantic/SQLModel schemas in `Backend/models/schemas.py` to include `source` and `source_id` on `IngredientCreate`, `IngredientUpdate`, and `IngredientRead` and included these fields in `ingredient_to_read` and update handling in `Backend/routes/ingredients.py`.
- Added an Alembic migration `Backend/migrations/versions/e1f2a3b4c5d6_add_ingredient_source_fields.py` which adds nullable `source` and `source_id` columns and provides a downgrade to remove them.
- Updated frontend type/contract and form logic by changing `Frontend/src/api-types.ts`, `Frontend/src/components/data/ingredient/form/useIngredientForm.ts`, and `Frontend/src/components/data/ingredient/form/SourceEdit.tsx` to persist `source`/`source_id`, and modified `NutritionEdit.tsx` to show a small warning and disable nutrition inputs when `source === "usda"`.

### Testing

- No backend or frontend test suites were executed as part of this change.
- A Playwright attempt to capture a screenshot failed with `net::ERR_EMPTY_RESPONSE` because the dev server was not running.
- The code changes were committed locally as `Add ingredient source metadata` and the migration file was created and staged.
- Manual verification steps to run (not executed): run `pwsh ./scripts/run-tests.ps1 -full` or `./scripts/run-tests.sh` and apply the migration via Alembic or `pwsh ./scripts/db/restore.ps1` flows before starting the app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950549eb268832298c3b2b5241fdf52)