### PR TITLE
Show USDA search macros in default units

### DIFF
--- a/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
@@ -197,7 +197,9 @@ describe('SourceEdit', () => {
     expect(bananaRow).toBeEnabled();
     expect(await screen.findByText(/Foundation \(primary\)/i)).toBeInTheDocument();
     expect(
-      await screen.findByText(/1 medium · Calories 0\.89 · Protein 0\.01 · Carbs 0\.23 · Fat 0/i),
+      await screen.findByText(
+        /1 medium · Calories 105\.02 · Protein 1\.29 · Carbs 26\.95 · Fat 0\.39/i,
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Per gram/i)).not.toBeInTheDocument();
 

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -82,13 +82,19 @@ const getDefaultUnitKey = (units: UsdaIngredientUnit[]): string | null => {
 };
 
 const getDefaultUnitLabel = (result: UsdaIngredientResult): string => {
+  const defaultUnit = getDefaultUnit(result);
+
+  return defaultUnit?.name ?? '1 g';
+};
+
+const getDefaultUnit = (result: UsdaIngredientResult): UsdaIngredientUnit | null => {
   const defaultUnit =
     result.units.find((unit) => createUsdaUnitKey(unit) === result.defaultUnitKey) ??
     result.units.find((unit) => unit.is_default) ??
     result.units[0] ??
     null;
 
-  return defaultUnit?.name ?? '1 g';
+  return defaultUnit;
 };
 
 const normalizeNutritionValue = (value: unknown): number => {
@@ -195,7 +201,10 @@ const formatNutritionSummary = (result: UsdaIngredientResult): string => {
     return `${reason} Basis: ${result.normalization.source_basis}.`;
   }
 
-  return `${getDefaultUnitLabel(result)} · Calories ${formatNutritionValue(result.nutrition.calories)} · Protein ${formatNutritionValue(result.nutrition.protein)} · Carbs ${formatNutritionValue(result.nutrition.carbohydrates)} · Fat ${formatNutritionValue(result.nutrition.fat)}`;
+  const defaultUnit = getDefaultUnit(result);
+  const multiplier = defaultUnit?.grams ?? 1;
+
+  return `${getDefaultUnitLabel(result)} · Calories ${formatNutritionValue(result.nutrition.calories * multiplier)} · Protein ${formatNutritionValue(result.nutrition.protein * multiplier)} · Carbs ${formatNutritionValue(result.nutrition.carbohydrates * multiplier)} · Fat ${formatNutritionValue(result.nutrition.fat * multiplier)}`;
 };
 
 function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {


### PR DESCRIPTION
### Motivation
- The USDA search results currently show macronutrients as per-gram base values which is less helpful than seeing the values in the USDA default household unit; this change displays the initial macro summary using the USDA default unit instead.
- Preserve existing fallback behavior when a default unit is missing so the UI remains robust for items without household units.

### Description
- Resolve the USDA default unit for a search result and expose a `getDefaultUnit` helper used to find that unit (Frontend/src/components/data/ingredient/form/SourceEdit.tsx).  
- Scale the displayed calories/protein/carbs/fat by the default unit `grams` multiplier in `formatNutritionSummary` instead of showing raw per-gram values (Frontend/src/components/data/ingredient/form/SourceEdit.tsx).  
- Update the `SourceEdit` frontend test to assert the new default-unit macro display for USDA results (Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx).

### Testing
- Ran the focused frontend unit test with `npm --prefix Frontend test -- --run src/components/data/ingredient/form/SourceEdit.test.tsx` and the test file passed (1 test file, 5 tests passed).  
- Executed repository helper checks `bash ./scripts/repo/check.sh` and `bash ./scripts/env/check.sh --fix`, which could not fully complete in this environment due to missing PowerShell / non-executable helper scripts and local worktree state, and therefore reported warnings; these do not affect the unit test outcome.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bebcb7e5e88322a4b01016416bab73)