### PR TITLE
Fix frontend lint failure in vite-env typings

### DIFF
--- a/Frontend/src/vite-env.d.ts
+++ b/Frontend/src/vite-env.d.ts
@@ -1,8 +1,1 @@
 /// <reference types="vite/client" />
-
-interface ImportMetaEnv {
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}


### PR DESCRIPTION
### Motivation
- ESLint rule `@typescript-eslint/no-empty-object-type` failed on an empty `ImportMetaEnv` interface in `Frontend/src/vite-env.d.ts`, causing the frontend lint step to error.

### Description
- Remove the empty `ImportMetaEnv` and `ImportMeta` declarations and keep only the `/// <reference types="vite/client" />` line so ambient Vite types are used.

### Testing
- Ran `npm --prefix Frontend run lint`, which completed successfully with no lint errors.
- Ran `bash ./scripts/repo/check.sh`, which reported a worktree layout audit error (non-zero exit) unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7282656b08322a2673dc7837c2750)