### PR TITLE
Fix bash workflow script chaining and branch-sync output corruption

### DIFF
--- a/scripts/docker/compose.sh
+++ b/scripts/docker/compose.sh
@@ -33,6 +33,9 @@ fi
 
 cd "$REPO_ROOT"
 
+# Use bash for nested shell entrypoints so Docker workflows do not depend on
+# executable permission metadata being preserved in the checkout.
+
 # --- Helper functions shared across subcommands ---
 
 compose_up() {
@@ -98,7 +101,7 @@ compose_up() {
 
   echo "Applying database migrations..."
   docker compose -p "$proj" exec -T backend python -m alembic upgrade head
-  ./scripts/env/activate-venv.sh
+  bash ./scripts/env/activate-venv.sh
   if [[ "$data_mode" == "prod" ]]; then
     echo "Importing production data..."
     python Database/import_from_csv.py --production

--- a/scripts/repo/check.sh
+++ b/scripts/repo/check.sh
@@ -60,15 +60,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# Invoke child bash entrypoints explicitly so repo workflows still work when
+# executable bits are missing (common on cross-platform checkouts).
 
 if [[ "$SKIP_SYNC" == false ]]; then
-  "$SCRIPT_DIR/sync-branches.sh" "${SYNC_ARGS[@]}"
+  bash "$SCRIPT_DIR/sync-branches.sh" "${SYNC_ARGS[@]}"
 fi
 
 if [[ "$SKIP_AUDIT" == false ]]; then
-  "$SCRIPT_DIR/audit-worktrees.sh"
+  bash "$SCRIPT_DIR/audit-worktrees.sh"
 fi
 
 if [[ "$SKIP_CONTAINERS" == false ]]; then
-  "$SCRIPT_DIR/audit-container-sets.sh" "${CONTAINER_ARGS[@]}"
+  bash "$SCRIPT_DIR/audit-container-sets.sh" "${CONTAINER_ARGS[@]}"
 fi

--- a/scripts/repo/sync-branches.sh
+++ b/scripts/repo/sync-branches.sh
@@ -46,7 +46,7 @@ import os, sys
 print(os.path.abspath(sys.argv[1]))
 PY
     ); then
-      printf '%s[BRANCH SYNC]' "$result"
+      printf '%s\n' "$result"
       return 0
     fi
   elif command -v python >/dev/null 2>&1; then
@@ -55,14 +55,14 @@ import os, sys
 print(os.path.abspath(sys.argv[1]))
 PY
     ); then
-      printf '%s[BRANCH SYNC]' "$result"
+      printf '%s\n' "$result"
       return 0
     fi
   fi
 
   if command -v realpath >/dev/null 2>&1; then
     if result=$(realpath "$path" 2>/dev/null); then
-      printf '%s[BRANCH SYNC]' "$result"
+      printf '%s\n' "$result"
       return 0
     fi
   fi
@@ -72,10 +72,10 @@ PY
   base=$(basename "$path")
   if [[ -d "$dir" ]]; then
     (
-      cd "$dir" 2>/dev/null && printf '%s/%s[BRANCH SYNC]' "$(pwd -P)" "$base"
+      cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$base"
     ) && return 0
   fi
-  printf '%s[BRANCH SYNC]' "$path"
+  printf '%s\n' "$path"
 }
 
 NO_FETCH=false
@@ -92,12 +92,12 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     -* )
-      printf 'Unknown option: %s[BRANCH SYNC][BRANCH SYNC]' "$1" >&2
+      printf 'Unknown option: %s\n' "$1" >&2
       usage >&2
       exit 1
       ;;
     * )
-      printf 'Unexpected argument: %s[BRANCH SYNC][BRANCH SYNC]' "$1" >&2
+      printf 'Unexpected argument: %s\n' "$1" >&2
       usage >&2
       exit 1
       ;;
@@ -113,7 +113,7 @@ source "$ROOT_DIR/scripts/lib/worktree.sh"
 
 repo_root="$(_wt_repo_root)"
 if [[ -z "$repo_root" ]]; then
-  printf '[BRANCH SYNC] Failed to resolve repository root.[BRANCH SYNC]' >&2
+  printf '[BRANCH SYNC] Failed to resolve repository root.\n' >&2
   exit 1
 fi
 repo_root="$(normalize_path "$repo_root")"
@@ -141,7 +141,7 @@ fi
 default_branch="$(_wt_default_branch)"
 info "Default branch: $default_branch"
 
-common_git_dir="$(git -C "$repo_root" rev-parse --git-common-dir | tr -d '[BRANCH SYNC]')"
+common_git_dir="$(git -C "$repo_root" rev-parse --git-common-dir)"
 if [[ "$common_git_dir" != /* && ! "$common_git_dir" =~ ^[A-Za-z]:/ ]]; then
   common_git_dir="$repo_root/$common_git_dir"
 fi
@@ -150,10 +150,10 @@ primary_root="$(cd "$common_git_dir/.." && pwd -P)"
 parent_dir="$(dirname "$primary_root")"
 
 declare -a local_branches=()
-mapfile -t local_branches < <(git -C "$repo_root" for-each-ref --format '%(refname:short)' refs/heads | tr -d '[BRANCH SYNC]' | awk 'NF')
+mapfile -t local_branches < <(git -C "$repo_root" for-each-ref --format '%(refname:short)' refs/heads | awk 'NF')
 
 declare -a remote_branches_raw=()
-mapfile -t remote_branches_raw < <(git -C "$repo_root" for-each-ref --format '%(refname:short)' refs/remotes/origin | tr -d '[BRANCH SYNC]' | awk 'NF')
+mapfile -t remote_branches_raw < <(git -C "$repo_root" for-each-ref --format '%(refname:short)' refs/remotes/origin | awk 'NF')
 
 declare -a remote_branches=()
 for ref in "${remote_branches_raw[@]}"; do
@@ -191,7 +191,7 @@ done
 
 sorted_local_only=()
 if ((${#local_only[@]} > 0)); then
-  mapfile -t sorted_local_only < <(printf '%s[BRANCH SYNC]' "${local_only[@]}" | sort)
+  mapfile -t sorted_local_only < <(printf '%s\n' "${local_only[@]}" | sort)
   info 'Local branches without matching origin branch:'
   for branch in "${sorted_local_only[@]}"; do
     info "  $branch"
@@ -202,7 +202,7 @@ fi
 
 sorted_remote_only=()
 if ((${#remote_only[@]} > 0)); then
-  mapfile -t sorted_remote_only < <(printf '%s[BRANCH SYNC]' "${remote_only[@]}" | sort)
+  mapfile -t sorted_remote_only < <(printf '%s\n' "${remote_only[@]}" | sort)
   info 'Remote branches without local copies:'
   for branch in "${sorted_remote_only[@]}"; do
     info "  $branch"
@@ -401,7 +401,7 @@ for idx in "${!WT_PATHS[@]}"; do
     if [[ -z "${branch_worktree_map[$branch]:-}" ]]; then
       branch_worktree_map["$branch"]="$path_norm"
     else
-      branch_worktree_map["$branch"]+=$'[BRANCH SYNC]'"$path_norm"
+      branch_worktree_map["$branch"]+=$'\n'"$path_norm"
     fi
   fi
 done
@@ -425,7 +425,7 @@ fi
 
 sorted_locals=()
 if ((${#local_branches[@]} > 0)); then
-  mapfile -t sorted_locals < <(printf '%s[BRANCH SYNC]' "${local_branches[@]}" | sort)
+  mapfile -t sorted_locals < <(printf '%s\n' "${local_branches[@]}" | sort)
 fi
 
 for branch in "${sorted_locals[@]}"; do

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -46,6 +46,8 @@ done
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Invoke child bash scripts explicitly so tests do not rely on executable bits.
+
 # Ensure virtual environment is active
 # shellcheck disable=SC1090
 source "$REPO_ROOT/scripts/lib/venv.sh"
@@ -54,7 +56,7 @@ ensure_venv
 # Optional: synchronize OpenAPI + migrations (non-interactive)
 if $RUN_SYNC; then
   echo "Synchronizing API schema and database migrations..."
-  "$REPO_ROOT/scripts/db/sync-api-and-migrations.sh" -y
+  bash "$REPO_ROOT/scripts/db/sync-api-and-migrations.sh" -y
 fi
 
 # Backend tests (exclude e2e by default; use --e2e to include)
@@ -67,5 +69,5 @@ CI=true npm --prefix Frontend test
 
 # Optional end-to-end tests
 if $RUN_E2E; then
-  "$REPO_ROOT/scripts/tests/run-e2e-tests.sh"
+  bash "$REPO_ROOT/scripts/tests/run-e2e-tests.sh"
 fi

--- a/scripts/tests/run-e2e-tests.sh
+++ b/scripts/tests/run-e2e-tests.sh
@@ -38,6 +38,9 @@ source "$REPO_ROOT/scripts/lib/branch-env.sh"
 source "$REPO_ROOT/scripts/lib/compose-utils.sh"
 branch_env_load
 
+# Invoke child bash scripts explicitly so the workflow survives non-executable
+# shell scripts on cross-platform filesystems.
+
 # Ensure the virtual environment is active
 ensure_venv
 
@@ -58,7 +61,7 @@ TEST_PROJECT="$(compose_test_project)"
 ENV_FILE=$(mktemp)
 cleanup_env() { rm -f "$ENV_FILE"; }
 trap cleanup_env EXIT
-COMPOSE_ENV_FILE="$ENV_FILE" ./scripts/docker/compose.sh up type -test data -test
+COMPOSE_ENV_FILE="$ENV_FILE" bash ./scripts/docker/compose.sh up type -test data -test
 # shellcheck disable=SC1090
 source "$ENV_FILE"
 
@@ -72,7 +75,7 @@ deadline=$((SECONDS + 120))
 until is_backend_healthy "$DEV_BACKEND_PORT"; do
   if (( SECONDS >= deadline )); then
     echo "Backend did not become healthy on port ${DEV_BACKEND_PORT} within timeout." >&2
-    ./scripts/docker/compose.sh down type -test || true
+    bash ./scripts/docker/compose.sh down type -test || true
     exit 1
   fi
   sleep 1
@@ -83,7 +86,7 @@ deadline=$((SECONDS + 180))
 until is_frontend_healthy "$DEV_FRONTEND_PORT"; do
   if (( SECONDS >= deadline )); then
     echo "Frontend did not become healthy on port ${DEV_FRONTEND_PORT} within timeout." >&2
-    ./scripts/docker/compose.sh down type -test || true
+    bash ./scripts/docker/compose.sh down type -test || true
     exit 1
   fi
   sleep 1
@@ -105,7 +108,7 @@ ui_exit=$?
 set -e
 
 # Tear down the dedicated TEST stack
-./scripts/docker/compose.sh down type -test
+bash ./scripts/docker/compose.sh down type -test
 
 if [[ $api_exit -ne 0 ]]; then
   exit $api_exit


### PR DESCRIPTION
### Motivation
- Repo tooling failed when executable bits were missing and `sync-branches` produced corrupted path output, breaking `scripts/repo/check.sh` and related workflows.
- Make worktree/branch sync robust and ensure top-level orchestration invokes nested shell entrypoints reliably across platforms and checkouts.

### Description
- Repaired `normalize_path` and other output formatting in `scripts/repo/sync-branches.sh` to emit newline-delimited paths (removed the `[BRANCH SYNC]` inline marker corruption) and fixed multi-worktree aggregation to join entries with `\n`.
- Removed fragile `tr -d '[BRANCH SYNC]'` hacks and normalized `common_git_dir` resolution to avoid malformed paths.
- Made nested script calls explicit by invoking child entrypoints with `bash`, updating `scripts/repo/check.sh`, `scripts/run-tests.sh`, `scripts/tests/run-e2e-tests.sh`, and `scripts/docker/compose.sh` so workflows do not rely on executable permission bits.
- Small change in `scripts/docker/compose.sh` to call `bash ./scripts/env/activate-venv.sh` when bootstrapping the venv inside compose flow.

### Testing
- Ran a syntax check across modified scripts with `bash -n` which completed successfully.
- Executed `bash ./scripts/repo/check.sh --skip-audit --skip-containers --no-fetch --dry-run` and observed expected dry-run output (completed without errors).
- Verified help/entry behavior with `bash ./scripts/run-tests.sh --help` and `bash ./scripts/tests/run-e2e-tests.sh --help` which both returned successfully.
- Backend unit tests previously executed with `pytest` returned `20 passed` (warnings only) during the investigation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee05b0c408322b0d35be6af5535c5)