### PR TITLE
Add Playwright browser e2e suite and integrate into branch‑isolated e2e runner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
 ### Testing and quality gates
 
 - `scripts/run-tests.ps1` / `scripts/run-tests.sh`
-  - Purpose: run backend unit tests, frontend unit tests, optional OpenAPI/migration sync, and optional end-to-end API tests.
+  - Purpose: run backend unit tests, frontend unit tests, optional OpenAPI/migration sync, and optional end-to-end API + browser suites.
   - Flags:
     - PowerShell: `-e2e`, `-sync`, `-full` (equivalent to both flags).
     - Bash: `--e2e`, `--sync`, `--full` (plus `-h|--help`).
@@ -171,9 +171,9 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
     - Always sources `scripts/lib/venv.ps1|.sh` to ensure the virtual environment is active.
 
 - `scripts/tests/run-e2e-tests.ps1` / `scripts/tests/run-e2e-tests.sh`
-  - Purpose: spin up a branch-isolated Docker Compose test stack, wait for the backend to become healthy, then execute `pytest -m e2e` against `Backend/tests/test_e2e_api.py`.
+  - Purpose: spin up a branch-isolated Docker Compose test stack, wait for the backend and frontend to become healthy, then execute both `pytest -m e2e` against `Backend/tests/test_e2e_api.py` and the Playwright browser suite under `Frontend/e2e/`.
   - Flags: accepts additional pytest arguments (pass-through). Both variants honour `-h|--help`.
-  - Call graph: loads helpers from `scripts/lib/venv.*`, `scripts/lib/branch-env.*`, and `scripts/lib/compose-utils.*`; always shells into `scripts/docker/compose.ps1|.sh` (`up ...` to start, `down ...` to tear down).
+  - Call graph: loads helpers from `scripts/lib/venv.*`, `scripts/lib/branch-env.*`, and `scripts/lib/compose-utils.*`; always shells into `scripts/docker/compose.ps1|.sh` (`up ...` to start, `down ...` to tear down), then runs `npm --prefix Frontend run e2e:install` followed by `npm --prefix Frontend run e2e`.
 
 ### Docker stack management
 
@@ -292,18 +292,19 @@ pwsh ./scripts/run-tests.ps1 -full      # sync + unit + e2e
 
 Bash: `./scripts/run-tests.sh` using the same flags (`--sync`, `--e2e`, `--full`).
 
-End-to-end API tests can also be invoked directly:
+End-to-end suites can also be invoked directly:
 
 ```pwsh
 pwsh ./scripts/tests/run-e2e-tests.ps1
 ./scripts/tests/run-e2e-tests.sh
 ```
 
-The e2e runners launch a temporary stack on the `TEST_*` ports and clean up after completion.
+The e2e runners launch a temporary stack on the `TEST_*` ports, run both the API and browser suites against that stack, and clean up after completion.
 
 Additional tooling:
 
 - `npm --prefix Frontend run lint`
+- `npm --prefix Frontend run e2e`
 - `npm --prefix Frontend run build`
 - `npm --prefix Frontend test`
 - `pytest` (when running backend unit tests outside the wrapper)

--- a/Frontend/e2e/nutrition-workflows.spec.ts
+++ b/Frontend/e2e/nutrition-workflows.spec.ts
@@ -1,0 +1,338 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const runId = `${Date.now()}`;
+
+const manualIngredientName = `E2E Manual Ingredient ${runId}`;
+const usdaIngredientName = `E2E USDA Ingredient ${runId}`;
+const foodName = `E2E Food ${runId}`;
+const planName = `E2E Plan ${runId}`;
+
+const USDA_FDC_ID = 424242;
+const USDA_DEFAULT_UNIT_NAME = "medium";
+
+const usdaSearchResponse = {
+  foods: [
+    {
+      id: USDA_FDC_ID,
+      name: usdaIngredientName,
+      nutrition: {
+        calories: 1,
+        protein: 0.2,
+        carbohydrates: 0.3,
+        fat: 0.05,
+        fiber: 0.1,
+      },
+      normalization: {
+        data_type: "Foundation",
+        source_basis: "per_100g",
+        normalized_basis: "per_g",
+        can_normalize: true,
+        reason: null,
+        serving_size: 50,
+        serving_size_unit: "g",
+        household_serving_full_text: USDA_DEFAULT_UNIT_NAME,
+      },
+      units: [
+        { id: null, name: "1 g", grams: 1, is_default: false },
+        { id: "medium", name: USDA_DEFAULT_UNIT_NAME, grams: 50, is_default: true },
+      ],
+    },
+  ],
+};
+
+const usdaDetailResponse = {
+  id: USDA_FDC_ID,
+  name: usdaIngredientName,
+  nutrition: {
+    calories: 1,
+    protein: 0.2,
+    carbohydrates: 0.3,
+    fat: 0.05,
+    fiber: 0.1,
+  },
+  normalization: {
+    data_type: "Foundation",
+    source_basis: "per_100g",
+    normalized_basis: "per_g",
+    can_normalize: true,
+    reason: null,
+    serving_size: 50,
+    serving_size_unit: "g",
+    household_serving_full_text: USDA_DEFAULT_UNIT_NAME,
+  },
+  units: [
+    { id: null, name: "1 g", grams: 1, is_default: false },
+    { id: "medium", name: USDA_DEFAULT_UNIT_NAME, grams: 50, is_default: true },
+  ],
+};
+
+const getDialog = (page: Page): Locator => page.getByRole("dialog").last();
+
+const roundForUi = (value: number): string => {
+  const rounded = Number.parseFloat(value.toPrecision(3));
+  return Number.isInteger(rounded) ? String(rounded) : String(rounded);
+};
+
+async function installUsdaMocks(page: Page): Promise<void> {
+  await page.route("**/api/usda/search?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(usdaSearchResponse),
+    });
+  });
+
+  await page.route(`**/api/usda/foods/${USDA_FDC_ID}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(usdaDetailResponse),
+    });
+  });
+}
+
+async function gotoDataTab(page: Page, tabName: "Foods" | "Ingredients"): Promise<void> {
+  await page.goto("/data");
+  await expect(page.getByRole("tab", { name: tabName })).toBeVisible();
+  await page.getByRole("tab", { name: tabName }).click();
+  await expect(page.getByRole("heading", { name: tabName })).toBeVisible();
+}
+
+async function navigateWithDrawer(page: Page, destination: "Shopping" | "Cooking" | "Logging"): Promise<void> {
+  const openDrawerButton = page.getByRole("button", { name: "open drawer" });
+  if (await openDrawerButton.isVisible()) {
+    await openDrawerButton.click();
+  }
+  await page.getByRole("link", { name: destination }).click();
+  const headingName = destination === "Shopping" ? "Shopping List" : destination;
+  await expect(page.getByRole("heading", { name: headingName })).toBeVisible();
+}
+
+async function chooseOption(trigger: Locator, page: Page, optionName: string): Promise<void> {
+  await trigger.click();
+  await page.getByRole("option", { name: optionName, exact: true }).click();
+}
+
+async function addManualIngredient(page: Page): Promise<void> {
+  await gotoDataTab(page, "Ingredients");
+
+  await page.getByRole("button", { name: /^Add Ingredient$/ }).click();
+  const dialog = getDialog(page);
+
+  await dialog.getByLabel("Name").fill(manualIngredientName);
+  await dialog.getByRole("button", { name: "add ingredient unit" }).click();
+
+  const unitDialog = getDialog(page);
+  await unitDialog.getByLabel("Unit name").fill("cup");
+  await unitDialog.getByLabel("Unit grams").fill("100");
+  await unitDialog.getByRole("button", { name: /^Add$/ }).click();
+
+  await chooseOption(dialog.getByLabel("Preferred shopping unit"), page, "g");
+  await dialog.getByLabel("Calories").fill("2");
+  await dialog.getByLabel("Protein").fill("0.5");
+  await dialog.getByLabel("Carbs").fill("0.25");
+  await dialog.getByLabel("Fat").fill("0.1");
+  await dialog.getByLabel("Fiber").fill("0.05");
+  await chooseOption(dialog.getByLabel("Preferred shopping unit"), page, "cup");
+
+  await dialog.getByRole("button", { name: "add ingredient" }).click();
+  await expect(dialog).toBeHidden();
+
+  const ingredientRow = page.getByRole("row", { name: new RegExp(manualIngredientName) });
+  await expect(ingredientRow).toContainText("cup");
+  await expect(ingredientRow).toContainText("200");
+}
+
+async function addUsdaIngredient(page: Page): Promise<void> {
+  await installUsdaMocks(page);
+  await gotoDataTab(page, "Ingredients");
+
+  await page.getByRole("button", { name: /^Add Ingredient$/ }).click();
+  const dialog = getDialog(page);
+
+  await chooseOption(dialog.getByLabel("Source"), page, "USDA");
+  await dialog.getByLabel("Search USDA").fill("banana");
+  await dialog.getByRole("button", { name: "Search" }).click();
+  await dialog.getByRole("button", { name: new RegExp(usdaIngredientName) }).click();
+
+  await expect(dialog.getByLabel("Name")).toHaveValue(usdaIngredientName);
+  await expect(dialog.getByText(/USDA-sourced nutrition is read-only/i)).toBeVisible();
+
+  await expect(dialog.getByLabel("Preferred shopping unit")).toContainText(USDA_DEFAULT_UNIT_NAME);
+  await chooseOption(dialog.getByLabel("Preferred shopping unit"), page, "g");
+  await expect(dialog.getByLabel("Calories")).toHaveValue("1");
+  await expect(dialog.getByLabel("Protein")).toHaveValue("0.2");
+
+  await chooseOption(dialog.getByLabel("Preferred shopping unit"), page, USDA_DEFAULT_UNIT_NAME);
+  await expect(dialog.getByLabel("Calories")).toHaveValue("50");
+
+  await dialog.getByRole("button", { name: "add ingredient" }).click();
+  await expect(dialog).toBeHidden();
+}
+
+async function searchIngredient(page: Page, ingredientName: string): Promise<Locator> {
+  const search = page.getByLabel("Search by name");
+  await search.fill(ingredientName);
+  const row = page.getByRole("row", { name: new RegExp(ingredientName) });
+  await expect(row).toBeVisible();
+  return row;
+}
+
+async function reopenIngredient(page: Page, ingredientName: string): Promise<Locator> {
+  const row = await searchIngredient(page, ingredientName);
+  await row.getByRole("button", { name: `Edit ingredient ${ingredientName}` }).click();
+  return getDialog(page);
+}
+
+async function addFood(page: Page): Promise<void> {
+  await gotoDataTab(page, "Foods");
+
+  await page.getByRole("button", { name: /^Add Food$/ }).click();
+  const form = page.locator("body");
+
+  await form.getByLabel("Name").fill(foodName);
+  await form.getByLabel("Recipe yields").fill("5");
+  await form.getByRole("button", { name: "Add Ingredients" }).click();
+
+  const ingredientDialog = getDialog(page);
+  await ingredientDialog.getByLabel("Search by name").fill(manualIngredientName);
+  await ingredientDialog.getByRole("button", { name: `Select ingredient ${manualIngredientName}` }).click();
+  await expect(ingredientDialog).toBeHidden();
+
+  await form.getByRole("button", { name: "Add Ingredients" }).click();
+  const secondIngredientDialog = getDialog(page);
+  await secondIngredientDialog.getByLabel("Search by name").fill(usdaIngredientName);
+  await secondIngredientDialog.getByRole("button", { name: `Select ingredient ${usdaIngredientName}` }).click();
+  await expect(secondIngredientDialog).toBeHidden();
+
+  const manualRow = page.getByRole("row", { name: new RegExp(manualIngredientName) });
+  const usdaRow = page.getByRole("row", { name: new RegExp(usdaIngredientName) });
+
+  await manualRow.getByRole("spinbutton").fill("2");
+  await usdaRow.getByRole("spinbutton").fill("3");
+
+  await page.getByRole("button", { name: "add food" }).click();
+  await expect(page.getByLabel("Name")).toHaveValue("");
+}
+
+async function reopenFood(page: Page): Promise<void> {
+  await gotoDataTab(page, "Foods");
+  await page.getByLabel("Search by name").fill(foodName);
+  const row = page.getByRole("row", { name: new RegExp(foodName) });
+  await expect(row).toBeVisible();
+  await row.getByRole("button", { name: `Edit food ${foodName}` }).click();
+}
+
+async function fetchFood(page: Page): Promise<{ ingredients: Array<{ unit_quantity: number }> }> {
+  const response = await page.request.get("/api/foods/");
+  expect(response.ok()).toBeTruthy();
+  const foods = (await response.json()) as Array<{ name: string; ingredients: Array<{ unit_quantity: number }> }>;
+  const food = foods.find((entry) => entry.name === foodName);
+  expect(food).toBeDefined();
+  return food!;
+}
+
+test.describe.configure({ mode: "serial" });
+
+test("creates a manual ingredient with units and a preferred shopping unit", async ({ page }) => {
+  await addManualIngredient(page);
+
+  const dialog = await reopenIngredient(page, manualIngredientName);
+  await expect(dialog.getByLabel("Name")).toHaveValue(manualIngredientName);
+  await expect(dialog.getByLabel("Preferred shopping unit")).toContainText("cup");
+  await expect(dialog.getByLabel("Calories")).toHaveValue("200");
+  await dialog.getByRole("button", { name: "close" }).click();
+});
+
+test("imports a USDA ingredient and reloads the saved default unit and per-gram nutrition", async ({ page }) => {
+  await addUsdaIngredient(page);
+
+  const dialog = await reopenIngredient(page, usdaIngredientName);
+  await expect(dialog.getByLabel("Source")).toContainText("USDA");
+  await expect(dialog.getByLabel("Preferred shopping unit")).toContainText(USDA_DEFAULT_UNIT_NAME);
+
+  await chooseOption(dialog.getByLabel("Preferred shopping unit"), page, "g");
+  await expect(dialog.getByLabel("Calories")).toHaveValue("1");
+  await expect(dialog.getByLabel("Protein")).toHaveValue("0.2");
+});
+
+test("creates a food with recipe yield normalization and reloads persisted ingredient quantities", async ({ page }) => {
+  await addFood(page);
+  await reopenFood(page);
+
+  const manualRow = page.getByRole("row", { name: new RegExp(manualIngredientName) });
+  const usdaRow = page.getByRole("row", { name: new RegExp(usdaIngredientName) });
+
+  await expect(page.getByLabel("Recipe yields")).toHaveValue("1");
+  await expect(manualRow.getByRole("spinbutton")).toHaveValue("0.4");
+  await expect(usdaRow.getByRole("spinbutton")).toHaveValue("0.6");
+
+  const persistedFood = await fetchFood(page);
+  expect(persistedFood.ingredients.map((ingredient) => ingredient.unit_quantity)).toEqual([0.4, 0.6]);
+});
+
+test("plans, shops, cooks, logs, and preserves daily totals after deleting the stored batch", async ({ page }) => {
+  await page.goto("/planning");
+  await expect(page.getByRole("heading", { name: "Planning" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Add Food" }).click();
+  const foodDialog = getDialog(page);
+  await foodDialog.getByLabel("Search by name").fill(foodName);
+  await foodDialog.getByRole("button", { name: `Select food ${foodName}` }).click();
+  await expect(foodDialog).toBeHidden();
+
+  await page.getByRole("button", { name: "Add Ingredient" }).click();
+  const ingredientDialog = getDialog(page);
+  await ingredientDialog.getByLabel("Search by name").fill(manualIngredientName);
+  await ingredientDialog.getByRole("button", { name: `Select ingredient ${manualIngredientName}` }).click();
+  await expect(ingredientDialog).toBeHidden();
+
+  const foodRow = page.getByRole("row", { name: new RegExp(foodName) });
+  const ingredientRow = page.getByRole("row", { name: new RegExp(manualIngredientName) });
+
+  await foodRow.getByRole("spinbutton").fill("1");
+  await ingredientRow.getByLabel("planned portions").fill("2");
+
+  const summary = page.locator("table").filter({ has: page.getByText("Total Overall") }).first();
+  await expect(summary.getByRole("row", { name: /Total Overall/ })).toContainText("510");
+  await expect(summary.getByRole("row", { name: /Per Day/ })).toContainText("510");
+
+  await page.getByRole("button", { name: "Save Plan" }).click();
+  const saveDialog = getDialog(page);
+  await saveDialog.getByLabel("Plan name").fill(planName);
+  await saveDialog.getByRole("button", { name: "Save as New" }).click();
+  await expect(saveDialog).toBeHidden();
+  await expect(page.getByText(`Saved plan "${planName}"`)).toBeVisible();
+
+  await navigateWithDrawer(page, "Shopping");
+  const shoppingManualRow = page.getByRole("row", { name: new RegExp(manualIngredientName) });
+  const shoppingUsdaRow = page.getByRole("row", { name: new RegExp(usdaIngredientName) });
+
+  await expect(shoppingManualRow).toContainText("cup");
+  await expect(shoppingManualRow).toContainText(roundForUi(2.4));
+  await expect(shoppingUsdaRow).toContainText(USDA_DEFAULT_UNIT_NAME);
+  await expect(shoppingUsdaRow).toContainText("0.6");
+
+  await navigateWithDrawer(page, "Cooking");
+  await page.getByRole("button", { name: `Mark ${foodName} complete` }).click();
+
+  await navigateWithDrawer(page, "Logging");
+  const fridgeRow = page.getByRole("row", { name: new RegExp(foodName) });
+  await expect(fridgeRow).toContainText("1");
+
+  await fridgeRow.getByLabel(`Portions to log for ${foodName}`).fill("0.5");
+  await fridgeRow.getByRole("button", { name: `Add ${foodName} to log` }).click();
+
+  await expect(fridgeRow).toContainText("0.5");
+  const dailyTotal = page.getByRole("group", { name: /Daily Total/i });
+  await expect(dailyTotal.getByLabel("Total calories")).toHaveText("55");
+  await expect(dailyTotal.getByLabel("Total protein")).toHaveText("13");
+  await expect(dailyTotal.getByLabel("Total carbs")).toHaveText("9.5");
+  await expect(dailyTotal.getByLabel("Total fat")).toHaveText("2.75");
+  await expect(dailyTotal.getByLabel("Total fiber")).toHaveText("2.5");
+
+  await fridgeRow.getByRole("button", { name: `Remove stored item ${foodName}` }).click();
+  await expect(page.getByRole("row", { name: new RegExp(foodName) })).toHaveCount(1);
+  await expect(dailyTotal.getByLabel("Total calories")).toHaveText("55");
+  await expect(page.getByRole("row", { name: new RegExp(`${foodName}.*55`) })).toBeVisible();
+});

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -27,6 +27,7 @@
         "vite": "^7.1.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@typescript-eslint/eslint-plugin": "^8.9.0",
         "@typescript-eslint/parser": "^8.9.0",
         "@vitest/ui": "^3.2.4",
@@ -1614,6 +1615,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -6124,6 +6141,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -26,6 +26,8 @@
     "start": "vite --host 0.0.0.0 --port 3000",
     "build": "vite build",
     "preview": "vite preview",
+    "e2e": "playwright test",
+    "e2e:install": "playwright install chromium",
     "test": "vitest",
     "lint": "eslint . --ext js,jsx,ts,tsx"
   },
@@ -85,6 +87,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@typescript-eslint/eslint-plugin": "^8.9.0",
     "@typescript-eslint/parser": "^8.9.0",
     "@vitest/ui": "^3.2.4",

--- a/Frontend/playwright.config.ts
+++ b/Frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const frontendPort = Number.parseInt(process.env.DEV_FRONTEND_PORT ?? process.env.TEST_FRONTEND_PORT ?? "3000", 10);
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 120_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  reporter: [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${frontendPort}`,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+});

--- a/Frontend/src/components/cooking/Cooking.tsx
+++ b/Frontend/src/components/cooking/Cooking.tsx
@@ -1292,6 +1292,7 @@ function Cooking() {
                                 <Button
                                   variant="contained"
                                   size="small"
+                                  aria-label={`Mark ${food?.name ?? "food"} complete`}
                                   onClick={() => markItemComplete(item, index)}
                                   disabled={foodCompletionDisabled}
                                 >
@@ -1889,6 +1890,7 @@ function Cooking() {
                         <Button
                             variant="contained"
                             size="small"
+                            aria-label={`Mark ${ingredient?.name ?? "ingredient"} complete`}
                             onClick={() => markItemComplete(item, index)}
                             disabled={
                               !ingredient ||

--- a/Frontend/src/components/data/food/FoodTable.tsx
+++ b/Frontend/src/components/data/food/FoodTable.tsx
@@ -266,6 +266,7 @@ function FoodTable({ onFoodDoubleClick, onFoodCtrlClick }: FoodTableProps) {
                           <Button
                             variant="outlined"
                             size="small"
+                            aria-label={`Edit food ${food.name}`}
                             onClick={(event) => handleFoodEdit(event, food)}
                           >
                             Edit
@@ -275,6 +276,7 @@ function FoodTable({ onFoodDoubleClick, onFoodCtrlClick }: FoodTableProps) {
                           <Button
                             variant="contained"
                             size="small"
+                            aria-label={`Select food ${food.name}`}
                             onClick={(event) => handleFoodSelect(event, food)}
                           >
                             Select
@@ -399,7 +401,6 @@ function FoodTable({ onFoodDoubleClick, onFoodCtrlClick }: FoodTableProps) {
   );
 }
 export default FoodTable;
-
 
 
 

--- a/Frontend/src/components/data/food/form/FoodForm.tsx
+++ b/Frontend/src/components/data/food/form/FoodForm.tsx
@@ -231,9 +231,9 @@ function FoodForm({ foodToEditData }) {
             />
           </>
 
-          <Button onClick={handleClearForm}>Clear</Button>
-          <Button onClick={handleFoodAction}>{isEditMode ? "Update" : "Add"}</Button>
-          {isEditMode && <Button onClick={() => dispatch({ type: "SET_CONFIRMATION_DIALOG", payload: true })}>Delete</Button>}
+          <Button aria-label="clear food form" onClick={handleClearForm}>Clear</Button>
+          <Button aria-label={isEditMode ? "update food" : "add food"} onClick={handleFoodAction}>{isEditMode ? "Update" : "Add"}</Button>
+          {isEditMode && <Button aria-label="delete food" onClick={() => dispatch({ type: "SET_CONFIRMATION_DIALOG", payload: true })}>Delete</Button>}
         </Collapse>
       </Paper>
 
@@ -254,4 +254,3 @@ function FoodForm({ foodToEditData }) {
 }
 
 export default FoodForm;
-

--- a/Frontend/src/components/data/ingredient/IngredientTable.tsx
+++ b/Frontend/src/components/data/ingredient/IngredientTable.tsx
@@ -297,6 +297,7 @@ function IngredientTable({
                         <Button
                           variant="outlined"
                           size="small"
+                          aria-label={`Edit ingredient ${ingredient.name}`}
                           onClick={(event) => handleIngredientEdit(event, ingredient)}
                         >
                           Edit
@@ -306,6 +307,7 @@ function IngredientTable({
                         <Button
                           variant="contained"
                           size="small"
+                          aria-label={`Select ingredient ${ingredient.name}`}
                           onClick={(event) => handleIngredientSelect(event, ingredient)}
                         >
                           Select

--- a/Frontend/src/components/data/ingredient/form/IngredientEditor.tsx
+++ b/Frontend/src/components/data/ingredient/form/IngredientEditor.tsx
@@ -74,12 +74,12 @@ function IngredientEditor({ mode, initial = null, onSaved, onDeleted }: Ingredie
 
       <Divider sx={{ my: 1 }} />
       <Box sx={{ display: "flex", gap: 1 }}>
-        <Button onClick={clearForm}>Clear</Button>
-        <Button variant="contained" onClick={handleSave}>
+        <Button aria-label="clear ingredient form" onClick={clearForm}>Clear</Button>
+        <Button aria-label={mode === "edit" ? "update ingredient" : "add ingredient"} variant="contained" onClick={handleSave}>
           {mode === "edit" ? "Update" : "Add"}
         </Button>
         {mode === "edit" && (
-          <Button color="error" onClick={handleDelete}>
+          <Button aria-label="delete ingredient" color="error" onClick={handleDelete}>
             Delete
           </Button>
         )}

--- a/Frontend/src/components/data/ingredient/form/UnitEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/UnitEdit.tsx
@@ -397,6 +397,8 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }: UnitEditProps) {
         <Select
           labelId="unit-select-label"
           id="unit-select"
+          inputProps={{ "aria-label": "Preferred shopping unit" }}
+          SelectDisplayProps={{ "aria-label": "Preferred shopping unit" }}
           value={
             ingredient.shoppingUnitId == null
               ? NULL_UNIT_VALUE
@@ -417,6 +419,7 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }: UnitEditProps) {
         </Select>
         <Box sx={{ display: "flex", gap: 1, justifyContent: "flex-start" }}>
           <Button
+            aria-label="add ingredient unit"
             variant="outlined"
             onClick={() => {
               setDialogMode("add");
@@ -426,6 +429,7 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }: UnitEditProps) {
             Add
           </Button>
           <Button
+            aria-label="edit ingredient unit"
             variant="outlined"
             onClick={() => {
               if (!selectedUnit) return;
@@ -436,7 +440,7 @@ function UnitEdit({ ingredient, dispatch, needsClearForm }: UnitEditProps) {
           >
             Edit
           </Button>
-          <Button variant="outlined" color="error" onClick={handleRemoveUnit} disabled={!selectedUnit}>
+          <Button aria-label="remove ingredient unit" variant="outlined" color="error" onClick={handleRemoveUnit} disabled={!selectedUnit}>
             Remove
           </Button>
         </Box>

--- a/Frontend/src/components/logging/Logging.tsx
+++ b/Frontend/src/components/logging/Logging.tsx
@@ -1317,6 +1317,7 @@ function Logging() {
                                     <Button
                                       variant="contained"
                                       size="small"
+                                      aria-label={`Add ${displayName} to log`}
                                       onClick={() => handleLogItem(item)}
                                       disabled={
                                         isDepleted ||
@@ -1330,6 +1331,7 @@ function Logging() {
                                       variant="outlined"
                                       size="small"
                                       color="error"
+                                      aria-label={`Remove stored item ${displayName}`}
                                       onClick={() => handleRemoveStoredItem(item)}
                                       disabled={
                                         removingStoredId === item.id || pendingId === item.id

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 - `pwsh ./scripts/switch-worktree-branch.ps1`: fetch remote refs, sync local tracking branches, and create or hop between branch-dedicated worktrees (`-CopyEnv` can copy the current `.env` into the target).
 - `pwsh ./scripts/env/check.ps1 -Fix`: ensure you are inside the correct worktree with an activated virtualenv (Bash variant available).
 - `pwsh ./scripts/docker/compose.ps1 <up|down|restart>`: manage the per-branch Docker stack.
-- `pwsh ./scripts/run-tests.ps1 [-sync] [-e2e]`: run backend + frontend tests with optional API/migration sync. Bash variant: `./scripts/run-tests.sh`.
+- `pwsh ./scripts/run-tests.ps1 [-sync] [-e2e]`: run backend + frontend tests with optional API/migration sync and branch-isolated API/browser e2e suites. Bash variant: `./scripts/run-tests.sh`.
 - `pwsh ./scripts/db/backup.ps1` / `restore.ps1`: create or restore branch-local Postgres backups. Bash variants available in the same directory.
 - `pwsh ./scripts/db/export-to-csv.ps1` / `./scripts/db/export-to-csv.sh`: export the current database tables to CSV (production by default, `--test` or `--output-dir` available).
 

--- a/scripts/env/activate-venv.sh
+++ b/scripts/env/activate-venv.sh
@@ -16,7 +16,7 @@ if [ ! -d "$VENV_PATH" ]; then
 fi
 
 # Activate the virtual environment unless we're already inside it.
-if [ "$VIRTUAL_ENV" != "$VENV_PATH" ]; then
+if [ "${VIRTUAL_ENV:-}" != "$VENV_PATH" ]; then
     echo "Activating Python virtual environment at: $VENV_PATH"
     # shellcheck disable=SC1090
     source "$VENV_PATH/bin/activate"

--- a/scripts/tests/run-e2e-tests.ps1
+++ b/scripts/tests/run-e2e-tests.ps1
@@ -1,5 +1,5 @@
-# Runs end-to-end API tests. If the branch-specific stack is not up/healthy,
-# spins it up in -test mode and waits for the backend to be reachable.
+# Runs branch-isolated end-to-end suites. Spins up the dedicated -test stack,
+# waits for backend and frontend health, then executes API and browser e2e suites.
 [CmdletBinding()]
 param(
   # Additional arguments passed to pytest
@@ -15,12 +15,12 @@ function Show-Usage {
   Write-Host "  pwsh ./scripts/tests/run-e2e-tests.ps1  [pytest-args...]"
   Write-Host ""
   Write-Host "Behavior:" -ForegroundColor Yellow
-  Write-Host "  - Uses docker compose to determine the backend port for the current branch"
-  Write-Host "  - If the backend is unreachable, starts a dedicated test stack via"
+  Write-Host "  - Starts a dedicated test stack via"
   Write-Host "    ./scripts/docker/compose.ps1 up type -test data -test"
   Write-Host "    and reads port information from the generated env file"
-  Write-Host "  - Waits for the backend to become healthy"
-  Write-Host "  - Runs: pytest -vv -rP -s -m e2e Backend/tests/test_e2e_api.py [pytest-args]"
+  Write-Host "  - Waits for both backend and frontend to become healthy"
+  Write-Host "  - Runs the backend API pytest e2e suite and the browser-driven Playwright suite"
+  Write-Host "  - Additional arguments are passed through to pytest"
   Write-Host ""
   Write-Host "Examples:" -ForegroundColor Yellow
   Write-Host "  pwsh ./scripts/tests/run-e2e-tests.ps1 -q"
@@ -52,6 +52,17 @@ function Test-BackendHealthy([int]$Port) {
   }
 }
 
+function Test-FrontendHealthy([int]$Port) {
+  try {
+    $uri = "http://localhost:$Port/"
+    $resp = Invoke-WebRequest -Uri $uri -Method GET -TimeoutSec 2 -MaximumRedirection 2 -ErrorAction Stop
+    return $true
+  }
+  catch {
+    return $false
+  }
+}
+
 # Determine a dedicated TEST compose project for this branch
 . "$PSScriptRoot/../lib/compose-utils.ps1"
 $testProject = Get-TestProject
@@ -59,6 +70,14 @@ $testProject = Get-TestProject
 function Get-BackendPort($proj) {
   try {
     $res = docker compose -p $proj port backend 8000 2>$null
+    if ($LASTEXITCODE -eq 0 -and $res) { return ($res -split ':')[-1] }
+  } catch { }
+  return $null
+}
+
+function Get-FrontendPort($proj) {
+  try {
+    $res = docker compose -p $proj port frontend 3000 2>$null
     if ($LASTEXITCODE -eq 0 -and $res) { return ($res -split ':')[-1] }
   } catch { }
   return $null
@@ -82,7 +101,10 @@ try {
   # Ask docker for the published backend port for this test project
   $backendPort = Get-BackendPort $testProject
   if (-not $backendPort) { $backendPort = $env:TEST_BACKEND_PORT }
+  $frontendPort = Get-FrontendPort $testProject
+  if (-not $frontendPort) { $frontendPort = $env:TEST_FRONTEND_PORT }
   $env:DEV_BACKEND_PORT = $backendPort
+  $env:DEV_FRONTEND_PORT = $frontendPort
 
   Write-Host "Checking backend health on port $backendPort..."
   $deadline = (Get-Date).AddSeconds(120)
@@ -94,11 +116,37 @@ try {
     Start-Sleep -Seconds 1
   }
 
-  Write-Host "Running e2e tests against http://localhost:$backendPort/api"
+  Write-Host "Checking frontend health on port $frontendPort..."
+  $deadline = (Get-Date).AddSeconds(180)
+  while (-not (Test-FrontendHealthy -Port $frontendPort)) {
+    if ((Get-Date) -ge $deadline) {
+      Write-Error "Frontend did not become healthy on port $frontendPort within timeout."
+      exit 1
+    }
+    Start-Sleep -Seconds 1
+  }
+
+  Write-Host "Installing Playwright browser runtime..."
+  & npm --prefix Frontend run e2e:install | Out-Null
+  if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  Write-Host "Running API e2e tests against http://localhost:$backendPort/api"
   & pytest -vv -rP -s -m e2e Backend/tests/test_e2e_api.py @PytestArgs
-  $exit = $LASTEXITCODE
+  $apiExit = $LASTEXITCODE
+
+  Write-Host "Running browser e2e tests against http://localhost:$frontendPort"
+  $env:PLAYWRIGHT_BASE_URL = "http://localhost:$frontendPort"
+  & npm --prefix Frontend run e2e
+  $uiExit = $LASTEXITCODE
+
+  if ($apiExit -ne 0) {
+    $exit = $apiExit
+  } else {
+    $exit = $uiExit
+  }
 } finally {
   # Tear down the dedicated TEST stack regardless of test outcome
   & "$PSScriptRoot/../docker/compose.ps1" down type -test
+  Remove-Item env:PLAYWRIGHT_BASE_URL -ErrorAction SilentlyContinue
 }
 exit $exit

--- a/scripts/tests/run-e2e-tests.sh
+++ b/scripts/tests/run-e2e-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run end-to-end API tests by standing up a dedicated TEST stack
+# Run branch-isolated end-to-end suites by standing up a dedicated TEST stack
 # with branch-specific TEST ports and tearing it down afterwards.
 
 set -euo pipefail
@@ -9,12 +9,13 @@ show_usage() {
 Usage: ./scripts/tests/run-e2e-tests.sh [pytest-args...]
 
 Behavior:
-  - Uses docker compose to determine the backend port for the current branch
-  - If the backend is unreachable, starts a dedicated test stack via
+  - Starts a dedicated test stack via
     ./scripts/docker/compose.sh up type -test data -test
-    and reads port information from the generated env file
-  - Waits for the backend to become healthy
-  - Runs: pytest -vv -rP -s -m e2e Backend/tests/test_e2e_api.py [pytest-args]
+    and reads branch-specific TEST ports from the generated env file
+  - Waits for both backend and frontend to become healthy
+  - Runs the backend API e2e pytest suite, then the browser-driven Playwright suite
+    against the branch-isolated frontend
+  - Additional CLI args are passed through to pytest
 
 Examples:
   ./scripts/tests/run-e2e-tests.sh -q
@@ -45,6 +46,11 @@ is_backend_healthy() {
   curl -fsS --max-time 1 "http://localhost:${port}/api/ingredients" >/dev/null 2>&1
 }
 
+is_frontend_healthy() {
+  local port="$1"
+  curl -fsS --max-time 2 "http://localhost:${port}/" >/dev/null 2>&1
+}
+
 # Determine dedicated TEST compose project for this branch
 TEST_PROJECT="$(compose_test_project)"
 
@@ -58,6 +64,7 @@ source "$ENV_FILE"
 
 # Ask docker for the published backend port for the test project
 DEV_BACKEND_PORT=$(docker compose -p "$TEST_PROJECT" port backend 8000 2>/dev/null | awk -F: '{print $2}' || echo "$TEST_BACKEND_PORT")
+DEV_FRONTEND_PORT=$(docker compose -p "$TEST_PROJECT" port frontend 3000 2>/dev/null | awk -F: '{print $2}' || echo "$TEST_FRONTEND_PORT")
 
 # Wait for backend to become healthy (up to 120s)
 echo "Checking backend health on port ${DEV_BACKEND_PORT}..."
@@ -71,12 +78,37 @@ until is_backend_healthy "$DEV_BACKEND_PORT"; do
   sleep 1
 done
 
-echo "Running e2e tests against http://localhost:${DEV_BACKEND_PORT}/api"
+echo "Checking frontend health on port ${DEV_FRONTEND_PORT}..."
+deadline=$((SECONDS + 180))
+until is_frontend_healthy "$DEV_FRONTEND_PORT"; do
+  if (( SECONDS >= deadline )); then
+    echo "Frontend did not become healthy on port ${DEV_FRONTEND_PORT} within timeout." >&2
+    ./scripts/docker/compose.sh down type -test || true
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Installing Playwright browser runtime..."
+npm --prefix Frontend run e2e:install >/dev/null
+
+echo "Running API e2e tests against http://localhost:${DEV_BACKEND_PORT}/api"
 set +e
 DEV_BACKEND_PORT="$DEV_BACKEND_PORT" pytest -vv -rP -s -m e2e Backend/tests/test_e2e_api.py "$@"
-test_exit=$?
+api_exit=$?
+echo "Running browser e2e tests against http://localhost:${DEV_FRONTEND_PORT}"
+PLAYWRIGHT_BASE_URL="http://localhost:${DEV_FRONTEND_PORT}" \
+DEV_BACKEND_PORT="$DEV_BACKEND_PORT" \
+DEV_FRONTEND_PORT="$DEV_FRONTEND_PORT" \
+npm --prefix Frontend run e2e
+ui_exit=$?
 set -e
 
 # Tear down the dedicated TEST stack
 ./scripts/docker/compose.sh down type -test
-exit $test_exit
+
+if [[ $api_exit -ne 0 ]]; then
+  exit $api_exit
+fi
+
+exit $ui_exit


### PR DESCRIPTION
### Motivation
- Provide a browser-driven end-to-end verification of core user flows (ingredient creation/import, food recipe normalization, planning→shopping, cooking→logging, and preserved daily totals) that runs against the branch‑isolated Docker test stack used by the API e2e runner. 
- Reuse existing branch-aware helpers so QA can run API and UI e2e suites against an isolated per‑branch environment rather than a separate ad-hoc bootstrap.

### Description
- Added a Playwright test harness and tests: `Frontend/e2e/nutrition-workflows.spec.ts` and `Frontend/playwright.config.ts`, plus `Frontend/package.json` scripts `e2e` and `e2e:install` and `@playwright/test` dev dependency. 
- Implemented the browser scenarios to cover manual ingredient creation (units & preferred shopping unit), USDA import with unit/nutrition mapping, food creation with recipe yield normalization, plan building and shopping-list verification, cooking/storing a batch and logging consumption, and deleting stored batches while preserving daily log totals. 
- Hooked the browser suite into the branch-isolated e2e runners by extending `scripts/tests/run-e2e-tests.sh` and `scripts/tests/run-e2e-tests.ps1` to wait for frontend health, install Playwright browsers, run the existing backend API pytest e2e suite, then run the Playwright UI suite against the same TEST compose project. 
- Added small accessibility/stability anchors (ARIA labels / explicit Select display props) and button labels used by the tests across ingredient/food editors, unit controls, table action buttons, cooking completion and logging actions. 
- Updated contributor docs (`CONTRIBUTING.md`, `README.md`) to describe the expanded API+browser e2e flow and fixed a venv activation edge-case (`scripts/env/activate-venv.sh`) used by the runners.

### Testing
- Ran frontend static checks: `npm --prefix Frontend run lint` — succeeded. 
- Verified Playwright discovery: `npx playwright test --list` — listed the new Playwright tests successfully. 
- Performed `npm install` in `Frontend` to ensure Playwright deps were available — succeeded (packages added). 
- Attempted the integrated branch-isolated run `./scripts/tests/run-e2e-tests.sh` / PowerShell variant from a worktree, which advanced through venv setup and attempted to start the dedicated TEST compose project, but the environment where the run was attempted does not provide Docker, so the runner could not start containers and the full API+UI run could not complete (observed `docker: command not found` / service startup failure). 
- The implementation and wiring are committed; in an environment with Docker available the runner will start the TEST stack, wait for backend and frontend health, run API e2e pytest, then run the Playwright browser suite against the branch-isolated frontend.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bded43e14883229861de2b1ad031ba)