### PR TITLE
Refactor Backend Dockerfile for deterministic production builds

### DIFF
--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -1,26 +1,47 @@
-FROM python:3.12-slim
+# syntax=docker/dockerfile:1.7
 
-# Set environment variables
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
+FROM python:3.12.10-slim-bookworm AS base
 
-# Set work directory
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1
+
 WORKDIR /app
 
-# Install build dependencies for psycopg2
-RUN apt-get update && apt-get install -y \
-    gcc \
-    libpq-dev \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies system-wide to ensure modules are available
 COPY Backend/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir --break-system-packages -r /tmp/requirements.txt
+RUN python -m pip install --upgrade pip setuptools wheel \
+    && python -m pip install --no-cache-dir -r /tmp/requirements.txt
 
-# Copy backend source preserving package structure
-COPY Backend/ /app/Backend
-
-# Copy Alembic configuration for database migrations
-## Alembic config now lives within the Backend/ tree and is copied above.
-
+# Development target keeps reload ergonomics and mounts source as a bind volume.
+FROM base AS dev
 CMD ["python", "-m", "uvicorn", "Backend.backend:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+
+FROM base AS prod
+
+ARG APP_UID=10001
+ARG APP_GID=10001
+
+RUN groupadd --gid "${APP_GID}" app \
+    && useradd --create-home --uid "${APP_UID}" --gid app --shell /usr/sbin/nologin app
+
+COPY Backend/ /app/Backend
+RUN chown -R app:app /app
+
+USER app
+
+ENV HOST=0.0.0.0 \
+    PORT=8000 \
+    WEB_CONCURRENCY=2 \
+    GUNICORN_TIMEOUT=60 \
+    GUNICORN_GRACEFUL_TIMEOUT=30 \
+    GUNICORN_KEEPALIVE=5 \
+    LOG_LEVEL=info
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "exec gunicorn Backend.backend:app -k uvicorn.workers.UvicornWorker --bind ${HOST}:${PORT} --workers ${WEB_CONCURRENCY} --timeout ${GUNICORN_TIMEOUT} --graceful-timeout ${GUNICORN_GRACEFUL_TIMEOUT} --keep-alive ${GUNICORN_KEEPALIVE} --access-logfile - --error-logfile - --log-level ${LOG_LEVEL}"]

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -9,3 +9,4 @@ alembic==1.16.4
 sqlmodel>=0.0.21
 pytest==8.4.1
 httpx>=0.24,<1.0
+gunicorn==22.0.0

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,6 +30,13 @@ services:
       ALLOW_ORIGINS: "${ALLOW_ORIGINS:?ALLOW_ORIGINS is required}"
       DB_AUTO_CREATE: "${DB_AUTO_CREATE:-false}"
       ALEMBIC_CONFIG: /app/Backend/alembic.ini
+      HOST: "${HOST:-0.0.0.0}"
+      PORT: "${PORT:-8000}"
+      WEB_CONCURRENCY: "${WEB_CONCURRENCY:-2}"
+      GUNICORN_TIMEOUT: "${GUNICORN_TIMEOUT:-60}"
+      GUNICORN_GRACEFUL_TIMEOUT: "${GUNICORN_GRACEFUL_TIMEOUT:-30}"
+      GUNICORN_KEEPALIVE: "${GUNICORN_KEEPALIVE:-5}"
+      LOG_LEVEL: "${LOG_LEVEL:-info}"
     depends_on:
       db:
         condition: service_healthy
@@ -49,8 +56,6 @@ services:
       - nutrition-net
     ports:
       - "${PROD_BACKEND_PORT:-8000}:8000"
-    command:
-      ["python", "-m", "uvicorn", "Backend.backend:app", "--host", "0.0.0.0", "--port", "8000"]
 
   frontend:
     image: "${FRONTEND_IMAGE:?FRONTEND_IMAGE is required (immutable tag)}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     build:
       context: .
       dockerfile: Backend/Dockerfile
+      target: dev
     environment:
       DATABASE_URL: postgresql://nutrition_user:nutrition_pass@db:5432/nutrition
       WATCHFILES_FORCE_POLLING: "true"
@@ -31,10 +32,8 @@ services:
         condition: service_healthy
     volumes:
       - ${BRANCH_WORKTREE_DIR:-.}/Backend:/app/Backend
-    command: >
-      bash -c "set -eux; python -m pip install --break-system-packages -v -r Backend/requirements.txt;
-      python -m pip show uvicorn;
-      exec python -m uvicorn Backend.backend:app --host 0.0.0.0 --port 8000 --reload"
+    command:
+      ["python", "-m", "uvicorn", "Backend.backend:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     networks:
       - nutrition-net
     ports:


### PR DESCRIPTION
### Motivation
- Ensure production images are deterministic by installing Python dependencies at build time and avoiding runtime `pip install` in compose commands.
- Provide a hardened production runtime that does not run as root and uses a process manager suitable for FastAPI (Gunicorn + Uvicorn workers) with sane defaults.
- Preserve developer ergonomics by keeping a separate `dev` stage with `uvicorn --reload` for local development.

### Description
- Converted `Backend/Dockerfile` to a multi-stage build (`base`, `dev`, `prod`) pinned to `python:3.12.10-slim-bookworm` and moved dependency installation to image build time via `COPY Backend/requirements.txt` and `pip install` in the `base` stage.
- Added a non-root `app` user in the `prod` stage and ensured app files are owned by that user before switching to `USER app`.
- Switched the production `CMD` to run `gunicorn Backend.backend:app -k uvicorn.workers.UvicornWorker` and exposed environment-driven knobs for `HOST`, `PORT`, `WEB_CONCURRENCY`, `GUNICORN_TIMEOUT`, `GUNICORN_GRACEFUL_TIMEOUT`, `GUNICORN_KEEPALIVE`, and `LOG_LEVEL`, with logs going to stdout/stderr.
- Kept a `dev` target that runs `uvicorn ... --reload` and updated `docker-compose.yml` to build the `dev` target and remove the runtime `pip install` step; updated `docker-compose.prod.yml` to provide the new runtime env defaults and to stop overriding the image `CMD` with `uvicorn`.
- Added `gunicorn==22.0.0` to `Backend/requirements.txt`.

### Testing
- Ran `python -m compileall Backend` which completed successfully for the backend source.
- Ran `bash ./scripts/repo/check.sh` which failed due to an unrelated worktree layout mismatch reported by the script.
- Attempted `docker compose -f docker-compose.yml config` / `docker compose -f docker-compose.prod.yml config` but these could not be executed because `docker` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c723b3233483228d9cbb4b51689997)