### PR TITLE
Define same-origin production API routing strategy

### DIFF
--- a/.env.prod.template
+++ b/.env.prod.template
@@ -11,7 +11,8 @@ POSTGRES_DB=nutrition
 # Backend runtime settings
 DATABASE_URL=postgresql://nutrition_user:change-me@db:5432/nutrition
 USDA_API_KEY=replace-with-real-key
-ALLOW_ORIGINS=https://your-app.example.com
+# Comma-separated list (or "*"). For same-origin proxy, keep this to your public frontend origin.
+CORS_ALLOW_ORIGINS=https://your-app.example.com
 DB_AUTO_CREATE=false
 
 # Public port mapping

--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,2 @@
 # USDA FoodData Central API key
 USDA_API_KEY=
-
-# Base URL for the backend API used by the frontend
-VITE_API_BASE_URL=http://localhost:8000

--- a/Backend/settings.py
+++ b/Backend/settings.py
@@ -79,8 +79,10 @@ class Settings:
             os.getenv("DB_AUTO_CREATE"), default=auto_create_default
         )
 
-        # Comma-separated list or "*"
-        origins_raw = os.getenv("CORS_ALLOW_ORIGINS", "*")
+        # Comma-separated list or "*".
+        # Keep ALLOW_ORIGINS as a backward-compatible alias used by older
+        # deployment manifests.
+        origins_raw = os.getenv("CORS_ALLOW_ORIGINS") or os.getenv("ALLOW_ORIGINS", "*")
         if origins_raw.strip() == "*":
             origins = ["*"]
         else:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,29 @@ Production compose intentionally differs from development compose:
 - only a named PostgreSQL data volume is persisted;
 - runtime configuration comes from `.env.prod` plus required `${VAR:?error}` guards that fail fast when critical variables are missing. Copy `.env.prod.template` to `.env.prod` and fill in real values before deployment.
 
+Frontend/API routing convention:
+
+- Production uses a **same-origin** strategy: browser requests hit the frontend origin and nginx forwards `/api/*` to `backend:8000`.
+- Development keeps the Vite proxy in `Frontend/vite.config.ts`; this proxy is dev-only and uses `BACKEND_URL`.
+- Because the app uses relative API paths (`/api/...`), production does not need `VITE_API_BASE_URL` or any runtime-injected frontend API config file.
+
+Recommended `.env.prod` values (defaults shown where applicable):
+
+| Variable | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `BACKEND_IMAGE` | Yes | — | Immutable backend image tag/digest. |
+| `FRONTEND_IMAGE` | Yes | — | Immutable frontend image tag/digest. |
+| `POSTGRES_IMAGE` | No | `postgres:13` | Override only when needed. |
+| `POSTGRES_USER` | Yes | — | DB user for Postgres container init. |
+| `POSTGRES_PASSWORD` | Yes | — | DB password for Postgres container init. |
+| `POSTGRES_DB` | Yes | — | Database name for Postgres container init. |
+| `DATABASE_URL` | Yes | — | Backend SQLAlchemy connection string. |
+| `USDA_API_KEY` | Yes | — | Required for USDA endpoints. |
+| `CORS_ALLOW_ORIGINS` | Yes | — | Comma-separated origins (`https://app.example.com`). Keep this tight in production. |
+| `DB_AUTO_CREATE` | No | `false` | Leave false when running migrations separately. |
+| `PROD_BACKEND_PORT` | No | `8000` | Host-port mapping for backend service. |
+| `PROD_FRONTEND_PORT` | No | `80` | Host-port mapping for frontend service. |
+
 ---
 
 ## Database Utilities
@@ -210,7 +233,7 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
 - `docker-compose.prod.yml`
   - Purpose: production runtime stack using prebuilt immutable images only (no host bind mounts).
   - Entry point: `docker compose --env-file .env.prod -f docker-compose.prod.yml up -d`.
-  - Requirements: `.env.prod` must define critical runtime variables (`BACKEND_IMAGE`, `FRONTEND_IMAGE`, database credentials, `DATABASE_URL`, `USDA_API_KEY`, `ALLOW_ORIGINS`) or Compose exits immediately via `${VAR:?error}` guards.
+  - Requirements: `.env.prod` must define critical runtime variables (`BACKEND_IMAGE`, `FRONTEND_IMAGE`, database credentials, `DATABASE_URL`, `USDA_API_KEY`, `CORS_ALLOW_ORIGINS`) or Compose exits immediately via `${VAR:?error}` guards.
 
 ### Environment and worktree helpers
 

--- a/Frontend/nginx.conf
+++ b/Frontend/nginx.conf
@@ -7,12 +7,14 @@ server {
     try_files $uri $uri/ /index.html;
   }
 
+  # Production strategy: serve frontend + API from one origin.
+  # Forward /api requests to the backend container.
   location /api/ {
     proxy_pass http://backend:8000;
     proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
     proxy_set_header Host $host;
-    proxy_cache_bypass $http_upgrade;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
   }
 }

--- a/Frontend/src/utils/utils.ts
+++ b/Frontend/src/utils/utils.ts
@@ -37,13 +37,6 @@ export const generateUUID = (): string => {
   });
 };
 
-const API_BASE_URL: string = import.meta.env?.VITE_API_BASE_URL || '';
-if (!API_BASE_URL) {
-  console.warn(
-    'VITE_API_BASE_URL is not set. Create a .env file from .env.template.',
-  );
-}
-
 /**
  * Minimal fetch wrapper.
  */
@@ -52,7 +45,7 @@ export const handleFetchRequest = async (
   method: string,
   data: unknown,
 ): Promise<void> => {
-  const endpoint = url.startsWith('http') ? url : `${API_BASE_URL}${url}`;
+  const endpoint = url;
   const response = await fetch(endpoint, {
     method,
     headers: {

--- a/Frontend/src/vite-env.d.ts
+++ b/Frontend/src/vite-env.d.ts
@@ -1,11 +1,8 @@
 /// <reference types="vite/client" />
 
-// Augment env typing for our custom variable
 interface ImportMetaEnv {
-  readonly VITE_API_BASE_URL?: string;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
-

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     port: 3000,
     host: true,
     strictPort: true,
+    // Dev-only API proxy. Production uses nginx same-origin routing.
     proxy: {
       "/api": {
         target: backendUrl,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A full-stack nutrition planning and tracking app built with:
    Copy-Item .env.template .env
    ```
 
-   Then fill in `USDA_API_KEY` and confirm `VITE_API_BASE_URL` in `.env`.
+   Then fill in `USDA_API_KEY`.
 
 4. Activate the developer environment (installs backend dependencies and keeps the virtualenv up to date).
 
@@ -88,6 +88,12 @@ pwsh ./scripts/docker/compose.ps1 up data -test
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md#docker-workflows) for detailed contributor workflows.
+
+### Frontend API routing strategy
+
+- **Production:** frontend and API are served from the same public origin, and nginx forwards `/api/*` to the backend container.
+- **Development:** Vite keeps a dev-only `/api` proxy (configured in `Frontend/vite.config.ts`) and targets `BACKEND_URL` from the frontend container environment.
+- **Environment impact:** the frontend image does not require `VITE_API_BASE_URL` in production because API calls are relative (`/api/...`).
 
 ---
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
     environment:
       DATABASE_URL: "${DATABASE_URL:?DATABASE_URL is required}"
       USDA_API_KEY: "${USDA_API_KEY:?USDA_API_KEY is required}"
-      ALLOW_ORIGINS: "${ALLOW_ORIGINS:?ALLOW_ORIGINS is required}"
+      CORS_ALLOW_ORIGINS: "${CORS_ALLOW_ORIGINS:?CORS_ALLOW_ORIGINS is required}"
       DB_AUTO_CREATE: "${DB_AUTO_CREATE:-false}"
       ALEMBIC_CONFIG: /app/Backend/alembic.ini
       HOST: "${HOST:-0.0.0.0}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,6 @@ services:
     environment:
       CHOKIDAR_USEPOLLING: "true"
       BACKEND_URL: "http://backend:8000"
-      VITE_API_BASE_URL: "${VITE_API_BASE_URL}"
     ports:
         - "${DEV_FRONTEND_PORT:-3000}:3000"
     networks:


### PR DESCRIPTION
### Motivation

- Choose a single clear production pattern for frontend↔API routing to make the frontend image reusable and reduce runtime config complexity. 
- Prefer a same-origin `/api` proxy in production so the browser uses relative API paths and ingress/nginx handles routing and header forwarding. 
- Keep Vite proxy behavior limited to development and tighten CORS handling on the backend for production.

### Description

- Selected same-origin production routing: `Frontend/nginx.conf` now forwards ` /api/*` to the backend and sets standard forwarding headers. 
- Removed runtime dependency on `VITE_API_BASE_URL` by making API requests use relative paths and cleaning the env typing (`Frontend/src/utils/utils.ts`, `Frontend/src/vite-env.d.ts`) and dev compose usage. 
- Kept the Vite proxy for development only and documented that in `Frontend/vite.config.ts` (dev-only comment) and removed the `VITE_API_BASE_URL` injection from `docker-compose.yml`. 
- Aligned env and CORS handling: `Backend/settings.py` now prefers `CORS_ALLOW_ORIGINS` with a backward-compatible fallback to `ALLOW_ORIGINS`; `docker-compose.prod.yml` and `.env.prod.template` updated to require/document `CORS_ALLOW_ORIGINS`; docs in `README.md` and `CONTRIBUTING.md` updated with the routing strategy and required production env vars.

### Testing

- Ran `npm --prefix Frontend run build` which completed successfully. 
- Ran the frontend unit test `npm --prefix Frontend run test -- --run src/tests/DataContext.test.tsx` which passed. 
- Ran `bash ./scripts/repo/check.sh` which reported a pre-existing worktree location mismatch in this environment (unrelated to these functional changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7254c56008322beeb43a93170ce51)