### PR TITLE
USDA: normalize nutrient keys and expose `id` in food payloads

### DIFF
--- a/Backend/routes/usda.py
+++ b/Backend/routes/usda.py
@@ -12,9 +12,10 @@ router = APIRouter(prefix="/usda", tags=["usda"])
 _BASE_URL = "https://api.nal.usda.gov/fdc/v1"
 _MACRO_NAMES = {
     "energy": "calories",
-    "protein": "protein_g",
-    "total lipid (fat)": "fat_g",
-    "carbohydrate, by difference": "carbs_g",
+    "protein": "protein",
+    "total lipid (fat)": "fat",
+    "carbohydrate, by difference": "carbohydrates",
+    "fiber, total dietary": "fiber",
 }
 
 
@@ -64,7 +65,7 @@ def _trim_nutrients(food_nutrients: Iterable[dict[str, Any]]) -> dict[str, float
 def _trim_food_payload(food: dict[str, Any]) -> dict[str, Any]:
     nutrients = _trim_nutrients(food.get("foodNutrients", []))
     return {
-        "fdc_id": food.get("fdcId"),
+        "id": food.get("fdcId"),
         "name": food.get("description"),
         "nutrients": nutrients,
     }


### PR DESCRIPTION
### Motivation
- Normalize USDA nutrient output to app-friendly keys so downstream code expects `calories`, `protein`, `carbohydrates`, `fat`, and `fiber` instead of vendor-specific names.
- Simplify the food payload identifier to `id` for consistency with other API responses and client models.
- Keep USDA route responses consistent between search and detail endpoints so the frontend can use a single shape.
- Surface a minimal change set confined to USDA response shaping to avoid broader breakage.

### Description
- Updated `Backend/routes/usda.py` to map USDA nutrient names to `calories`, `protein`, `carbohydrates`, `fat`, and `fiber` via the `_MACRO_NAMES` map.
- Added `fiber` mapping for `fiber, total dietary` in the nutrient trimming logic used by `_trim_nutrients`.
- Changed `_trim_food_payload` to expose `id` (set from `fdcId`) instead of `fdc_id` so returned foods have `id`, `name`, and `nutrients`.
- Both `/api/usda/search` and `/api/usda/foods/{fdc_id}` now return the same shaped objects: `foods: [{ id, name, nutrients: { calories, protein, carbohydrates, fat, fiber } }]` or a single trimmed food for the detail endpoint.

### Testing
- No automated tests were executed as part of this change.
- Recommend running `pwsh ./scripts/run-tests.ps1 -full` (or `./scripts/run-tests.sh`) to validate backend and frontend test suites.
- If present, update OpenAPI snapshots or generated schemas (e.g. `Backend/openapi.json`) and any tests in `Backend/tests` that assert old fields (`fdc_id` or old nutrient keys). 
- Manual verification: search and detail endpoints should be exercised by the client e2e or API tests to confirm shape compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950649ca1548322a8ea536a1523403a)