### PR TITLE
Add USDA data-type filters to SourceEdit and forward selection to API

### DIFF
--- a/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
@@ -1,14 +1,14 @@
-import React from "react";
-import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from 'react';
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useData } from "@/contexts/DataContext";
+import { useData } from '@/contexts/DataContext';
 
-import SourceEdit from "./SourceEdit";
-import { useIngredientForm } from "./useIngredientForm";
+import SourceEdit from './SourceEdit';
+import { useIngredientForm } from './useIngredientForm';
 
-vi.mock("@/contexts/DataContext", () => ({
+vi.mock('@/contexts/DataContext', () => ({
   useData: vi.fn(),
 }));
 
@@ -16,16 +16,16 @@ const mockedUseData = vi.mocked(useData);
 
 const baseIngredient = {
   id: 1,
-  name: "Test Ingredient",
+  name: 'Test Ingredient',
   units: [
     {
-      id: "unit-1",
+      id: 'unit-1',
       ingredient_id: 1,
-      name: "g",
-      grams: "1",
+      name: 'g',
+      grams: '1',
     },
   ],
-  shoppingUnitId: "unit-1",
+  shoppingUnitId: 'unit-1',
   nutrition: {
     calories: 0,
     protein: 0,
@@ -34,7 +34,7 @@ const baseIngredient = {
     fiber: 0,
   },
   tags: [],
-  source: "usda",
+  source: 'usda',
   source_id: null,
   sourceName: null,
 };
@@ -53,16 +53,58 @@ afterEach(() => {
   window.sessionStorage.clear();
 });
 
-describe("SourceEdit", () => {
-  it("shows the USDA default unit in search results and prefers detail units on selection", async () => {
-    const fetchMock = vi.fn()
+describe('SourceEdit', () => {
+  it('defaults USDA searches to Foundation and forwards selected USDA data types', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ foods: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <SourceEdit
+        ingredient={baseIngredient as never}
+        dispatch={vi.fn()}
+        applyUsdaResult={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /foundation \(primary \/ most current usda data\)/i }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      screen.getByText(
+        /foundation is the default because it is the usda primary \/ most current data set/i,
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/search usda/i), 'banana');
+    await userEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/usda/search?query=banana&data_types=Foundation',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /branded/i }));
+    await userEvent.click(screen.getByRole('button', { name: /experimental/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/usda/search?query=banana&data_types=Foundation&data_types=Branded&data_types=Experimental',
+    );
+    expect(screen.getByLabelText(/search usda/i)).toHaveValue('banana');
+  });
+
+  it('shows the USDA default unit in search results and prefers detail units on selection', async () => {
+    const fetchMock = vi
+      .fn()
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           foods: [
             {
               id: 123,
-              name: "Banana",
+              name: 'Banana',
               nutrition: {
                 calories: 0.89,
                 protein: 0.0109,
@@ -72,17 +114,17 @@ describe("SourceEdit", () => {
               },
               normalization: {
                 can_normalize: true,
-                source_basis: "per_100g",
-                normalized_basis: "per_g",
+                source_basis: 'per_100g',
+                normalized_basis: 'per_g',
                 reason: null,
-                data_type: "Foundation",
+                data_type: 'Foundation',
                 serving_size: null,
                 serving_size_unit: null,
                 household_serving_full_text: null,
               },
               units: [
-                { name: "1 g", grams: 1, is_default: false },
-                { name: "1 medium", grams: 118, is_default: true },
+                { name: '1 g', grams: 1, is_default: false },
+                { name: '1 medium', grams: 118, is_default: true },
               ],
             },
           ],
@@ -92,7 +134,7 @@ describe("SourceEdit", () => {
         ok: true,
         json: async () => ({
           id: 123,
-          name: "Banana",
+          name: 'Banana',
           nutrition: {
             calories: 0.89,
             protein: 0.0109,
@@ -102,22 +144,22 @@ describe("SourceEdit", () => {
           },
           normalization: {
             can_normalize: true,
-            source_basis: "per_100g",
-            normalized_basis: "per_g",
+            source_basis: 'per_100g',
+            normalized_basis: 'per_g',
             reason: null,
-            data_type: "Foundation",
+            data_type: 'Foundation',
             serving_size: null,
             serving_size_unit: null,
             household_serving_full_text: null,
           },
           units: [
-            { name: "1 g", grams: 1, is_default: false },
-            { name: "1 large", grams: 136, is_default: true },
-            { name: "1 cup sliced", grams: 150, is_default: false },
+            { name: '1 g', grams: 1, is_default: false },
+            { name: '1 large', grams: 136, is_default: true },
+            { name: '1 cup sliced', grams: 150, is_default: false },
           ],
         }),
       });
-    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal('fetch', fetchMock);
 
     const applyUsdaResult = vi.fn();
     render(
@@ -128,10 +170,10 @@ describe("SourceEdit", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText(/search usda/i), "banana");
-    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+    await userEvent.type(screen.getByLabelText(/search usda/i), 'banana');
+    await userEvent.click(screen.getByRole('button', { name: /search/i }));
 
-    const bananaRow = await screen.findByRole("button", { name: /banana/i });
+    const bananaRow = await screen.findByRole('button', { name: /banana/i });
     expect(bananaRow).toBeEnabled();
     expect(
       await screen.findByText(/1 medium · Calories 0\.89 · Protein 0\.01 · Carbs 0\.23 · Fat 0/i),
@@ -143,52 +185,53 @@ describe("SourceEdit", () => {
     await waitFor(() => {
       expect(applyUsdaResult).toHaveBeenCalledWith(
         expect.objectContaining({
-          id: "123",
-          name: "Banana",
+          id: '123',
+          name: 'Banana',
           units: [
-            expect.objectContaining({ name: "1 g", grams: 1, is_default: false }),
-            expect.objectContaining({ name: "1 large", grams: 136, is_default: true }),
-            expect.objectContaining({ name: "1 cup sliced", grams: 150, is_default: false }),
+            expect.objectContaining({ name: '1 g', grams: 1, is_default: false }),
+            expect.objectContaining({ name: '1 large', grams: 136, is_default: true }),
+            expect.objectContaining({ name: '1 cup sliced', grams: 150, is_default: false }),
           ],
-          defaultUnitKey: "name:1 large|grams:136",
+          defaultUnitKey: 'name:1 large|grams:136',
           nutrition: expect.objectContaining({
             calories: 0.89,
             protein: 0.0109,
           }),
           normalization: expect.objectContaining({
             can_normalize: true,
-            source_basis: "per_100g",
+            source_basis: 'per_100g',
           }),
         }),
       );
     });
   });
 
-  it("disables USDA results that cannot be normalized to per-gram nutrition", async () => {
+  it('disables USDA results that cannot be normalized to per-gram nutrition', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({
         foods: [
           {
             id: 456,
-            name: "Orange juice",
+            name: 'Orange juice',
             nutrition: null,
             normalization: {
               can_normalize: false,
-              source_basis: "per_100ml",
+              source_basis: 'per_100ml',
               normalized_basis: null,
-              reason: "USDA branded nutrients are standardized to 100 mL for this item, so they cannot be converted to per-gram values without density data.",
-              data_type: "Branded",
+              reason:
+                'USDA branded nutrients are standardized to 100 mL for this item, so they cannot be converted to per-gram values without density data.',
+              data_type: 'Branded',
               serving_size: 240,
-              serving_size_unit: "ml",
-              household_serving_full_text: "8 fl oz",
+              serving_size_unit: 'ml',
+              household_serving_full_text: '8 fl oz',
             },
-            units: [{ name: "1 g", grams: 1, is_default: true }],
+            units: [{ name: '1 g', grams: 1, is_default: true }],
           },
         ],
       }),
     });
-    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal('fetch', fetchMock);
 
     const applyUsdaResult = vi.fn();
     render(
@@ -199,23 +242,25 @@ describe("SourceEdit", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText(/search usda/i), "juice");
-    await userEvent.click(screen.getByRole("button", { name: /search/i }));
+    await userEvent.type(screen.getByLabelText(/search usda/i), 'juice');
+    await userEvent.click(screen.getByRole('button', { name: /search/i }));
 
-    const resultButton = await screen.findByRole("button", { name: /orange juice/i });
-    expect(resultButton).toHaveAttribute("aria-disabled", "true");
-    expect(await screen.findByText(/cannot be converted to per-gram values without density data/i)).toBeInTheDocument();
+    const resultButton = await screen.findByRole('button', { name: /orange juice/i });
+    expect(resultButton).toHaveAttribute('aria-disabled', 'true');
+    expect(
+      await screen.findByText(/cannot be converted to per-gram values without density data/i),
+    ).toBeInTheDocument();
     expect(applyUsdaResult).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("retains the USDA default unit in form state and imports rounded per-gram USDA nutrition", () => {
+  it('retains the USDA default unit in form state and imports rounded per-gram USDA nutrition', () => {
     const { result } = renderHook(() => useIngredientForm());
 
     act(() => {
       result.current.applyUsdaResult({
-        id: "333",
-        name: "Apple slices",
+        id: '333',
+        name: 'Apple slices',
         nutrition: {
           calories: 0.52,
           protein: 0.0003,
@@ -224,27 +269,27 @@ describe("SourceEdit", () => {
           fiber: 0.024,
         },
         normalization: {
-          source_basis: "per_100g",
-          normalized_basis: "per_g",
+          source_basis: 'per_100g',
+          normalized_basis: 'per_g',
           can_normalize: true,
           reason: null,
-          data_type: "Foundation",
+          data_type: 'Foundation',
           serving_size: null,
           serving_size_unit: null,
           household_serving_full_text: null,
         },
         units: [
-          { name: "1 g", grams: 1, is_default: false },
-          { name: "1 cup sliced", grams: 109, is_default: true },
-          { name: "1 tbsp", grams: 8.5, is_default: false },
+          { name: '1 g', grams: 1, is_default: false },
+          { name: '1 cup sliced', grams: 109, is_default: true },
+          { name: '1 tbsp', grams: 8.5, is_default: false },
         ],
-        defaultUnitKey: "name:1 cup sliced|grams:109",
+        defaultUnitKey: 'name:1 cup sliced|grams:109',
       });
     });
 
-    expect(result.current.ingredient.source).toBe("usda");
-    expect(result.current.ingredient.source_id).toBe("333");
-    expect(result.current.ingredient.sourceName).toBe("Apple slices");
+    expect(result.current.ingredient.source).toBe('usda');
+    expect(result.current.ingredient.source_id).toBe('333');
+    expect(result.current.ingredient.sourceName).toBe('Apple slices');
     expect(result.current.ingredient.nutrition).toEqual({
       calories: 0.52,
       protein: 0,
@@ -253,14 +298,14 @@ describe("SourceEdit", () => {
       fiber: 0.02,
     });
     expect(result.current.ingredient.units).toEqual([
-      expect.objectContaining({ name: "g", grams: 1 }),
-      expect.objectContaining({ name: "1 cup sliced", grams: 109 }),
-      expect.objectContaining({ name: "1 tbsp", grams: 8.5 }),
+      expect.objectContaining({ name: 'g', grams: 1 }),
+      expect.objectContaining({ name: '1 cup sliced', grams: 109 }),
+      expect.objectContaining({ name: '1 tbsp', grams: 8.5 }),
     ]);
 
     const selectedUnit = result.current.ingredient.units.find(
       (unit) => String(unit.id) === String(result.current.ingredient.shoppingUnitId),
     );
-    expect(selectedUnit).toEqual(expect.objectContaining({ name: "1 cup sliced", grams: 109 }));
+    expect(selectedUnit).toEqual(expect.objectContaining({ name: '1 cup sliced', grams: 109 }));
   });
 });

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
@@ -12,15 +12,20 @@ import {
   MenuItem,
   Select,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
-} from "@mui/material";
+} from '@mui/material';
 
-import type { IngredientSource, UsdaIngredientResult, UsdaIngredientUnit } from "./useIngredientForm";
-import { formatNutritionValue } from "@/utils/nutritionPrecision";
+import type {
+  IngredientSource,
+  UsdaIngredientResult,
+  UsdaIngredientUnit,
+} from './useIngredientForm';
+import { formatNutritionValue } from '@/utils/nutritionPrecision';
 
-
-const createUsdaUnitKey = (unit: Pick<UsdaIngredientUnit, "id" | "name" | "grams">): string => {
-  if (unit.id !== null && unit.id !== undefined && String(unit.id).trim() !== "") {
+const createUsdaUnitKey = (unit: Pick<UsdaIngredientUnit, 'id' | 'name' | 'grams'>): string => {
+  if (unit.id !== null && unit.id !== undefined && String(unit.id).trim() !== '') {
     return `id:${String(unit.id)}`;
   }
 
@@ -35,12 +40,12 @@ const mapUsdaUnits = (value: unknown): UsdaIngredientUnit[] => {
   const seen = new Set<string>();
 
   return value.reduce<UsdaIngredientUnit[]>((acc, unit) => {
-    if (!unit || typeof unit !== "object") {
+    if (!unit || typeof unit !== 'object') {
       return acc;
     }
 
     const rawUnit = unit as Record<string, unknown>;
-    const name = String(rawUnit.name ?? "").trim();
+    const name = String(rawUnit.name ?? '').trim();
     const grams = Number(rawUnit.grams);
 
     if (!name || !Number.isFinite(grams) || grams <= 0) {
@@ -76,7 +81,7 @@ const getDefaultUnitLabel = (result: UsdaIngredientResult): string => {
     result.units[0] ??
     null;
 
-  return defaultUnit?.name ?? "1 g";
+  return defaultUnit?.name ?? '1 g';
 };
 
 const normalizeNutritionValue = (value: unknown): number => {
@@ -90,13 +95,16 @@ const normalizeMetadataNumber = (value: unknown): number | null => {
 };
 
 const mapUsdaResult = (item: Record<string, unknown>): UsdaIngredientResult | null => {
-  const name = String(item.name ?? item.description ?? item.label ?? "").trim();
+  const name = String(item.name ?? item.description ?? item.label ?? '').trim();
   if (!name) {
     return null;
   }
 
   const idValue = item.id ?? item.fdcId ?? item.foodId ?? item.food_id ?? name;
-  const nutritionSource = (item.nutrition ?? item.nutrients ?? null) as Record<string, unknown> | null;
+  const nutritionSource = (item.nutrition ?? item.nutrients ?? null) as Record<
+    string,
+    unknown
+  > | null;
   const normalizationSource = (item.normalization ?? {}) as Record<string, unknown>;
   const canNormalize = Boolean(normalizationSource.can_normalize);
   const units = mapUsdaUnits(item.units);
@@ -108,15 +116,18 @@ const mapUsdaResult = (item: Record<string, unknown>): UsdaIngredientResult | nu
       ? {
           calories: normalizeNutritionValue(nutritionSource.calories ?? nutritionSource.energy),
           protein: normalizeNutritionValue(nutritionSource.protein),
-          carbohydrates: normalizeNutritionValue(nutritionSource.carbohydrates ?? nutritionSource.carbs),
+          carbohydrates: normalizeNutritionValue(
+            nutritionSource.carbohydrates ?? nutritionSource.carbs,
+          ),
           fat: normalizeNutritionValue(nutritionSource.fat),
           fiber: normalizeNutritionValue(nutritionSource.fiber),
         }
       : null,
     normalization: {
-      source_basis: String(normalizationSource.source_basis ?? "unknown"),
+      source_basis: String(normalizationSource.source_basis ?? 'unknown'),
       normalized_basis:
-        normalizationSource.normalized_basis === null || normalizationSource.normalized_basis === undefined
+        normalizationSource.normalized_basis === null ||
+        normalizationSource.normalized_basis === undefined
           ? null
           : String(normalizationSource.normalized_basis),
       can_normalize: canNormalize,
@@ -130,11 +141,13 @@ const mapUsdaResult = (item: Record<string, unknown>): UsdaIngredientResult | nu
           : String(normalizationSource.data_type),
       serving_size: normalizeMetadataNumber(normalizationSource.serving_size),
       serving_size_unit:
-        normalizationSource.serving_size_unit === null || normalizationSource.serving_size_unit === undefined
+        normalizationSource.serving_size_unit === null ||
+        normalizationSource.serving_size_unit === undefined
           ? null
           : String(normalizationSource.serving_size_unit),
       household_serving_full_text:
-        normalizationSource.household_serving_full_text === null || normalizationSource.household_serving_full_text === undefined
+        normalizationSource.household_serving_full_text === null ||
+        normalizationSource.household_serving_full_text === undefined
           ? null
           : String(normalizationSource.household_serving_full_text),
     },
@@ -147,7 +160,7 @@ const normalizeResults = (data: unknown): UsdaIngredientResult[] => {
   if (Array.isArray(data)) {
     return data
       .map((item) => {
-        if (item && typeof item === "object") {
+        if (item && typeof item === 'object') {
           return mapUsdaResult(item as Record<string, unknown>);
         }
         return null;
@@ -155,7 +168,7 @@ const normalizeResults = (data: unknown): UsdaIngredientResult[] => {
       .filter((result): result is UsdaIngredientResult => Boolean(result));
   }
 
-  if (data && typeof data === "object") {
+  if (data && typeof data === 'object') {
     const possibleResults = (data as { results?: unknown; foods?: unknown }).results;
     const foodsResults = (data as { foods?: unknown }).foods;
     if (possibleResults) {
@@ -169,9 +182,22 @@ const normalizeResults = (data: unknown): UsdaIngredientResult[] => {
   return [];
 };
 
+type USDADataType = 'Foundation' | 'SR Legacy' | 'Survey (FNDDS)' | 'Branded' | 'Experimental';
+
+const USDA_DATA_TYPE_OPTIONS: Array<{ value: USDADataType; label: string }> = [
+  { value: 'Foundation', label: 'Foundation (primary / most current USDA data)' },
+  { value: 'SR Legacy', label: 'SR Legacy' },
+  { value: 'Survey (FNDDS)', label: 'Survey (FNDDS)' },
+  { value: 'Branded', label: 'Branded' },
+  { value: 'Experimental', label: 'Experimental' },
+];
+
+const DEFAULT_USDA_DATA_TYPES: USDADataType[] = ['Foundation'];
+
 const formatNutritionSummary = (result: UsdaIngredientResult): string => {
   if (!result.normalization.can_normalize || !result.nutrition) {
-    const reason = result.normalization.reason ?? "USDA basis is not safe to convert to per-gram nutrition.";
+    const reason =
+      result.normalization.reason ?? 'USDA basis is not safe to convert to per-gram nutrition.';
     return `${reason} Basis: ${result.normalization.source_basis}.`;
   }
 
@@ -179,30 +205,43 @@ const formatNutritionSummary = (result: UsdaIngredientResult): string => {
 };
 
 function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState('');
   const [results, setResults] = useState<UsdaIngredientResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
+  const [selectedDataTypes, setSelectedDataTypes] = useState<USDADataType[]>(() =>
+    ingredient.source === 'usda' ? DEFAULT_USDA_DATA_TYPES : [],
+  );
+  const [hasInitializedUsdaDataTypes, setHasInitializedUsdaDataTypes] = useState(
+    ingredient.source === 'usda',
+  );
 
-  const selectedSource: IngredientSource = ingredient.source ?? "manual";
-  const disabledSearch = selectedSource !== "usda";
+  const selectedSource: IngredientSource = ingredient.source ?? 'manual';
+  const disabledSearch = selectedSource !== 'usda';
 
   const hasResults = results.length > 0;
 
+  useEffect(() => {
+    if (selectedSource === 'usda' && !hasInitializedUsdaDataTypes) {
+      setSelectedDataTypes(DEFAULT_USDA_DATA_TYPES);
+      setHasInitializedUsdaDataTypes(true);
+    }
+  }, [hasInitializedUsdaDataTypes, selectedSource]);
+
   const statusMessage = useMemo(() => {
     if (isSearching) {
-      return "Searching USDA database...";
+      return 'Searching USDA database...';
     }
     if (error) {
       return error;
     }
     if (!query.trim()) {
-      return "Enter a name to search the USDA database.";
+      return 'Enter a name to search the USDA database.';
     }
     if (!hasResults) {
-      return "No USDA matches yet. Try a different search.";
+      return 'No USDA matches yet. Try a different search.';
     }
     return null;
   }, [error, isSearching, query, hasResults]);
@@ -210,14 +249,22 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
   const handleSourceChange = (event) => {
     const value = event.target.value as IngredientSource;
     dispatch({
-      type: "SET_INGREDIENT",
+      type: 'SET_INGREDIENT',
       payload: {
         ...ingredient,
         source: value,
-        source_id: value === "manual" ? null : ingredient.source_id ?? null,
-        sourceName: value === "manual" ? null : ingredient.sourceName ?? null,
+        source_id: value === 'manual' ? null : (ingredient.source_id ?? null),
+        sourceName: value === 'manual' ? null : (ingredient.sourceName ?? null),
       },
     });
+  };
+
+  const handleDataTypeChange = (_event: React.MouseEvent<HTMLElement>, value: USDADataType[]) => {
+    if (value.length === 0) {
+      return;
+    }
+
+    setSelectedDataTypes(value);
   };
 
   const handleSearch = async () => {
@@ -232,15 +279,22 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
     setDetailError(null);
 
     try {
-      const response = await fetch(`/api/usda/search?query=${encodeURIComponent(trimmed)}`);
+      const params = new URLSearchParams({ query: trimmed });
+      const dataTypesForRequest =
+        selectedDataTypes.length > 0 ? selectedDataTypes : DEFAULT_USDA_DATA_TYPES;
+      dataTypesForRequest.forEach((dataType) => {
+        params.append('data_types', dataType);
+      });
+
+      const response = await fetch(`/api/usda/search?${params.toString()}`);
       if (!response.ok) {
-        throw new Error("USDA search failed.");
+        throw new Error('USDA search failed.');
       }
       const data = await response.json();
       setResults(normalizeResults(data));
     } catch (searchError) {
       setResults([]);
-      setError("Unable to load USDA results right now.");
+      setError('Unable to load USDA results right now.');
       // eslint-disable-next-line no-console
       console.error(searchError);
     } finally {
@@ -250,7 +304,9 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
 
   const handleSelectResult = async (result: UsdaIngredientResult) => {
     if (!result.normalization.can_normalize || !result.nutrition) {
-      setDetailError(result.normalization.reason ?? "This USDA item cannot be imported as per-gram nutrition.");
+      setDetailError(
+        result.normalization.reason ?? 'This USDA item cannot be imported as per-gram nutrition.',
+      );
       return;
     }
 
@@ -260,12 +316,12 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
     try {
       const response = await fetch(`/api/usda/foods/${result.id}`);
       if (!response.ok) {
-        throw new Error("USDA detail fetch failed.");
+        throw new Error('USDA detail fetch failed.');
       }
       const data = await response.json();
       const mapped = mapUsdaResult(data);
       if (!mapped) {
-        throw new Error("USDA detail mapping failed.");
+        throw new Error('USDA detail mapping failed.');
       }
 
       const preferredMapped =
@@ -278,14 +334,16 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
             };
 
       if (!preferredMapped.normalization.can_normalize || !preferredMapped.nutrition) {
-        throw new Error(preferredMapped.normalization.reason ?? "USDA detail did not return per-gram nutrition.");
+        throw new Error(
+          preferredMapped.normalization.reason ?? 'USDA detail did not return per-gram nutrition.',
+        );
       }
       applyUsdaResult(preferredMapped);
     } catch (detailFetchError) {
       setDetailError(
         detailFetchError instanceof Error
           ? detailFetchError.message
-          : "Unable to load USDA details. Using search results instead.",
+          : 'Unable to load USDA details. Using search results instead.',
       );
       applyUsdaResult(result);
       // eslint-disable-next-line no-console
@@ -296,38 +354,66 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
   };
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
       <FormControl sx={{ minWidth: 200 }}>
         <InputLabel id="ingredient-source-label">Source</InputLabel>
         <Select
           labelId="ingredient-source-label"
           label="Source"
           value={selectedSource}
-          onChange={handleSourceChange}>
+          onChange={handleSourceChange}
+        >
           <MenuItem value="manual">Manual</MenuItem>
           <MenuItem value="usda">USDA</MenuItem>
         </Select>
       </FormControl>
 
-      {selectedSource === "usda" && (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-          <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
-            <TextField
-              label="Search USDA"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              fullWidth
-            />
-            <Button
-              variant="outlined"
-              onClick={handleSearch}
-              disabled={disabledSearch || isSearching || isLoadingDetail}>
-              Search
-            </Button>
+      {selectedSource === 'usda' && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+              <TextField
+                label="Search USDA"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                fullWidth
+              />
+              <Button
+                variant="outlined"
+                onClick={handleSearch}
+                disabled={disabledSearch || isSearching || isLoadingDetail}
+              >
+                Search
+              </Button>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+              <Typography variant="caption" color="text.secondary">
+                USDA data sets to search. Foundation is the default because it is the USDA primary /
+                most current data set.
+              </Typography>
+              <ToggleButtonGroup
+                value={selectedDataTypes}
+                onChange={handleDataTypeChange}
+                size="small"
+                aria-label="USDA data types"
+                sx={{ flexWrap: 'wrap', justifyContent: 'flex-start', gap: 0.75 }}
+              >
+                {USDA_DATA_TYPE_OPTIONS.map((option) => (
+                  <ToggleButton
+                    key={option.value}
+                    value={option.value}
+                    aria-label={option.label}
+                    sx={{ textTransform: 'none', borderRadius: 1 }}
+                  >
+                    {option.label}
+                  </ToggleButton>
+                ))}
+              </ToggleButtonGroup>
+            </Box>
           </Box>
           {(isSearching || isLoadingDetail) && <CircularProgress size={20} />}
           {statusMessage && (
-            <Typography variant="body2" color={error ? "error" : "text.secondary"}>
+            <Typography variant="body2" color={error ? 'error' : 'text.secondary'}>
               {statusMessage}
             </Typography>
           )}
@@ -342,7 +428,10 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
                 const isSupported = result.normalization.can_normalize && Boolean(result.nutrition);
                 return (
                   <ListItem key={result.id} disablePadding>
-                    <ListItemButton onClick={() => handleSelectResult(result)} disabled={!isSupported}>
+                    <ListItemButton
+                      onClick={() => handleSelectResult(result)}
+                      disabled={!isSupported}
+                    >
                       <ListItemText
                         primary={result.name}
                         secondary={formatNutritionSummary(result)}


### PR DESCRIPTION
### Motivation

- Provide users control over which USDA database groups to search from the ingredient editor while keeping the existing search flow intact.
- Default USDA searches to the primary/current dataset so new USDA selections yield predictable, current results.

### Description

- Added a compact `ToggleButtonGroup` near the existing `Search USDA` field with options for `Foundation`, `SR Legacy`, `Survey (FNDDS)`, `Branded`, and `Experimental` and helper copy calling out `Foundation (primary / most current USDA data)` as the default label. 
- Introduced component state `selectedDataTypes` (and an init guard) so the USDA data-type selection defaults to `Foundation` the first time USDA is chosen and remains unchanged by toggle changes unless the user alters them. 
- When performing a search the component now appends selected `data_types` query params to the `/api/usda/search` request (falling back to `Foundation` if nothing is selected) while preserving the current query and the existing loading/error behavior. 
- USDA-only controls remain hidden when the ingredient `source` is `manual`. 
- Extended `SourceEdit` unit tests to cover the defaulting behavior, preserving the search query when toggles change, and forwarding selected data types to the backend API. 

### Testing

- Ran the focused frontend unit tests with `npm --prefix Frontend test -- SourceEdit.test.tsx`, and all tests passed (`4 tests` passed).
- Ran `npx --yes prettier --write` on the changed files to format the edits without changing behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdf55c380c83229904d91ba8b74ea1)