### PR TITLE
Preserve USDA units in ingredient imports

### DIFF
--- a/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
@@ -1,9 +1,18 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useData } from "@/contexts/DataContext";
 
 import SourceEdit from "./SourceEdit";
+import { useIngredientForm } from "./useIngredientForm";
+
+vi.mock("@/contexts/DataContext", () => ({
+  useData: vi.fn(),
+}));
+
+const mockedUseData = vi.mocked(useData);
 
 const baseIngredient = {
   id: 1,
@@ -30,12 +39,22 @@ const baseIngredient = {
   sourceName: null,
 };
 
+beforeEach(() => {
+  mockedUseData.mockReturnValue({
+    setIngredientsNeedsRefetch: vi.fn(),
+    startRequest: vi.fn(),
+    endRequest: vi.fn(),
+  } as never);
+  window.sessionStorage.clear();
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
+  window.sessionStorage.clear();
 });
 
 describe("SourceEdit", () => {
-  it("imports normalized USDA detail results as per-gram nutrition", async () => {
+  it("shows the USDA default unit in search results and prefers detail units on selection", async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -61,6 +80,10 @@ describe("SourceEdit", () => {
                 serving_size_unit: null,
                 household_serving_full_text: null,
               },
+              units: [
+                { name: "1 g", grams: 1, is_default: false },
+                { name: "1 medium", grams: 118, is_default: true },
+              ],
             },
           ],
         }),
@@ -87,6 +110,11 @@ describe("SourceEdit", () => {
             serving_size_unit: null,
             household_serving_full_text: null,
           },
+          units: [
+            { name: "1 g", grams: 1, is_default: false },
+            { name: "1 large", grams: 136, is_default: true },
+            { name: "1 cup sliced", grams: 150, is_default: false },
+          ],
         }),
       });
     vi.stubGlobal("fetch", fetchMock);
@@ -105,7 +133,8 @@ describe("SourceEdit", () => {
 
     const bananaRow = await screen.findByRole("button", { name: /banana/i });
     expect(bananaRow).toBeEnabled();
-    expect(await screen.findByText(/Per gram/i)).toBeInTheDocument();
+    expect(await screen.findByText(/1 medium · Calories 0\.89/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Per gram/i)).not.toBeInTheDocument();
 
     await userEvent.click(bananaRow);
 
@@ -114,6 +143,12 @@ describe("SourceEdit", () => {
         expect.objectContaining({
           id: "123",
           name: "Banana",
+          units: [
+            expect.objectContaining({ name: "1 g", grams: 1, is_default: false }),
+            expect.objectContaining({ name: "1 large", grams: 136, is_default: true }),
+            expect.objectContaining({ name: "1 cup sliced", grams: 150, is_default: false }),
+          ],
+          defaultUnitKey: "name:1 large|grams:136",
           nutrition: expect.objectContaining({
             calories: 0.89,
             protein: 0.0109,
@@ -146,6 +181,7 @@ describe("SourceEdit", () => {
               serving_size_unit: "ml",
               household_serving_full_text: "8 fl oz",
             },
+            units: [{ name: "1 g", grams: 1, is_default: true }],
           },
         ],
       }),
@@ -169,5 +205,53 @@ describe("SourceEdit", () => {
     expect(await screen.findByText(/cannot be converted to per-gram values without density data/i)).toBeInTheDocument();
     expect(applyUsdaResult).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the USDA default unit in form state and imports gram plus USDA units", () => {
+    const { result } = renderHook(() => useIngredientForm());
+
+    act(() => {
+      result.current.applyUsdaResult({
+        id: "333",
+        name: "Apple slices",
+        nutrition: {
+          calories: 0.52,
+          protein: 0.0003,
+          carbohydrates: 0.14,
+          fat: 0.0002,
+          fiber: 0.024,
+        },
+        normalization: {
+          source_basis: "per_100g",
+          normalized_basis: "per_g",
+          can_normalize: true,
+          reason: null,
+          data_type: "Foundation",
+          serving_size: null,
+          serving_size_unit: null,
+          household_serving_full_text: null,
+        },
+        units: [
+          { name: "1 g", grams: 1, is_default: false },
+          { name: "1 cup sliced", grams: 109, is_default: true },
+          { name: "1 tbsp", grams: 8.5, is_default: false },
+        ],
+        defaultUnitKey: "name:1 cup sliced|grams:109",
+      });
+    });
+
+    expect(result.current.ingredient.source).toBe("usda");
+    expect(result.current.ingredient.source_id).toBe("333");
+    expect(result.current.ingredient.sourceName).toBe("Apple slices");
+    expect(result.current.ingredient.units).toEqual([
+      expect.objectContaining({ name: "g", grams: 1 }),
+      expect.objectContaining({ name: "1 cup sliced", grams: 109 }),
+      expect.objectContaining({ name: "1 tbsp", grams: 8.5 }),
+    ]);
+
+    const selectedUnit = result.current.ingredient.units.find(
+      (unit) => String(unit.id) === String(result.current.ingredient.shoppingUnitId),
+    );
+    expect(selectedUnit).toEqual(expect.objectContaining({ name: "1 cup sliced", grams: 109 }));
   });
 });

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -15,7 +15,68 @@ import {
   Typography,
 } from "@mui/material";
 
-import type { IngredientSource, UsdaIngredientResult } from "./useIngredientForm";
+import type { IngredientSource, UsdaIngredientResult, UsdaIngredientUnit } from "./useIngredientForm";
+
+
+const createUsdaUnitKey = (unit: Pick<UsdaIngredientUnit, "id" | "name" | "grams">): string => {
+  if (unit.id !== null && unit.id !== undefined && String(unit.id).trim() !== "") {
+    return `id:${String(unit.id)}`;
+  }
+
+  return `name:${unit.name.trim().toLowerCase()}|grams:${Number(unit.grams)}`;
+};
+
+const mapUsdaUnits = (value: unknown): UsdaIngredientUnit[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+
+  return value.reduce<UsdaIngredientUnit[]>((acc, unit) => {
+    if (!unit || typeof unit !== "object") {
+      return acc;
+    }
+
+    const rawUnit = unit as Record<string, unknown>;
+    const name = String(rawUnit.name ?? "").trim();
+    const grams = Number(rawUnit.grams);
+
+    if (!name || !Number.isFinite(grams) || grams <= 0) {
+      return acc;
+    }
+
+    const mappedUnit: UsdaIngredientUnit = {
+      id: rawUnit.id as string | number | null | undefined,
+      name,
+      grams,
+      is_default: Boolean(rawUnit.is_default ?? rawUnit.isDefault),
+    };
+    const key = createUsdaUnitKey(mappedUnit);
+    if (seen.has(key)) {
+      return acc;
+    }
+
+    seen.add(key);
+    acc.push(mappedUnit);
+    return acc;
+  }, []);
+};
+
+const getDefaultUnitKey = (units: UsdaIngredientUnit[]): string | null => {
+  const defaultUnit = units.find((unit) => unit.is_default) ?? units[0] ?? null;
+  return defaultUnit ? createUsdaUnitKey(defaultUnit) : null;
+};
+
+const getDefaultUnitLabel = (result: UsdaIngredientResult): string => {
+  const defaultUnit =
+    result.units.find((unit) => createUsdaUnitKey(unit) === result.defaultUnitKey) ??
+    result.units.find((unit) => unit.is_default) ??
+    result.units[0] ??
+    null;
+
+  return defaultUnit?.name ?? "1 g";
+};
 
 const normalizeNutritionValue = (value: unknown): number => {
   const numeric = Number(value);
@@ -37,6 +98,7 @@ const mapUsdaResult = (item: Record<string, unknown>): UsdaIngredientResult | nu
   const nutritionSource = (item.nutrition ?? item.nutrients ?? null) as Record<string, unknown> | null;
   const normalizationSource = (item.normalization ?? {}) as Record<string, unknown>;
   const canNormalize = Boolean(normalizationSource.can_normalize);
+  const units = mapUsdaUnits(item.units);
 
   return {
     id: String(idValue),
@@ -75,6 +137,8 @@ const mapUsdaResult = (item: Record<string, unknown>): UsdaIngredientResult | nu
           ? null
           : String(normalizationSource.household_serving_full_text),
     },
+    units,
+    defaultUnitKey: getDefaultUnitKey(units),
   };
 };
 
@@ -110,7 +174,7 @@ const formatNutritionSummary = (result: UsdaIngredientResult): string => {
     return `${reason} Basis: ${result.normalization.source_basis}.`;
   }
 
-  return `Per gram · Calories ${result.nutrition.calories} · Protein ${result.nutrition.protein} · Carbs ${result.nutrition.carbohydrates} · Fat ${result.nutrition.fat}`;
+  return `${getDefaultUnitLabel(result)} · Calories ${result.nutrition.calories} · Protein ${result.nutrition.protein} · Carbs ${result.nutrition.carbohydrates} · Fat ${result.nutrition.fat}`;
 };
 
 function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
@@ -202,10 +266,20 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
       if (!mapped) {
         throw new Error("USDA detail mapping failed.");
       }
-      if (!mapped.normalization.can_normalize || !mapped.nutrition) {
-        throw new Error(mapped.normalization.reason ?? "USDA detail did not return per-gram nutrition.");
+
+      const preferredMapped =
+        mapped.units.length > 0
+          ? mapped
+          : {
+              ...mapped,
+              units: result.units,
+              defaultUnitKey: result.defaultUnitKey,
+            };
+
+      if (!preferredMapped.normalization.can_normalize || !preferredMapped.nutrition) {
+        throw new Error(preferredMapped.normalization.reason ?? "USDA detail did not return per-gram nutrition.");
       }
-      applyUsdaResult(mapped);
+      applyUsdaResult(preferredMapped);
     } catch (detailFetchError) {
       setDetailError(
         detailFetchError instanceof Error

--- a/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
+++ b/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
@@ -13,6 +13,13 @@ type IngredientRequest = operations["add_ingredient_api_ingredients__post"]["req
 
 export type IngredientSource = "manual" | "usda";
 
+export type UsdaIngredientUnit = {
+  id?: string | number | null;
+  name: string;
+  grams: number;
+  is_default?: boolean;
+};
+
 export type UsdaIngredientResult = {
   id: string;
   name: string;
@@ -33,6 +40,8 @@ export type UsdaIngredientResult = {
     serving_size_unit: string | null;
     household_serving_full_text: string | null;
   };
+  units: UsdaIngredientUnit[];
+  defaultUnitKey: string | null;
 };
 
 type IngredientFormIngredient = IngredientRead & {
@@ -87,6 +96,52 @@ const initializeEmptyIngredient = (): IngredientFormState["ingredient"] => ({
   source_id: null,
   sourceName: null,
 });
+
+
+const createUsdaUnitKey = (unit: Pick<UsdaIngredientUnit, "id" | "name" | "grams">): string => {
+  if (unit.id !== null && unit.id !== undefined && String(unit.id).trim() !== "") {
+    return `id:${String(unit.id)}`;
+  }
+
+  return `name:${unit.name.trim().toLowerCase()}|grams:${Number(unit.grams)}`;
+};
+
+const normalizeUsdaUnits = (units: UsdaIngredientUnit[] | null | undefined): UsdaIngredientUnit[] => {
+  if (!Array.isArray(units)) {
+    return [];
+  }
+
+  const seen = new Set<string>();
+
+  return units.reduce<UsdaIngredientUnit[]>((acc, unit) => {
+    const name = typeof unit.name === "string" ? unit.name.trim() : "";
+    const grams = Number(unit.grams);
+
+    if (!name || !Number.isFinite(grams) || grams <= 0) {
+      return acc;
+    }
+
+    const normalizedUnit: UsdaIngredientUnit = {
+      id: unit.id ?? null,
+      name,
+      grams,
+      is_default: Boolean(unit.is_default),
+    };
+    const key = createUsdaUnitKey(normalizedUnit);
+    if (seen.has(key)) {
+      return acc;
+    }
+
+    seen.add(key);
+    acc.push(normalizedUnit);
+    return acc;
+  }, []);
+};
+
+const getDefaultUsdaUnitKey = (units: UsdaIngredientUnit[]): string | null => {
+  const defaultUnit = units.find((unit) => unit.is_default) ?? units[0] ?? null;
+  return defaultUnit ? createUsdaUnitKey(defaultUnit) : null;
+};
 
 const createInitialState = (): IngredientFormState => ({
   ingredient: initializeEmptyIngredient(),
@@ -286,11 +341,38 @@ export const useIngredientForm = () => {
         fiber: result.nutrition.fiber ?? 0,
       };
 
+      const normalizedUsdaUnits = normalizeUsdaUnits(result.units);
+      const importedUnits = [
+        {
+          id: "0",
+          ingredient_id: state.ingredient.id,
+          name: "g",
+          grams: 1,
+        },
+        ...normalizedUsdaUnits
+          .filter((unit) => !(unit.name.toLowerCase() === "1 g" && Number(unit.grams) === 1))
+          .map((unit) => ({
+            id: createUsdaUnitKey(unit),
+            ingredient_id: state.ingredient.id,
+            name: unit.name,
+            grams: unit.grams,
+          })),
+      ];
+
+      const normalizedDefaultUnitKey = result.defaultUnitKey ?? getDefaultUsdaUnitKey(normalizedUsdaUnits);
+      const defaultImportedUnit =
+        importedUnits.find((unit) => String(unit.id) === normalizedDefaultUnitKey) ??
+        importedUnits.find((unit) => unit.name === "g" && Number(unit.grams) === 1) ??
+        importedUnits[0] ??
+        null;
+
       dispatch({
         type: "SET_INGREDIENT",
         payload: {
           ...state.ingredient,
           name: result.name,
+          units: importedUnits,
+          shoppingUnitId: defaultImportedUnit?.id ?? null,
           nutrition: updatedNutrition,
           source: "usda",
           source_id: result.id,


### PR DESCRIPTION
### Motivation
- Search and detail responses from the USDA API include household/portion units and a preferred/default unit, and importing USDA data should carry that unit metadata through the ingredient form so the UI shows the USDA default label and retains the selected unit after import.

### Description
- Extend the USDA result model by adding `UsdaIngredientUnit` and adding `units: UsdaIngredientUnit[]` plus a stable `defaultUnitKey` to `UsdaIngredientResult` in `useIngredientForm.ts`.
- Parse and normalize USDA unit payloads with `mapUsdaUnits`/`normalizeUsdaUnits` and produce stable keys via `createUsdaUnitKey` / `getDefaultUsdaUnitKey` so units can be deduplicated and identified reliably.
- Update `mapUsdaResult` in `SourceEdit.tsx` to read backend `units` and compute `defaultUnitKey` from the payload, and change `formatNutritionSummary` to show the USDA default unit label (e.g. `1 medium · Calories X · ...`) instead of `Per gram` for search results.
- In `handleSelectResult`, prefer the USDA detail payload’s `units`/`defaultUnitKey` when available and fall back to search-result units if detail lacks unit data.
- In `applyUsdaResult`, replace the ingredient’s units with the required base `g` unit plus normalized USDA gram-backed units, and set `shoppingUnitId` to the USDA default unit so the selected/default unit is retained after import while preserving `source`, `source_id`, and `sourceName`.
- Add/update frontend tests in `SourceEdit.test.tsx` covering search-result default label, selection preferring detail units, disabled non-normalizable items, and that imported units contain `g` plus USDA units and the shopping unit is set to the USDA default.

### Testing
- Ran the focused frontend test `vitest SourceEdit.test.tsx --run`, which passed (3 tests passed). 
- Ran `eslint` against the modified frontend files (`SourceEdit.tsx`, `useIngredientForm.ts`, `SourceEdit.test.tsx`) and it completed without errors on the changed files.
- Ran backend unit tests `pytest Backend/tests/test_usda.py` and they passed (`9 passed`).
- Attempted the full test runner `./scripts/run-tests.sh --full` but it could not complete in this environment due to venv activation/sourcing constraints (not related to the changes above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bde7e130f48322a1158a25dd425d12)