### PR TITLE
Fix USDA search calorie extraction

### DIFF
--- a/Backend/routes/usda.py
+++ b/Backend/routes/usda.py
@@ -18,6 +18,16 @@ _MACRO_NAMES = {
     "carbohydrate, by difference": "carbohydrates",
     "fiber, total dietary": "fiber",
 }
+_MACRO_NUTRIENT_IDS = {
+    1008: "calories",
+    1003: "protein",
+    1004: "fat",
+    1005: "carbohydrates",
+    1079: "fiber",
+    2047: "calories",
+    2048: "calories",
+}
+_KILOCALORIE_UNITS = {"kcal", "kilocalorie", "kilocalories"}
 _GRAM_UNITS = {"g", "gram", "grams"}
 _MILLILITER_UNITS = {"ml", "milliliter", "milliliters", "mL"}
 _DEFAULT_USDA_DATA_TYPES = ["Foundation"]
@@ -104,12 +114,63 @@ def _extract_nutrient_value(entry: dict[str, Any]) -> float | None:
     return _coerce_float(entry.get("value", entry.get("amount")))
 
 
+def _extract_nutrient_id(entry: dict[str, Any]) -> int | None:
+    nutrient = entry.get("nutrient") or {}
+    for candidate in (entry.get("nutrientId"), nutrient.get("id"), nutrient.get("number")):
+        numeric = _coerce_float(candidate)
+        if numeric is not None:
+            return int(numeric)
+    return None
+
+
+def _extract_nutrient_unit(entry: dict[str, Any]) -> str | None:
+    unit_name = entry.get("unitName")
+    if unit_name:
+        return str(unit_name)
+
+    nutrient = entry.get("nutrient") or {}
+    nutrient_unit = nutrient.get("unitName")
+    if nutrient_unit:
+        return str(nutrient_unit)
+
+    return None
+
+
+def _resolve_macro_name(entry: dict[str, Any]) -> str | None:
+    nutrient_id = _extract_nutrient_id(entry)
+    if nutrient_id in _MACRO_NUTRIENT_IDS:
+        macro_name = _MACRO_NUTRIENT_IDS[nutrient_id]
+        if macro_name != "calories":
+            return macro_name
+
+        unit = _normalize_name(_extract_nutrient_unit(entry))
+        if not unit or unit in _KILOCALORIE_UNITS:
+            return macro_name
+
+    name = _normalize_name(_extract_nutrient_name(entry))
+    if name in _MACRO_NAMES:
+        if name != "energy":
+            return _MACRO_NAMES[name]
+
+        unit = _normalize_name(_extract_nutrient_unit(entry))
+        if not unit or unit in _KILOCALORIE_UNITS:
+            return "calories"
+        return None
+
+    if name.startswith("energy"):
+        unit = _normalize_name(_extract_nutrient_unit(entry))
+        if not unit or unit in _KILOCALORIE_UNITS:
+            return "calories"
+
+    return None
+
+
 def _trim_nutrients(food_nutrients: Iterable[dict[str, Any]]) -> dict[str, float | None]:
     macros: dict[str, float | None] = {value: None for value in _MACRO_NAMES.values()}
     for nutrient in food_nutrients:
-        name = _normalize_name(_extract_nutrient_name(nutrient))
-        if name in _MACRO_NAMES:
-            macros[_MACRO_NAMES[name]] = _extract_nutrient_value(nutrient)
+        macro_name = _resolve_macro_name(nutrient)
+        if macro_name is not None:
+            macros[macro_name] = _extract_nutrient_value(nutrient)
     return macros
 
 

--- a/Backend/tests/test_usda.py
+++ b/Backend/tests/test_usda.py
@@ -191,6 +191,63 @@ def test_trim_food_payload_marks_branded_liquids_as_not_normalizable() -> None:
     }
 
 
+def test_trim_food_payload_uses_usda_energy_variants_for_calories() -> None:
+    payload = _trim_food_payload(
+        {
+            "fdcId": 555,
+            "description": "Apple sample",
+            "dataType": "Foundation",
+            "foodNutrients": [
+                {
+                    "nutrientName": "Energy (Atwater General Factors)",
+                    "value": 52,
+                    "nutrient": {"id": 2047, "number": "2047", "unitName": "kcal"},
+                },
+                {
+                    "nutrientName": "Protein",
+                    "value": 0.26,
+                    "nutrient": {"id": 1003, "number": "1003", "unitName": "g"},
+                },
+            ],
+        }
+    )
+
+    assert payload["nutrition"] == pytest.approx(
+        {
+            "calories": 0.52,
+            "protein": 0.0026,
+            "fat": None,
+            "carbohydrates": None,
+            "fiber": None,
+        }
+    )
+
+
+def test_trim_food_payload_ignores_non_kilocalorie_energy_variants() -> None:
+    payload = _trim_food_payload(
+        {
+            "fdcId": 556,
+            "description": "Energy in kilojoules only",
+            "dataType": "Foundation",
+            "foodNutrients": [
+                {
+                    "nutrientName": "Energy",
+                    "value": 210,
+                    "nutrient": {"id": 1062, "number": "1062", "unitName": "kJ"},
+                }
+            ],
+        }
+    )
+
+    assert payload["nutrition"] == {
+        "calories": None,
+        "protein": None,
+        "fat": None,
+        "carbohydrates": None,
+        "fiber": None,
+    }
+
+
 class _MockUsdaResponse:
     def __init__(self, payload):
         self._payload = payload


### PR DESCRIPTION
### Motivation
- Some USDA search results were missing calories because the code only matched nutrient names and treated any "Energy" entry as calories regardless of reported units, which caused values labeled with alternate nutrient identifiers or non-kilocalorie units to be ignored or misinterpreted.

### Description
- Add `_MACRO_NUTRIENT_IDS` and `_KILOCALORIE_UNITS` and implement `_extract_nutrient_id`, `_extract_nutrient_unit`, and `_resolve_macro_name` to resolve macros by nutrient id and to ensure energy is only treated as calories when the unit is kilocalories.
- Replace the previous name-only matching in `_trim_nutrients` with the new `_resolve_macro_name` flow so calories from USDA variants (e.g. Atwater energy entries) are captured and kilojoule-only energy entries are ignored.
- Add tests `test_trim_food_payload_uses_usda_energy_variants_for_calories` and `test_trim_food_payload_ignores_non_kilocalorie_energy_variants` to `Backend/tests/test_usda.py` covering alternate energy labels and non-kcal units.

### Testing
- Ran `pytest Backend/tests/test_usda.py` and all tests passed (`15 passed`).
- Ran `python -m compileall Backend/routes/usda.py` to verify syntax and compilation and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bee5b6556083228550b9ce431338d0)