### PR TITLE
Fetch USDA ingredient details on selection and improve search/error handling

### DIFF
--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -57,9 +57,13 @@ const normalizeResults = (data: unknown): UsdaIngredientResult[] => {
   }
 
   if (data && typeof data === "object") {
-    const possibleResults = (data as { results?: unknown }).results;
+    const possibleResults = (data as { results?: unknown; foods?: unknown }).results;
+    const foodsResults = (data as { foods?: unknown }).foods;
     if (possibleResults) {
       return normalizeResults(possibleResults);
+    }
+    if (foodsResults) {
+      return normalizeResults(foodsResults);
     }
   }
 
@@ -69,8 +73,10 @@ const normalizeResults = (data: unknown): UsdaIngredientResult[] => {
 function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<UsdaIngredientResult[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
 
   const selectedSource: IngredientSource = ingredient.source ?? "manual";
   const disabledSearch = selectedSource !== "usda";
@@ -78,7 +84,7 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
   const hasResults = results.length > 0;
 
   const statusMessage = useMemo(() => {
-    if (isLoading) {
+    if (isSearching) {
       return "Searching USDA database...";
     }
     if (error) {
@@ -91,7 +97,7 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
       return "No USDA matches yet. Try a different search.";
     }
     return null;
-  }, [error, isLoading, query, hasResults]);
+  }, [error, isSearching, query, hasResults]);
 
   const handleSourceChange = (event) => {
     const value = event.target.value as IngredientSource;
@@ -113,8 +119,9 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
       return;
     }
 
-    setIsLoading(true);
+    setIsSearching(true);
     setError(null);
+    setDetailError(null);
 
     try {
       const response = await fetch(`/api/usda/search?query=${encodeURIComponent(trimmed)}`);
@@ -129,12 +136,33 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
       // eslint-disable-next-line no-console
       console.error(searchError);
     } finally {
-      setIsLoading(false);
+      setIsSearching(false);
     }
   };
 
-  const handleSelectResult = (result: UsdaIngredientResult) => {
-    applyUsdaResult(result);
+  const handleSelectResult = async (result: UsdaIngredientResult) => {
+    setIsLoadingDetail(true);
+    setDetailError(null);
+
+    try {
+      const response = await fetch(`/api/usda/foods/${result.id}`);
+      if (!response.ok) {
+        throw new Error("USDA detail fetch failed.");
+      }
+      const data = await response.json();
+      const mapped = mapUsdaResult(data);
+      if (!mapped) {
+        throw new Error("USDA detail mapping failed.");
+      }
+      applyUsdaResult(mapped);
+    } catch (detailFetchError) {
+      setDetailError("Unable to load USDA details. Using search results instead.");
+      applyUsdaResult(result);
+      // eslint-disable-next-line no-console
+      console.error(detailFetchError);
+    } finally {
+      setIsLoadingDetail(false);
+    }
   };
 
   return (
@@ -160,14 +188,22 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
               onChange={(event) => setQuery(event.target.value)}
               fullWidth
             />
-            <Button variant="outlined" onClick={handleSearch} disabled={disabledSearch || isLoading}>
+            <Button
+              variant="outlined"
+              onClick={handleSearch}
+              disabled={disabledSearch || isSearching || isLoadingDetail}>
               Search
             </Button>
           </Box>
-          {isLoading && <CircularProgress size={20} />}
+          {(isSearching || isLoadingDetail) && <CircularProgress size={20} />}
           {statusMessage && (
             <Typography variant="body2" color={error ? "error" : "text.secondary"}>
               {statusMessage}
+            </Typography>
+          )}
+          {detailError && (
+            <Typography variant="body2" color="warning.main">
+              {detailError}
             </Typography>
           )}
           {hasResults && (


### PR DESCRIPTION
### Motivation
- Selecting a USDA search result should fetch the USDA food detail to populate complete nutrition data before applying it to an ingredient.
- The USDA search endpoint sometimes returns a `foods` array payload shape that must be normalized into results.
- The UI should clearly indicate when a detail fetch fails and fall back to usable search data instead of silently failing.

### Description
- Normalize USDA search responses that include either `results` or `foods` by updating `normalizeResults` in `SourceEdit.tsx`.
- Add `isSearching`, `isLoadingDetail`, and `detailError` state, and show a combined spinner and status messages while searching or fetching details.
- On selecting a USDA result call `/api/usda/foods/{fdc_id}`, map the returned detail through `mapUsdaResult`, and apply the mapped result but fall back to the original search result if detail fetch/mapping fails.
- Disable search interaction while requests are underway and display a warning message when the detail fetch fails and a fallback is used.

### Testing
- Attempted to run the repo check with `pwsh ./scripts/repo/check.ps1`, which failed because PowerShell (`pwsh`) is not available in this environment.
- No automated frontend or backend test suites were executed in this environment due to missing dev tooling.
- The change was compiled and committed locally (no runtime server started or integration tests run as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69507555deac8322b6d3d70e0418d2d9)