### PR TITLE
Align USDA nutrition precision with ingredient editor

### DIFF
--- a/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/NutritionEdit.tsx
@@ -1,13 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { TextField, Typography } from "@mui/material";
-
-const roundToTwoDecimalPlaces = (value: number): number => {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-
-  return Math.round((value + Number.EPSILON) * 100) / 100;
-};
+import { roundNutritionValue } from "@/utils/nutritionPrecision";
 
 function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) {
   const [multiplier, setMultiplier] = useState(1);
@@ -79,11 +72,11 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
   };
   const getRoundedDisplayNutrition = useCallback(
     (targetMultiplier: number) => ({
-      calories: roundToTwoDecimalPlaces((ingredient?.nutrition?.calories ?? 0) * targetMultiplier),
-      protein: roundToTwoDecimalPlaces((ingredient?.nutrition?.protein ?? 0) * targetMultiplier),
-      carbohydrates: roundToTwoDecimalPlaces((ingredient?.nutrition?.carbohydrates ?? 0) * targetMultiplier),
-      fat: roundToTwoDecimalPlaces((ingredient?.nutrition?.fat ?? 0) * targetMultiplier),
-      fiber: roundToTwoDecimalPlaces((ingredient?.nutrition?.fiber ?? 0) * targetMultiplier),
+      calories: roundNutritionValue((ingredient?.nutrition?.calories ?? 0) * targetMultiplier),
+      protein: roundNutritionValue((ingredient?.nutrition?.protein ?? 0) * targetMultiplier),
+      carbohydrates: roundNutritionValue((ingredient?.nutrition?.carbohydrates ?? 0) * targetMultiplier),
+      fat: roundNutritionValue((ingredient?.nutrition?.fat ?? 0) * targetMultiplier),
+      fiber: roundNutritionValue((ingredient?.nutrition?.fiber ?? 0) * targetMultiplier),
     }),
     [ingredient],
   );
@@ -93,7 +86,7 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
     const normalized = Object.keys(displayNutrition).reduce((acc, key) => {
       const raw = displayNutrition[key];
       const parsed = parseFloat(String(raw).replace(",", "."));
-      const numericValue = Number.isNaN(parsed) ? 0 : roundToTwoDecimalPlaces(parsed);
+      const numericValue = Number.isNaN(parsed) ? 0 : roundNutritionValue(parsed);
       return { ...acc, [key]: numericValue };
     }, {});
 
@@ -250,6 +243,5 @@ function NutritionEdit({ ingredient, dispatch, needsClearForm, needsFillForm }) 
 }
 
 export default NutritionEdit;
-
 
 

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
@@ -133,7 +133,9 @@ describe("SourceEdit", () => {
 
     const bananaRow = await screen.findByRole("button", { name: /banana/i });
     expect(bananaRow).toBeEnabled();
-    expect(await screen.findByText(/1 medium · Calories 0\.89/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/1 medium · Calories 0\.89 · Protein 0\.01 · Carbs 0\.23 · Fat 0/i),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/Per gram/i)).not.toBeInTheDocument();
 
     await userEvent.click(bananaRow);
@@ -207,7 +209,7 @@ describe("SourceEdit", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("retains the USDA default unit in form state and imports gram plus USDA units", () => {
+  it("retains the USDA default unit in form state and imports rounded per-gram USDA nutrition", () => {
     const { result } = renderHook(() => useIngredientForm());
 
     act(() => {
@@ -243,6 +245,13 @@ describe("SourceEdit", () => {
     expect(result.current.ingredient.source).toBe("usda");
     expect(result.current.ingredient.source_id).toBe("333");
     expect(result.current.ingredient.sourceName).toBe("Apple slices");
+    expect(result.current.ingredient.nutrition).toEqual({
+      calories: 0.52,
+      protein: 0,
+      carbohydrates: 0.14,
+      fat: 0,
+      fiber: 0.02,
+    });
     expect(result.current.ingredient.units).toEqual([
       expect.objectContaining({ name: "g", grams: 1 }),
       expect.objectContaining({ name: "1 cup sliced", grams: 109 }),

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 
 import type { IngredientSource, UsdaIngredientResult, UsdaIngredientUnit } from "./useIngredientForm";
+import { formatNutritionValue } from "@/utils/nutritionPrecision";
 
 
 const createUsdaUnitKey = (unit: Pick<UsdaIngredientUnit, "id" | "name" | "grams">): string => {
@@ -174,7 +175,7 @@ const formatNutritionSummary = (result: UsdaIngredientResult): string => {
     return `${reason} Basis: ${result.normalization.source_basis}.`;
   }
 
-  return `${getDefaultUnitLabel(result)} · Calories ${result.nutrition.calories} · Protein ${result.nutrition.protein} · Carbs ${result.nutrition.carbohydrates} · Fat ${result.nutrition.fat}`;
+  return `${getDefaultUnitLabel(result)} · Calories ${formatNutritionValue(result.nutrition.calories)} · Protein ${formatNutritionValue(result.nutrition.protein)} · Carbs ${formatNutritionValue(result.nutrition.carbohydrates)} · Fat ${formatNutritionValue(result.nutrition.fat)}`;
 };
 
 function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {

--- a/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
+++ b/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 
 import { useData } from "@/contexts/DataContext";
 import { useSessionStorageReducer } from "@/hooks/useSessionStorageState";
+import { roundNutritionValue } from "@/utils/nutritionPrecision";
 import { generateUUID, handleFetchRequest } from "@/utils/utils";
 import type { components, operations } from "@/api-types";
 
@@ -334,11 +335,11 @@ export const useIngredientForm = () => {
       }
 
       const updatedNutrition = {
-        calories: result.nutrition.calories ?? 0,
-        protein: result.nutrition.protein ?? 0,
-        carbohydrates: result.nutrition.carbohydrates ?? 0,
-        fat: result.nutrition.fat ?? 0,
-        fiber: result.nutrition.fiber ?? 0,
+        calories: roundNutritionValue(result.nutrition.calories ?? 0),
+        protein: roundNutritionValue(result.nutrition.protein ?? 0),
+        carbohydrates: roundNutritionValue(result.nutrition.carbohydrates ?? 0),
+        fat: roundNutritionValue(result.nutrition.fat ?? 0),
+        fiber: roundNutritionValue(result.nutrition.fiber ?? 0),
       };
 
       const normalizedUsdaUnits = normalizeUsdaUnits(result.units);

--- a/Frontend/src/tests/nutrition.test.ts
+++ b/Frontend/src/tests/nutrition.test.ts
@@ -116,16 +116,16 @@ describe("macrosForIngredientPortion", () => {
     expect(result).toEqual(ZERO_MACROS);
   });
 
-  it("applies USDA per-gram nutrition correctly for a 100 gram portion", () => {
+  it("treats USDA nutrition as rounded per-gram base values for larger portions", () => {
     const ingredient = makeIngredient({
       id: 303,
       name: "Banana USDA",
       nutrition: {
         calories: 0.89,
-        protein: 0.0109,
-        fat: 0.0033,
-        carbohydrates: 0.2284,
-        fiber: 0.026,
+        protein: 0.01,
+        fat: 0,
+        carbohydrates: 0.23,
+        fiber: 0.03,
       } as unknown as IngredientRead["nutrition"],
       units: [
         { id: 31, name: "gram", grams: 1 },
@@ -140,11 +140,41 @@ describe("macrosForIngredientPortion", () => {
 
     expect(result).toEqual({
       calories: 89,
-      protein: 1.09,
-      fat: 0.33,
-      carbs: 22.84,
-      fiber: 2.6,
+      protein: 1,
+      fat: 0,
+      carbs: 23,
+      fiber: 3,
     });
+  });
+
+  it("continues to scale per-gram USDA nutrition through non-gram units", () => {
+    const ingredient = makeIngredient({
+      id: 404,
+      name: "Apple slices USDA",
+      nutrition: {
+        calories: 0.52,
+        protein: 0,
+        fat: 0,
+        carbohydrates: 0.14,
+        fiber: 0.02,
+      } as unknown as IngredientRead["nutrition"],
+      units: [
+        { id: 40, name: "gram", grams: 1 },
+        { id: 41, name: "cup sliced", grams: 109 },
+      ] as unknown as IngredientRead["units"],
+    });
+
+    const result = macrosForIngredientPortion({
+      ingredient,
+      unitId: 41,
+      quantity: 1,
+    });
+
+    expect(result.calories).toBeCloseTo(56.68);
+    expect(result.protein).toBeCloseTo(0);
+    expect(result.fat).toBeCloseTo(0);
+    expect(result.carbs).toBeCloseTo(15.26);
+    expect(result.fiber).toBeCloseTo(2.18);
   });
 
 });

--- a/Frontend/src/utils/nutritionPrecision.ts
+++ b/Frontend/src/utils/nutritionPrecision.ts
@@ -1,0 +1,9 @@
+export const roundNutritionValue = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+};
+
+export const formatNutritionValue = (value: number): string => `${roundNutritionValue(value)}`;


### PR DESCRIPTION
### Motivation
- USDA-derived nutrition values were displayed and stored with inconsistent precision compared to the ingredient editor, causing mismatches between displayed summaries and downstream per-gram calculations.
- The change ensures a single two-decimal rounding rule is used both for display summaries and when importing USDA per-gram nutrition into ingredient state while preserving per-gram scaling semantics.

### Description
- Introduced a shared helper `Frontend/src/utils/nutritionPrecision.ts` that exposes `roundNutritionValue` and `formatNutritionValue` and centralizes the two-decimal rounding logic.
- Updated `NutritionEdit.tsx` to use `roundNutritionValue` for displayed values and when parsing user edits so manual and USDA editing flows use the same precision.
- Updated `SourceEdit.tsx` (`formatNutritionSummary`) to format USDA search-result summaries using `formatNutritionValue` so displayed macros match the ingredient editor precision.
- Updated `useIngredientForm.ts` (`applyUsdaResult`) to round imported USDA per-gram nutrition to the shared precision before dispatching ingredient state while keeping stored values as per-gram base values; unit import/selection behavior is preserved.
- Extended/updated tests in `SourceEdit.test.tsx` and `Frontend/src/tests/nutrition.test.ts` to assert that USDA summaries are shown with rounded precision, imported nutrition is rounded on store, and per-gram scaling still works across gram and non-gram units.

### Testing
- Ran targeted unit tests with `npm --prefix Frontend test -- --run src/components/data/ingredient/form/SourceEdit.test.tsx src/tests/nutrition.test.ts` and observed all tests passed (`2 test files, 14 tests total`), ✅ success.
- Ran frontend lint with `npm --prefix Frontend run lint -- <changed files>` and it completed successfully, ✅ success.
- Attempted repository audit with `bash ./scripts/repo/check.sh` and `bash ./scripts/env/check.sh --fix` as recommended by project guidance, but the repo audit script failed in this environment due to helper-script execution/path issues, ⚠️ not completed (environment-related, unrelated to code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdeb5bf3dc8322afbf5c4107e7ee92)