### PR TITLE
Exclude Playwright e2e specs from Vitest discovery

### DIFF
--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: "./src/tests/setupTests.ts",
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
     transformMode: {
       web: [/\.[jt]sx?$/],
     },

--- a/Frontend/vite.config.ts
+++ b/Frontend/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: "./src/tests/setupTests.ts",
-    exclude: ["e2e/**", "node_modules/**", "dist/**"],
+    include: ["src/**/*.{test,spec}.{js,jsx,ts,tsx}"],
     transformMode: {
       web: [/\.[jt]sx?$/],
     },

--- a/Frontend/vitest.config.ts
+++ b/Frontend/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: './src/tests/setupTests.ts',
-    exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
+    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
     transformMode: {
       web: [/\.[jt]sx?$/],
     },

--- a/Frontend/vitest.config.ts
+++ b/Frontend/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: './src/tests/setupTests.ts',
+    exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
     transformMode: {
       web: [/\.[jt]sx?$/],
     },


### PR DESCRIPTION
### Motivation
- Prevent Vitest from attempting to parse Playwright e2e specs under `e2e/**`, which produced Rollup parse errors during test collection.

### Description
- Added `test.exclude: ['e2e/**', 'node_modules/**', 'dist/**']` to `Frontend/vite.config.ts` and `Frontend/vitest.config.ts` so Vitest will ignore Playwright specs and standard build/dependency directories.

### Testing
- Ran `npm --prefix Frontend test -- --run` and the unit/integration suite completed successfully (14 files, 55 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c729f6faf483229c73dca253b2795a)