### PR TITLE
Adjust USDA search result macro display units

### DIFF
--- a/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.test.tsx
@@ -229,6 +229,55 @@ describe('SourceEdit', () => {
     });
   });
 
+  it('falls back to 100 g in USDA search results when the only available default is 1 g', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        foods: [
+          {
+            id: 789,
+            name: 'Apple',
+            nutrition: {
+              calories: 0.52,
+              protein: 0.0003,
+              carbohydrates: 0.14,
+              fat: 0.0002,
+              fiber: 0.024,
+            },
+            normalization: {
+              can_normalize: true,
+              source_basis: 'per_100g',
+              normalized_basis: 'per_g',
+              reason: null,
+              data_type: 'Foundation',
+              serving_size: null,
+              serving_size_unit: null,
+              household_serving_full_text: null,
+            },
+            units: [{ name: '1 g', grams: 1, is_default: true }],
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <SourceEdit
+        ingredient={baseIngredient as never}
+        dispatch={vi.fn()}
+        applyUsdaResult={vi.fn()}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText(/search usda/i), 'apple');
+    await userEvent.click(screen.getByRole('button', { name: /search/i }));
+
+    expect(
+      await screen.findByText(/100 g · Calories 52 · Protein 0\.03 · Carbs 14 · Fat 0\.02/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/1 g · Calories 0\.52/i)).not.toBeInTheDocument();
+  });
+
 
   it('renders dataset labels from normalization.data_type for mixed USDA result rows', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({

--- a/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
+++ b/Frontend/src/components/data/ingredient/form/SourceEdit.tsx
@@ -97,6 +97,34 @@ const getDefaultUnit = (result: UsdaIngredientResult): UsdaIngredientUnit | null
   return defaultUnit;
 };
 
+const getSearchDisplayUnit = (
+  result: UsdaIngredientResult,
+): { label: string; multiplier: number } | null => {
+  const defaultUnit = getDefaultUnit(result);
+  if (defaultUnit && defaultUnit.grams > 1) {
+    return {
+      label: defaultUnit.name,
+      multiplier: defaultUnit.grams,
+    };
+  }
+
+  if (result.normalization.can_normalize && result.normalization.source_basis === 'per_100g') {
+    return {
+      label: '100 g',
+      multiplier: 100,
+    };
+  }
+
+  if (defaultUnit) {
+    return {
+      label: defaultUnit.name,
+      multiplier: defaultUnit.grams,
+    };
+  }
+
+  return null;
+};
+
 const normalizeNutritionValue = (value: unknown): number => {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : 0;
@@ -201,10 +229,11 @@ const formatNutritionSummary = (result: UsdaIngredientResult): string => {
     return `${reason} Basis: ${result.normalization.source_basis}.`;
   }
 
-  const defaultUnit = getDefaultUnit(result);
-  const multiplier = defaultUnit?.grams ?? 1;
+  const searchDisplayUnit = getSearchDisplayUnit(result);
+  const multiplier = searchDisplayUnit?.multiplier ?? 1;
+  const label = searchDisplayUnit?.label ?? getDefaultUnitLabel(result);
 
-  return `${getDefaultUnitLabel(result)} · Calories ${formatNutritionValue(result.nutrition.calories * multiplier)} · Protein ${formatNutritionValue(result.nutrition.protein * multiplier)} · Carbs ${formatNutritionValue(result.nutrition.carbohydrates * multiplier)} · Fat ${formatNutritionValue(result.nutrition.fat * multiplier)}`;
+  return `${label} · Calories ${formatNutritionValue(result.nutrition.calories * multiplier)} · Protein ${formatNutritionValue(result.nutrition.protein * multiplier)} · Carbs ${formatNutritionValue(result.nutrition.carbohydrates * multiplier)} · Fat ${formatNutritionValue(result.nutrition.fat * multiplier)}`;
 };
 
 function SourceEdit({ ingredient, dispatch, applyUsdaResult }) {


### PR DESCRIPTION
## Summary
- update USDA ingredient search result summaries to prefer the USDA default unit when it is larger than 1 g
- fall back to a 100 g summary in search results when the only available default/search unit is 1 g
- add a SourceEdit test covering the 100 g fallback behavior while preserving the stored 1 g unit for import/edit flows

## Testing
- not run (per environment/task constraints)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee33e45888322928b2a63de8c2822)