### PR TITLE
Check frontend openapi-typescript dependency before generation

### DIFF
--- a/scripts/db/update-api-schema.ps1
+++ b/scripts/db/update-api-schema.ps1
@@ -71,7 +71,11 @@ try {
     Out-Ok "Saved OpenAPI to Backend/openapi.json"
 
     Out-Step "Generating TypeScript types for frontend..."
-    npx --prefix Frontend openapi-typescript Backend/openapi.json -o Frontend/src/api-types.ts | Out-Null
+    $openapiTypescript = Join-Path -Path $repoRoot -ChildPath "Frontend/node_modules/.bin/openapi-typescript"
+    if (-not (Test-Path $openapiTypescript)) {
+        throw "Missing Frontend/node_modules/.bin/openapi-typescript. Run 'npm install' in Frontend before generating API types."
+    }
+    npx --yes --prefix Frontend openapi-typescript Backend/openapi.json -o Frontend/src/api-types.ts | Out-Null
     Out-Ok "Generated Frontend/src/api-types.ts"
 }
 catch {

--- a/scripts/db/update-api-schema.sh
+++ b/scripts/db/update-api-schema.sh
@@ -36,4 +36,8 @@ done
 curl "http://localhost:${DEV_BACKEND_PORT}/openapi.json" -o Backend/openapi.json
 
 # Generate TypeScript types for the frontend
-npx --prefix Frontend openapi-typescript Backend/openapi.json -o Frontend/src/api-types.ts
+if [ ! -f "Frontend/node_modules/.bin/openapi-typescript" ]; then
+  echo "Missing Frontend/node_modules/.bin/openapi-typescript. Run 'npm install' in Frontend before generating API types." >&2
+  exit 1
+fi
+npx --yes --prefix Frontend openapi-typescript Backend/openapi.json -o Frontend/src/api-types.ts


### PR DESCRIPTION
### Motivation
- Fail fast with a clear error if the frontend `openapi-typescript` binary is missing so users run `npm install` in `Frontend` first. 
- Avoid interactive `npx` prompts when output is redirected by making invocations non-interactive. 
- Keep PowerShell and Bash helper scripts behavior consistent so both environments error the same way. 

### Description
- Add a guard in `scripts/db/update-api-schema.ps1` that checks `Frontend/node_modules/.bin/openapi-typescript` and throws a helpful message if missing. 
- Replace the `npx` call in the PowerShell script with `npx --yes --prefix Frontend openapi-typescript ...` to force non-interactive execution. 
- Mirror the same guard and `--yes --prefix Frontend` `npx` invocation in `scripts/db/update-api-schema.sh`, printing the error to `stderr` and exiting `1` when missing. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69505ac1a854832293da7ae9f6665b47)