### PR TITLE
Show USDA dataset labels in SourceEdit and reuse normalization.data_type

### DIFF
--- a/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { act, render, renderHook, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -74,7 +74,7 @@ describe('SourceEdit', () => {
     ).toHaveAttribute('aria-pressed', 'true');
     expect(
       screen.getByText(
-        /foundation is the default because it is the usda primary \/ most current data set/i,
+        /foundation is selected by default because it is the usda’s primary current food-data set for this use case/i,
       ),
     ).toBeInTheDocument();
 
@@ -175,6 +175,7 @@ describe('SourceEdit', () => {
 
     const bananaRow = await screen.findByRole('button', { name: /banana/i });
     expect(bananaRow).toBeEnabled();
+    expect(await screen.findByText(/Foundation \(primary\)/i)).toBeInTheDocument();
     expect(
       await screen.findByText(/1 medium · Calories 0\.89 · Protein 0\.01 · Carbs 0\.23 · Fat 0/i),
     ).toBeInTheDocument();
@@ -204,6 +205,97 @@ describe('SourceEdit', () => {
         }),
       );
     });
+  });
+
+
+  it('renders dataset labels for all supported USDA result types alongside normalization details', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        foods: [
+          {
+            id: 1,
+            name: 'Rolled oats',
+            nutrition: {
+              calories: 3.89,
+              protein: 0.169,
+              carbohydrates: 0.663,
+              fat: 0.069,
+              fiber: 0.106,
+            },
+            normalization: {
+              can_normalize: true,
+              source_basis: 'per_100g',
+              normalized_basis: 'per_g',
+              reason: null,
+              data_type: 'SR Legacy',
+              serving_size: null,
+              serving_size_unit: null,
+              household_serving_full_text: null,
+            },
+            units: [{ name: '1 g', grams: 1, is_default: true }],
+          },
+          {
+            id: 2,
+            name: 'Survey cereal',
+            nutrition: {
+              calories: 3.7,
+              protein: 0.08,
+              carbohydrates: 0.79,
+              fat: 0.02,
+              fiber: 0.05,
+            },
+            normalization: {
+              can_normalize: true,
+              source_basis: 'per_100g',
+              normalized_basis: 'per_g',
+              reason: null,
+              data_type: 'Survey (FNDDS)',
+              serving_size: null,
+              serving_size_unit: null,
+              household_serving_full_text: null,
+            },
+            units: [{ name: '1 g', grams: 1, is_default: true }],
+          },
+          {
+            id: 3,
+            name: 'Protein bar',
+            nutrition: null,
+            normalization: {
+              can_normalize: false,
+              source_basis: 'per_serving',
+              normalized_basis: null,
+              reason: 'Serving-only data cannot be normalized safely.',
+              data_type: 'Branded',
+              serving_size: 50,
+              serving_size_unit: 'g',
+              household_serving_full_text: '1 bar',
+            },
+            units: [{ name: '1 bar', grams: 50, is_default: true }],
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <SourceEdit
+        ingredient={baseIngredient as never}
+        dispatch={vi.fn()}
+        applyUsdaResult={vi.fn()}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText(/search usda/i), 'oats');
+    await userEvent.click(screen.getByRole('button', { name: /search/i }));
+
+    const resultsList = await screen.findByRole('list');
+    expect(within(resultsList).getByText('SR Legacy')).toBeInTheDocument();
+    expect(within(resultsList).getByText('Survey (FNDDS)')).toBeInTheDocument();
+    expect(within(resultsList).getByText('Branded')).toBeInTheDocument();
+    expect(
+      await screen.findByText(/serving-only data cannot be normalized safely/i),
+    ).toBeInTheDocument();
   });
 
   it('disables USDA results that cannot be normalized to per-gram nutrition', async () => {

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
+  Chip,
   CircularProgress,
   FormControl,
   InputLabel,
@@ -22,6 +23,12 @@ import type {
   UsdaIngredientResult,
   UsdaIngredientUnit,
 } from './useIngredientForm';
+import {
+  DEFAULT_USDA_DATA_TYPES,
+  getUsdaDataTypeLabel,
+  USDA_DATA_TYPE_OPTIONS,
+} from './usdaDataTypes';
+import type { USDADataType } from './usdaDataTypes';
 import { formatNutritionValue } from '@/utils/nutritionPrecision';
 
 const createUsdaUnitKey = (unit: Pick<UsdaIngredientUnit, 'id' | 'name' | 'grams'>): string => {
@@ -181,19 +188,6 @@ const normalizeResults = (data: unknown): UsdaIngredientResult[] => {
 
   return [];
 };
-
-type USDADataType = 'Foundation' | 'SR Legacy' | 'Survey (FNDDS)' | 'Branded' | 'Experimental';
-
-const USDA_DATA_TYPE_OPTIONS: Array<{ value: USDADataType; label: string }> = [
-  { value: 'Foundation', label: 'Foundation (primary / most current USDA data)' },
-  { value: 'SR Legacy', label: 'SR Legacy' },
-  { value: 'Survey (FNDDS)', label: 'Survey (FNDDS)' },
-  { value: 'Branded', label: 'Branded' },
-  { value: 'Experimental', label: 'Experimental' },
-];
-
-const DEFAULT_USDA_DATA_TYPES: USDADataType[] = ['Foundation'];
-
 const formatNutritionSummary = (result: UsdaIngredientResult): string => {
   if (!result.normalization.can_normalize || !result.nutrition) {
     const reason =
@@ -388,8 +382,8 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
             </Box>
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
               <Typography variant="caption" color="text.secondary">
-                USDA data sets to search. Foundation is the default because it is the USDA primary /
-                most current data set.
+                Foundation is selected by default because it is the USDA’s primary current food-data
+                set for this use case.
               </Typography>
               <ToggleButtonGroup
                 value={selectedDataTypes}
@@ -433,7 +427,25 @@ function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {
                       disabled={!isSupported}
                     >
                       <ListItemText
-                        primary={result.name}
+                        primary={
+                          <Box
+                            sx={{
+                              display: 'flex',
+                              flexWrap: 'wrap',
+                              alignItems: 'center',
+                              gap: 0.75,
+                            }}
+                          >
+                            <Box component="span">{result.name}</Box>
+                            {getUsdaDataTypeLabel(result.normalization.data_type, 'result') && (
+                              <Chip
+                                size="small"
+                                label={getUsdaDataTypeLabel(result.normalization.data_type, 'result')}
+                                variant="outlined"
+                              />
+                            )}
+                          </Box>
+                        }
                         secondary={formatNutritionSummary(result)}
                       />
                     </ListItemButton>

--- a/Frontend/src/components/data/ingredient/form/usdaDataTypes.ts
+++ b/Frontend/src/components/data/ingredient/form/usdaDataTypes.ts
@@ -1,0 +1,63 @@
+export const USDA_DATA_TYPES = [
+  'Foundation',
+  'SR Legacy',
+  'Survey (FNDDS)',
+  'Branded',
+  'Experimental',
+] as const;
+
+export type USDADataType = (typeof USDA_DATA_TYPES)[number];
+export type UsdaNormalizationDataType = USDADataType | (string & {});
+
+const USDA_DATA_TYPE_LABELS: Record<
+  USDADataType,
+  {
+    filter: string;
+    result: string;
+  }
+> = {
+  Foundation: {
+    filter: 'Foundation (primary / most current USDA data)',
+    result: 'Foundation (primary)',
+  },
+  'SR Legacy': {
+    filter: 'SR Legacy',
+    result: 'SR Legacy',
+  },
+  'Survey (FNDDS)': {
+    filter: 'Survey (FNDDS)',
+    result: 'Survey (FNDDS)',
+  },
+  Branded: {
+    filter: 'Branded',
+    result: 'Branded',
+  },
+  Experimental: {
+    filter: 'Experimental',
+    result: 'Experimental',
+  },
+};
+
+export const USDA_DATA_TYPE_OPTIONS: Array<{ value: USDADataType; label: string }> =
+  USDA_DATA_TYPES.map((value) => ({
+    value,
+    label: USDA_DATA_TYPE_LABELS[value].filter,
+  }));
+
+export const DEFAULT_USDA_DATA_TYPES: USDADataType[] = ['Foundation'];
+
+export const getUsdaDataTypeLabel = (
+  dataType: string | null | undefined,
+  variant: 'filter' | 'result' = 'result',
+): string | null => {
+  const normalized = dataType?.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized in USDA_DATA_TYPE_LABELS) {
+    return USDA_DATA_TYPE_LABELS[normalized as USDADataType][variant];
+  }
+
+  return normalized;
+};

--- a/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
+++ b/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
@@ -6,6 +6,8 @@ import { roundNutritionValue } from "@/utils/nutritionPrecision";
 import { generateUUID, handleFetchRequest } from "@/utils/utils";
 import type { components, operations } from "@/api-types";
 
+import type { UsdaNormalizationDataType } from "./usdaDataTypes";
+
 type IngredientRead = components["schemas"]["IngredientRead"];
 type IngredientUnitUpdate = components["schemas"]["IngredientUnitUpdate"];
 type IngredientUnitCreate = components["schemas"]["IngredientUnitCreate"];
@@ -36,7 +38,7 @@ export type UsdaIngredientResult = {
     normalized_basis: string | null;
     can_normalize: boolean;
     reason: string | null;
-    data_type: string | null;
+    data_type: UsdaNormalizationDataType | null;
     serving_size: number | null;
     serving_size_unit: string | null;
     household_serving_full_text: string | null;


### PR DESCRIPTION
### Motivation
- Surface the USDA dataset associated with each search result so users can see which USDA collection a food comes from. 
- Reuse the already-mapped `normalization.data_type` value from `mapUsdaResult` so dataset labeling is consistent with normalization metadata. 
- Provide a clearer Foundation label and a short helper line next to the dataset toggles to explain why Foundation is the default. 
- Preserve existing normalization warnings for unsupported results while augmenting them with dataset labels.

### Description
- Add a shared helper module `usdaDataTypes.ts` containing canonical USDA data type constants, option labels for the toggles, the default selection, and a `getUsdaDataTypeLabel` helper for filter/result label variants. 
- Update the `UsdaIngredientResult` typing in `useIngredientForm.ts` so `normalization.data_type` uses the new `UsdaNormalizationDataType` type alias. 
- Update `SourceEdit.tsx` to import the shared `USDA_DATA_TYPE_OPTIONS`, `DEFAULT_USDA_DATA_TYPES`, and `getUsdaDataTypeLabel`, change the helper copy near the toggles to the new wording, and render a small `Chip` next to each result name showing the dataset label derived from `normalization.data_type`. 
- Keep the existing normalization-based enabling/disabling and warning text for results that cannot be normalized; the dataset chip complements rather than replaces those messages. 
- Extend `SourceEdit` unit tests to cover the new helper copy, Foundation result label, and dataset-label rendering for `SR Legacy`, `Survey (FNDDS)`, and `Branded` entries.

### Testing
- Ran the focused unit tests with `npm --prefix Frontend test -- --run src/components/data/ingredient/form/SourceEdit.test.tsx`, which passed (5 tests, 5 passed). 
- Ran linting for the modified files with `npm --prefix Frontend run lint -- src/components/data/ingredient/form/SourceEdit.tsx src/components/data/ingredient/form/SourceEdit.test.tsx src/components/data/ingredient/form/useIngredientForm.ts src/components/data/ingredient/form/usdaDataTypes.ts`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdf6a2aa9083229c48d38ae6e61e69)