### PR TITLE
Improve E2E test cleanup and make repo worktree parsing robust

### DIFF
--- a/Backend/tests/test_e2e_api.py
+++ b/Backend/tests/test_e2e_api.py
@@ -46,49 +46,63 @@ class TestIngredientRoutes:
             "units": [{"name": "100g", "grams": 100}],
         }
 
-        # Create
-        resp = httpx.post(f"{BASE_URL}/ingredients/", json=create_payload)
-        assert (
-            resp.status_code == 201
-        ), f"create ingredient expected 201, got {resp.status_code}: {resp.text}"
-        ingredient = resp.json()
-        ingredient_id = ingredient["id"]
-        assert (
-            ingredient["name"] == unique_ing_name
-        ), "created ingredient name should match request"
-        _ok(f"Created ingredient '{unique_ing_name}' with id={ingredient_id}")
+        ingredient_id: int | None = None
+        try:
+            # Create
+            resp = httpx.post(f"{BASE_URL}/ingredients/", json=create_payload)
+            assert (
+                resp.status_code == 201
+            ), f"create ingredient expected 201, got {resp.status_code}: {resp.text}"
+            ingredient = resp.json()
+            ingredient_id = ingredient["id"]
+            assert (
+                ingredient["name"] == unique_ing_name
+            ), "created ingredient name should match request"
+            _ok(f"Created ingredient '{unique_ing_name}' with id={ingredient_id}")
 
-        # Read
-        resp = httpx.get(f"{BASE_URL}/ingredients/{ingredient_id}")
-        assert (
-            resp.status_code == 200
-        ), f"read ingredient expected 200, got {resp.status_code}: {resp.text}"
-        assert (
-            resp.json()["name"] == unique_ing_name
-        ), "fetched ingredient name should equal created name"
-        _ok("Fetched ingredient by id with expected name")
+            # Read
+            resp = httpx.get(f"{BASE_URL}/ingredients/{ingredient_id}")
+            assert (
+                resp.status_code == 200
+            ), f"read ingredient expected 200, got {resp.status_code}: {resp.text}"
+            assert (
+                resp.json()["name"] == unique_ing_name
+            ), "fetched ingredient name should equal created name"
+            _ok("Fetched ingredient by id with expected name")
 
-        # Update
-        updated_ing_name = f"{unique_ing_name}_updated"
-        update_payload = create_payload | {"name": updated_ing_name}
-        resp = httpx.put(f"{BASE_URL}/ingredients/{ingredient_id}", json=update_payload)
-        assert (
-            resp.status_code == 200
-        ), f"update ingredient expected 200, got {resp.status_code}: {resp.text}"
-        assert (
-            resp.json()["name"] == updated_ing_name
-        ), "updated ingredient name should be persisted"
-        _ok("Updated ingredient name persisted")
+            # Update
+            updated_ing_name = f"{unique_ing_name}_updated"
+            update_payload = create_payload | {"name": updated_ing_name}
+            resp = httpx.put(
+                f"{BASE_URL}/ingredients/{ingredient_id}", json=update_payload
+            )
+            assert (
+                resp.status_code == 200
+            ), f"update ingredient expected 200, got {resp.status_code}: {resp.text}"
+            assert (
+                resp.json()["name"] == updated_ing_name
+            ), "updated ingredient name should be persisted"
+            _ok("Updated ingredient name persisted")
 
-        # Delete
-        resp = httpx.delete(f"{BASE_URL}/ingredients/{ingredient_id}")
-        assert (
-            resp.status_code == 200
-        ), f"delete ingredient expected 200, got {resp.status_code}: {resp.text}"
-        assert (
-            resp.json()["message"] == "Ingredient deleted successfully"
-        ), "delete response should include success message"
-        _ok("Deleted ingredient successfully")
+            # Delete
+            resp = httpx.delete(f"{BASE_URL}/ingredients/{ingredient_id}")
+            assert (
+                resp.status_code == 200
+            ), f"delete ingredient expected 200, got {resp.status_code}: {resp.text}"
+            assert (
+                resp.json()["message"] == "Ingredient deleted successfully"
+            ), "delete response should include success message"
+            _ok("Deleted ingredient successfully")
+
+            resp = httpx.get(f"{BASE_URL}/ingredients/{ingredient_id}")
+            assert (
+                resp.status_code == 404
+            ), f"fetch after delete expected 404, got {resp.status_code}: {resp.text}"
+            _ok("Deleted ingredient no longer available by id")
+            ingredient_id = None
+        finally:
+            if ingredient_id is not None:
+                httpx.delete(f"{BASE_URL}/ingredients/{ingredient_id}")
 
 
 @pytest.mark.e2e
@@ -101,63 +115,78 @@ class TestFoodRoutes:
             "name": unique_ing_name,
             "units": [{"name": "1 cup", "grams": 100}],
         }
-        resp = httpx.post(f"{BASE_URL}/ingredients/", json=ingredient_payload)
-        assert (
-            resp.status_code == 201
-        ), f"seed ingredient expected 201, got {resp.status_code}: {resp.text}"
-        ingredient_id = resp.json()["id"]
-        _ok(f"Seeded ingredient '{unique_ing_name}' id={ingredient_id}")
+        ingredient_id: int | None = None
+        food_id: int | None = None
+        try:
+            resp = httpx.post(f"{BASE_URL}/ingredients/", json=ingredient_payload)
+            assert (
+                resp.status_code == 201
+            ), f"seed ingredient expected 201, got {resp.status_code}: {resp.text}"
+            ingredient_id = resp.json()["id"]
+            _ok(f"Seeded ingredient '{unique_ing_name}' id={ingredient_id}")
 
-        unique_food_name = f"_test_e2e_food_{uuid4().hex[:8]}"
-        food_payload = {
-            "name": unique_food_name,
-            "ingredients": [{"ingredient_id": ingredient_id, "unit_quantity": 1}],
-        }
+            unique_food_name = f"_test_e2e_food_{uuid4().hex[:8]}"
+            food_payload = {
+                "name": unique_food_name,
+                "ingredients": [{"ingredient_id": ingredient_id, "unit_quantity": 1}],
+            }
 
-        # Create
-        resp = httpx.post(f"{BASE_URL}/foods/", json=food_payload)
-        assert (
-            resp.status_code == 201
-        ), f"create food expected 201, got {resp.status_code}: {resp.text}"
-        food = resp.json()
-        food_id = food["id"]
-        assert (
-            food["name"] == unique_food_name
-        ), "created food name should match request"
-        _ok(f"Created food '{unique_food_name}' with id={food_id}")
+            # Create
+            resp = httpx.post(f"{BASE_URL}/foods/", json=food_payload)
+            assert (
+                resp.status_code == 201
+            ), f"create food expected 201, got {resp.status_code}: {resp.text}"
+            food = resp.json()
+            food_id = food["id"]
+            assert (
+                food["name"] == unique_food_name
+            ), "created food name should match request"
+            _ok(f"Created food '{unique_food_name}' with id={food_id}")
 
-        # Read
-        resp = httpx.get(f"{BASE_URL}/foods/{food_id}")
-        assert (
-            resp.status_code == 200
-        ), f"read food expected 200, got {resp.status_code}: {resp.text}"
-        assert (
-            resp.json()["name"] == unique_food_name
-        ), "fetched food name should equal created name"
-        _ok("Fetched food by id with expected name")
+            # Read
+            resp = httpx.get(f"{BASE_URL}/foods/{food_id}")
+            assert (
+                resp.status_code == 200
+            ), f"read food expected 200, got {resp.status_code}: {resp.text}"
+            assert (
+                resp.json()["name"] == unique_food_name
+            ), "fetched food name should equal created name"
+            _ok("Fetched food by id with expected name")
 
-        # Update
-        updated_food_name = f"{unique_food_name}_updated"
-        update_payload = food_payload | {"name": updated_food_name}
-        resp = httpx.put(f"{BASE_URL}/foods/{food_id}", json=update_payload)
-        assert (
-            resp.status_code == 200
-        ), f"update food expected 200, got {resp.status_code}: {resp.text}"
-        assert (
-            resp.json()["name"] == updated_food_name
-        ), "updated food name should be persisted"
-        _ok("Updated food name persisted")
+            # Update
+            updated_food_name = f"{unique_food_name}_updated"
+            update_payload = food_payload | {"name": updated_food_name}
+            resp = httpx.put(f"{BASE_URL}/foods/{food_id}", json=update_payload)
+            assert (
+                resp.status_code == 200
+            ), f"update food expected 200, got {resp.status_code}: {resp.text}"
+            assert (
+                resp.json()["name"] == updated_food_name
+            ), "updated food name should be persisted"
+            _ok("Updated food name persisted")
 
-        # Delete
-        resp = httpx.delete(f"{BASE_URL}/foods/{food_id}")
-        assert (
-            resp.status_code == 200
-        ), f"delete food expected 200, got {resp.status_code}: {resp.text}"
-        assert (
-            resp.json()["message"] == "Food deleted successfully"
-        ), "delete response should include success message"
-        _ok("Deleted food successfully")
+            # Delete
+            resp = httpx.delete(f"{BASE_URL}/foods/{food_id}")
+            assert (
+                resp.status_code == 200
+            ), f"delete food expected 200, got {resp.status_code}: {resp.text}"
+            assert (
+                resp.json()["message"] == "Food deleted successfully"
+            ), "delete response should include success message"
+            _ok("Deleted food successfully")
 
-        # Clean up ingredient
-        httpx.delete(f"{BASE_URL}/ingredients/{ingredient_id}")
-        _ok("Cleaned up seed ingredient")
+            resp = httpx.get(f"{BASE_URL}/foods/{food_id}")
+            assert (
+                resp.status_code == 404
+            ), f"fetch after delete expected 404, got {resp.status_code}: {resp.text}"
+            _ok("Deleted food no longer available by id")
+            food_id = None
+        finally:
+            if food_id is not None:
+                httpx.delete(f"{BASE_URL}/foods/{food_id}")
+            if ingredient_id is not None:
+                resp = httpx.delete(f"{BASE_URL}/ingredients/{ingredient_id}")
+                assert (
+                    resp.status_code in (200, 404)
+                ), f"cleanup ingredient delete expected 200/404, got {resp.status_code}: {resp.text}"
+                _ok("Cleaned up seed ingredient")

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Nutrition/
   the backend stores a fridge entry and the UI now confirms the save with a toast.
 - Stored items validate their macro data server-side: calories, protein, carbs, fat, and fiber must all be zero or positive values,
   and the API refuses to consume more portions than remain in the fridge.
-- Switch to the Food Logging tab to record consumption against a chosen day. Logging actions emit success or error toasts, and the
-  backend enforces the same non-negative macro rules so contributor tests cover the end-to-end fridge workflow.
+- Switch to the Food Logging tab to record consumption against a chosen day. Logging actions emit success or error toasts, while the
+  backend enforces the same non-negative macro rules. Contributor tests cover this end-to-end fridge workflow.
 
 ---
 

--- a/scripts/repo/check.sh
+++ b/scripts/repo/check.sh
@@ -12,6 +12,9 @@ Runs sync-branches followed by audit-worktrees and container-set auditing. Non-c
 to sync-branches. Use --skip-sync, --skip-audit, or --skip-containers to bypass individual steps.
 
 Options:
+  --skip-sync      Skip the sync-branches step.
+  --skip-audit     Skip the audit-worktrees step.
+  --skip-containers Skip the audit-container-sets step.
   --yes            Answer "yes" to all confirmations in downstream scripts.
 USAGE
 }

--- a/scripts/repo/sync-branches.sh
+++ b/scripts/repo/sync-branches.sh
@@ -234,10 +234,10 @@ load_worktrees() {
       continue
     fi
     case "$line" in
-      worktree[BRANCH SYNC]*)
+      worktree\ *)
         current_wt="${line#worktree }"
         ;;
-      branch[BRANCH SYNC]*)
+      branch\ *)
         current_branch="${line#branch }"
         ;;
       detached)
@@ -246,7 +246,7 @@ load_worktrees() {
       *)
         ;;
     esac
-  done < <(git -C "$repo_root" worktree list --porcelain | tr -d '[BRANCH SYNC]')
+  done < <(git -C "$repo_root" worktree list --porcelain)
   if [[ -n "$current_wt" ]]; then
     WT_PATHS+=("$current_wt")
     WT_BRANCH_REFS+=("$current_branch")


### PR DESCRIPTION
### Motivation
- Ensure end-to-end tests reliably clean up resources and verify deletion behavior to avoid leftover state between runs.
- Make repository helper scripts less brittle when parsing `git worktree` output.
- Small documentation clarity improvement in the `README` describing logging/validation behavior.

### Description
- Wrap ingredient and food CRUD flows in `Backend/tests/test_e2e_api.py` with `try/finally`, track resource ids as `int | None`, and ensure cleanup runs on failure. 
- Add post-delete `GET` assertions that expect `404` to validate resources are actually removed and accept `200`/`404` on cleanup deletes for idempotent teardown.
- Update `scripts/repo/check.sh` usage text to document the `--skip-containers` option. 
- Make `scripts/repo/sync-branches.sh` parsing more robust by matching `worktree ` and `branch ` lines directly and removing the brittle `tr -d '[BRANCH SYNC]'` transformation. 
- Tweak a sentence in `README.md` for clearer phrasing around food logging behavior.

### Testing
- Ran the backend E2E tests in `Backend/tests/test_e2e_api.py` with `pytest` and the modified CRUD flows passed. 
- Executed `bash scripts/repo/check.sh --help` to validate the updated usage text and it exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb0d98b0883228cb4baf07b3d7619)