### PR TITLE
Preserve daily logs when clearing stored food; add regression test and align UI button labels

### DIFF
--- a/Backend/routes/stored_food.py
+++ b/Backend/routes/stored_food.py
@@ -209,6 +209,23 @@ def clear_stored_food(user_id: str = Query(...), db: Session = Depends(get_db)) 
     if not _stored_food_table_available(db):
         return
 
+    stored_food_items = db.exec(
+        select(StoredFood).where(StoredFood.user_id == user_id)
+    ).all()
+
+    for stored_food in stored_food_items:
+        entries = db.exec(
+            select(DailyLogEntry).where(DailyLogEntry.stored_food_id == stored_food.id)
+        ).all()
+        for entry in entries:
+            entry.stored_food_id = None
+            if stored_food.food_id is not None:
+                entry.food_id = stored_food.food_id
+                entry.ingredient_id = None
+            elif stored_food.ingredient_id is not None:
+                entry.ingredient_id = stored_food.ingredient_id
+                entry.food_id = None
+
     statement = delete(StoredFood).where(StoredFood.user_id == user_id)
     db.exec(statement)
     db.commit()

--- a/Backend/tests/test_stored_food.py
+++ b/Backend/tests/test_stored_food.py
@@ -452,3 +452,52 @@ def test_clear_stored_food(client: TestClient, engine) -> None:
             select(StoredFood).where(StoredFood.user_id == "other-user")
         ).all()
         assert len(others) == 1
+
+
+def test_clear_stored_food_preserves_daily_logs(client: TestClient, engine) -> None:
+    with Session(engine) as session:
+        ingredient = _create_ingredient(session, "Lentil Soup")
+
+    payload = {
+        "user_id": "user-clear-stored-logs",
+        "ingredient_id": ingredient.id,
+        "prepared_portions": 2,
+        "per_portion_calories": 190,
+        "per_portion_protein": 11,
+        "per_portion_carbohydrates": 24,
+        "per_portion_fat": 5,
+        "per_portion_fiber": 7,
+    }
+
+    stored_response = client.post("/api/stored_food/", json=payload)
+    assert stored_response.status_code == 201
+    stored_id = stored_response.json()["id"]
+
+    log_response = client.post(
+        "/api/logs/",
+        json={
+            "user_id": payload["user_id"],
+            "log_date": "2024-02-03",
+            "stored_food_id": stored_id,
+            "portions_consumed": 1,
+            "calories": payload["per_portion_calories"],
+            "protein": payload["per_portion_protein"],
+            "carbohydrates": payload["per_portion_carbohydrates"],
+            "fat": payload["per_portion_fat"],
+            "fiber": payload["per_portion_fiber"],
+        },
+    )
+    assert log_response.status_code == 201
+    log_id = log_response.json()["id"]
+
+    clear_response = client.delete(
+        "/api/stored_food/", params={"user_id": payload["user_id"]}
+    )
+    assert clear_response.status_code == 204
+
+    with Session(engine) as session:
+        entry = session.get(DailyLogEntry, log_id)
+        assert entry is not None
+        assert entry.stored_food_id is None
+        assert entry.ingredient_id == ingredient.id
+        assert entry.food_id is None

--- a/Frontend/src/components/cooking/Cooking.tsx
+++ b/Frontend/src/components/cooking/Cooking.tsx
@@ -1292,7 +1292,6 @@ function Cooking() {
                                 <Button
                                   variant="contained"
                                   size="small"
-                                  aria-label={`Mark ${food?.name ?? "food"} complete`}
                                   onClick={() => markItemComplete(item, index)}
                                   disabled={foodCompletionDisabled}
                                 >
@@ -1890,7 +1889,6 @@ function Cooking() {
                         <Button
                             variant="contained"
                             size="small"
-                            aria-label={`Mark ${ingredient?.name ?? "ingredient"} complete`}
                             onClick={() => markItemComplete(item, index)}
                             disabled={
                               !ingredient ||

--- a/Frontend/src/components/logging/Logging.tsx
+++ b/Frontend/src/components/logging/Logging.tsx
@@ -1317,7 +1317,6 @@ function Logging() {
                                     <Button
                                       variant="contained"
                                       size="small"
-                                      aria-label={`Add ${displayName} to log`}
                                       onClick={() => handleLogItem(item)}
                                       disabled={
                                         isDepleted ||
@@ -1331,7 +1330,6 @@ function Logging() {
                                       variant="outlined"
                                       size="small"
                                       color="error"
-                                      aria-label={`Remove stored item ${displayName}`}
                                       onClick={() => handleRemoveStoredItem(item)}
                                       disabled={
                                         removingStoredId === item.id || pendingId === item.id


### PR DESCRIPTION
### Motivation
- Clearing all stored-food rows for a user previously deleted the rows without preserving linked daily log entries, causing loss of references that single-item deletion handled correctly. 
- A regression test was needed to ensure bulk deletion preserves and updates daily-log rows the same way single-item deletion does. 
- UI tests were failing to locate action buttons because their accessible names included dynamic item-specific aria-labels that did not match the visible button text. 

### Description
- Update `Backend/routes/stored_food.py` to iterate the user's `StoredFood` items and, for each, update linked `DailyLogEntry` rows to clear `stored_food_id` and restore `food_id` or `ingredient_id` before performing the bulk delete. (`clear_stored_food` behavior adjusted.)
- Add `test_clear_stored_food_preserves_daily_logs` in `Backend/tests/test_stored_food.py` to cover the bulk-clear case with a linked daily log and assert the log remains with restored ingredient reference.
- Remove item-specific `aria-label` attributes from action buttons in `Frontend/src/components/logging/Logging.tsx` so accessible names match visible labels (`Add to log`, `Remove`).
- Remove item-specific `aria-label` attributes from action buttons in `Frontend/src/components/cooking/Cooking.tsx` so accessible names match the visible `Mark complete` label.

### Testing
- Ran `pytest Backend/tests/test_stored_food.py -q`; result: all tests passed (13 passed, 0 failed).
- Ran full backend test suite `pytest Backend/tests -q`; result: all tests passed (65 passed, 1 skipped).
- Ran the focused frontend suites `CI=1 npx vitest run src/tests/Logging.test.tsx src/tests/Cooking.test.tsx`; result: both suites passed after the UI label adjustments.
- Ran broader frontend test command `CI=1 npm test -- --run`; this still shows an unrelated timeout in an existing `Planning` test and was not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1c7ab2348832290b5af54efc38571)