### PR TITLE
Add immutable production Docker Compose stack and docs

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -1,0 +1,19 @@
+# Immutable image references (pin by digest or immutable release tag)
+BACKEND_IMAGE=ghcr.io/your-org/nutrition-backend:2026.03.27
+FRONTEND_IMAGE=ghcr.io/your-org/nutrition-frontend:2026.03.27
+POSTGRES_IMAGE=postgres:13
+
+# Database container credentials
+POSTGRES_USER=nutrition_user
+POSTGRES_PASSWORD=change-me
+POSTGRES_DB=nutrition
+
+# Backend runtime settings
+DATABASE_URL=postgresql://nutrition_user:change-me@db:5432/nutrition
+USDA_API_KEY=replace-with-real-key
+ALLOW_ORIGINS=https://your-app.example.com
+DB_AUTO_CREATE=false
+
+# Public port mapping
+PROD_BACKEND_PORT=8000
+PROD_FRONTEND_PORT=80

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,9 @@ Other repo utilities:
 
 ## Docker Workflows
 
-Always use the wrapper scripts instead of calling `docker compose` directly; they load branch metadata and enforce the naming scheme.
+### Development entrypoint (default contributor flow)
+
+Always use the wrapper scripts instead of calling `docker compose` directly for day-to-day development; they load branch metadata and enforce the naming scheme.
 
 Start services (choose a seed dataset):
 
@@ -126,6 +128,21 @@ Branch-aware environment variables exported by the wrapper:
 | `DATABASE_URL`       | Branch-local connection string                     |
 
 Multiple branches can run simultaneously because each stack has a unique project name, volume suffix, and port offset.
+
+### Production entrypoint (immutable runtime images)
+
+For production-style deployments, use the root-level `docker-compose.prod.yml` directly:
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+```
+
+Production compose intentionally differs from development compose:
+
+- no source bind mounts (immutable image-only runtime);
+- explicit `restart: unless-stopped` and service healthchecks;
+- only a named PostgreSQL data volume is persisted;
+- runtime configuration comes from `.env.prod` plus required `${VAR:?error}` guards that fail fast when critical variables are missing. Copy `.env.prod.template` to `.env.prod` and fill in real values before deployment.
 
 ---
 
@@ -178,7 +195,7 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
 ### Docker stack management
 
 - `scripts/docker/compose.ps1` / `scripts/docker/compose.sh`
-  - Purpose: orchestrate Docker Compose stacks with branch-specific project names, port offsets, and data seed flows.
+  - Purpose: orchestrate **development** Docker Compose stacks with branch-specific project names, port offsets, and data seed flows (`docker-compose.yml`).
   - Subcommands (common to both shells):
     - `up [type <-dev|-test>] data <-test|-prod> [service...]`
     - `down [type <-dev|-test>]`
@@ -189,6 +206,11 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
     - Writes resolved ports to `$COMPOSE_ENV_FILE` when present so callers (for example the e2e runner) can source them.
     - Ensures migrations run and seed data loads after startup, and provides graceful teardown including volume cleanup.
   - Call graph: loads `scripts/lib/branch-env.*`, `scripts/lib/worktree.sh` (Bash variant), and `scripts/lib/compose-utils.*`; PowerShell also imports `scripts/env/activate-venv.ps1` when applying test data.
+
+- `docker-compose.prod.yml`
+  - Purpose: production runtime stack using prebuilt immutable images only (no host bind mounts).
+  - Entry point: `docker compose --env-file .env.prod -f docker-compose.prod.yml up -d`.
+  - Requirements: `.env.prod` must define critical runtime variables (`BACKEND_IMAGE`, `FRONTEND_IMAGE`, database credentials, `DATABASE_URL`, `USDA_API_KEY`, `ALLOW_ORIGINS`) or Compose exits immediately via `${VAR:?error}` guards.
 
 ### Environment and worktree helpers
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 
 ---
 
+
+## Development vs Production Compose
+
+- `docker-compose.yml` is **development-only**. It builds local images, bind-mounts `Backend/` and `Frontend/`, and enables hot reload for iterative coding.
+- `docker-compose.prod.yml` is **production-focused**. It runs prebuilt immutable images, uses an `env_file` (`.env.prod`), enforces required runtime variables via `${VAR:?error}` checks, and persists only PostgreSQL data in a named volume. Start from `.env.prod.template` when creating the production env file.
+
+Production entrypoint example:
+
+```bash
+docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
+```
+
+Development entrypoint remains the branch-aware wrapper:
+
+```pwsh
+pwsh ./scripts/docker/compose.ps1 up data -test
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md#docker-workflows) for detailed contributor workflows.
+
+---
+
 ## Key Helper Scripts
 
 - `pwsh ./scripts/repo/check.ps1`: fetch latest refs, audit worktrees, flag stale container stacks, and suggest fixes. Bash: `./scripts/repo/check.sh`.
@@ -98,7 +120,8 @@ Nutrition/
 ├── Backend/       # FastAPI app (routes, models, migrations)
 ├── Frontend/      # React app (Vite + Material UI)
 ├── Database/      # CSV seed data and backup scripts
-├── docker-compose.yml
+├── docker-compose.yml      # Development compose (bind mounts + hot reload)
+├── docker-compose.prod.yml # Production compose (immutable images only)
 └── scripts/       # Cross-platform helper scripts
     ├── db/        # Database + OpenAPI utilities
     ├── docker/    # Compose orchestration

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,78 @@
+services:
+  db:
+    image: "${POSTGRES_IMAGE:-postgres:13}"
+    restart: unless-stopped
+    env_file:
+      - .env.prod
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER:?POSTGRES_USER is required}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+      POSTGRES_DB: "${POSTGRES_DB:?POSTGRES_DB is required}"
+    volumes:
+      - dbdata_prod:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - nutrition-net
+
+  backend:
+    image: "${BACKEND_IMAGE:?BACKEND_IMAGE is required (immutable tag)}"
+    restart: unless-stopped
+    env_file:
+      - .env.prod
+    environment:
+      DATABASE_URL: "${DATABASE_URL:?DATABASE_URL is required}"
+      USDA_API_KEY: "${USDA_API_KEY:?USDA_API_KEY is required}"
+      ALLOW_ORIGINS: "${ALLOW_ORIGINS:?ALLOW_ORIGINS is required}"
+      DB_AUTO_CREATE: "${DB_AUTO_CREATE:-false}"
+      ALEMBIC_CONFIG: /app/Backend/alembic.ini
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/openapi.json', timeout=5)",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - nutrition-net
+    ports:
+      - "${PROD_BACKEND_PORT:-8000}:8000"
+    command:
+      ["python", "-m", "uvicorn", "Backend.backend:app", "--host", "0.0.0.0", "--port", "8000"]
+
+  frontend:
+    image: "${FRONTEND_IMAGE:?FRONTEND_IMAGE is required (immutable tag)}"
+    restart: unless-stopped
+    env_file:
+      - .env.prod
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - nutrition-net
+    ports:
+      - "${PROD_FRONTEND_PORT:-80}:80"
+
+volumes:
+  dbdata_prod:
+
+networks:
+  nutrition-net:


### PR DESCRIPTION
### Motivation

- Provide a production-focused compose file that runs prebuilt immutable images and does not mount source code from host paths.
- Ensure a predictable runtime by adding restart policies, explicit healthchecks, and failing fast when required environment variables are missing.
- Persist only the PostgreSQL data volume in production and document the difference between development and production runtime flows.

### Description

- Add `docker-compose.prod.yml` with `db`, `backend`, and `frontend` services that use image-only runtime (no host bind mounts), `restart: unless-stopped`, explicit `healthcheck`s, `env_file: .env.prod`, and `${VAR:?error}` guards for critical runtime variables.
- Add `.env.prod.template` as a starter for required production env values including `BACKEND_IMAGE`, `FRONTEND_IMAGE`, database credentials, `DATABASE_URL`, `USDA_API_KEY`, and public port mappings.
- Use a single named volume `dbdata_prod` for persistent Postgres data and remove any development bind mounts from the production stack; backend command runs Uvicorn without `--reload`.
- Update `README.md` and `CONTRIBUTING.md` to document the dev vs prod entrypoints, note `docker-compose.yml` remains development-focused, and show an example production startup (`docker compose --env-file .env.prod -f docker-compose.prod.yml up -d`).

### Testing

- Parsed `docker-compose.prod.yml` successfully with `python` + `yaml.safe_load`, confirming valid YAML syntax.
- Ran `bash ./scripts/repo/check.sh` which executed but reported an existing worktree audit mismatch in this environment (script ran, returned warnings).
- Attempted `docker compose -f docker-compose.prod.yml config` by copying `.env.prod.template` to `.env.prod`, but the Docker CLI is not available in this environment so the `docker compose` validation could not be executed.
- Attempted PowerShell checks (`pwsh ./scripts/repo/check.ps1`) but PowerShell is not installed in this environment so that step could not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c711bfb9bc8322a503c5c6f69ef250)