### PR TITLE
Make production DB lifecycle deterministic with explicit migration flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,15 +89,18 @@ Always use the wrapper scripts instead of calling `docker compose` directly for 
 Start services (choose a seed dataset):
 
 ```pwsh
-pwsh ./scripts/docker/compose.ps1 up data -test     # test fixtures
-pwsh ./scripts/docker/compose.ps1 up data -prod     # production-like fixtures
+pwsh ./scripts/docker/compose.ps1 up data -test     # test fixtures + auto migrations
+pwsh ./scripts/docker/compose.ps1 up data -prod     # production-like startup (no implicit seed)
 ```
 
 Options:
 
 - Add `type -test` to run on the dedicated test ports (`TEST_*`). Useful for end-to-end runs that should not collide with your dev stack.
 - Append service names (e.g. `frontend backend`) to limit which containers start.
-- The script waits for PostgreSQL, ensures the backend dependencies are present, runs Alembic migrations inside the container, then seeds data: `data -test` loads test CSV fixtures; `data -prod` restores the latest branch dump in PowerShell and seeds production CSV fixtures in Bash.
+- The script waits for PostgreSQL and backend dependencies.
+- `data -test` runs migrations then loads test CSV fixtures.
+- `data -prod` intentionally skips migrations/seeding so deployment pipelines can run an explicit migration job before traffic.
+- Run the explicit migration job with `pwsh ./scripts/db/migrate.ps1` (or `./scripts/db/migrate.sh`) during deploy.
 
 Stop services:
 
@@ -183,13 +186,15 @@ Deployment secret checklist:
 All database helpers live under `scripts/db/` and respect the current branch's environment variables. Detailed usage for every script—including call chains and flags—lives in the [Script catalog](#script-catalog--call-graph), but the short list below highlights the most common flows.
 
 - `pwsh ./scripts/db/backup.ps1` / `./scripts/db/backup.sh`
-  Writes `Database/backups/<sanitized>-<timestamp>.dump` plus metadata (Alembic revision, git SHA).
+  Writes `Database/backups/<sanitized>-<timestamp>.dump` plus metadata (Alembic revision, git SHA). Refuses non-local DBs unless `-AllowNonLocalDb` / `--allow-non-local-db` is provided.
+- `pwsh ./scripts/db/migrate.ps1`
+  Explicitly runs `alembic upgrade head` against the running stack. Use this as a one-time deploy job before routing traffic.
 - `pwsh ./scripts/db/restore.ps1 [-ResetSchema] [-UpgradeAfter] [<file>]`
   Restores the most recent dump for the branch or a provided file. `-ResetSchema` drops/recreates the public schema; `-UpgradeAfter` reapplies migrations.
 - `pwsh ./scripts/db/export-to-csv.ps1 [-Production|-Test] [-OutputDir <path>]`
   Writes the current database tables to CSV (defaults to production data). Bash: `./scripts/db/export-to-csv.sh`.
 - `pwsh ./scripts/db/import-from-csv.ps1 [-test|-production]`
-  Loads CSV seed data into the running container; used automatically for `compose.ps1 up data -test`.
+  Loads CSV seed data into the running container; used automatically for `compose.ps1 up data -test`. Production mode requires explicit confirmation flags.
 - `pwsh ./scripts/db/check-migration-drift.ps1`
   Compares the migration state between the database and `Backend/migrations`.
 - `pwsh ./scripts/db/update-api-schema.ps1`
@@ -198,6 +203,19 @@ All database helpers live under `scripts/db/` and respect the current branch's e
   One-stop command: runs Alembic autogenerate, formats new migrations, updates OpenAPI + TS types, runs drift checks, and prompts you to commit generated artifacts.
 
 Most scripts accept Bash equivalents with the same flags.
+
+### Safe deploy sequence (backup, migrate, rollback)
+
+Use this sequence in server deployments to keep schema lifecycle deterministic:
+
+1. **Backup before migration**  
+   `pwsh ./scripts/db/backup.ps1` (or `./scripts/db/backup.sh`).
+2. **Run one explicit migration job (before app traffic)**  
+   `pwsh ./scripts/db/migrate.ps1` (or `./scripts/db/migrate.sh`).
+3. **Start/update app containers**  
+   Use your deploy platform; avoid implicit seeding in production startup.
+4. **Rollback if migration fails post-deploy**  
+   `pwsh ./scripts/db/restore.ps1 -ResetSchema <backup.dump>` (or `./scripts/db/restore.sh --reset-schema <backup.dump>`), then redeploy the previous app version.
 
 ---
 
@@ -234,10 +252,11 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
     - `restart [type <-dev|-test>] data <-test|-prod>`
   - Behavior:
     - `type -test` remaps the dev ports/volumes to the dedicated `TEST_*` values for isolated stacks.
-    - `data -prod` seeds production fixtures. PowerShell restores the latest branch backup via `scripts/db/restore.ps1 -UpgradeAfter`; Bash seeds CSV fixtures via `Database/import_from_csv.py --production`.
+    - `data -test` runs migrations and then loads test fixtures.
+    - `data -prod` skips migrations and fixture import by design; run `scripts/db/migrate.ps1|.sh` explicitly in deployment flows.
     - Writes resolved ports to `$COMPOSE_ENV_FILE` when present so callers (for example the e2e runner) can source them.
-    - Ensures migrations run and seed data loads after startup, and provides graceful teardown including volume cleanup.
-  - Call graph: loads `scripts/lib/branch-env.*`, `scripts/lib/worktree.sh` (Bash variant), and `scripts/lib/compose-utils.*`; PowerShell also imports `scripts/env/activate-venv.ps1` when applying test data.
+    - Provides graceful teardown including volume cleanup.
+  - Call graph: loads `scripts/lib/branch-env.*`, `scripts/lib/worktree.sh` (Bash variant), and `scripts/lib/compose-utils.*`; PowerShell also imports `scripts/env/activate-venv.ps1` for test-fixture startup.
 
 - `docker-compose.prod.yml`
   - Purpose: production runtime stack using prebuilt immutable images only (no host bind mounts).
@@ -280,19 +299,24 @@ The repository keeps Bash and PowerShell twins for every contributor-facing scri
 
 - `scripts/db/backup.ps1` / `scripts/db/backup.sh`
   - Purpose: capture a branch-local Postgres dump and write companion metadata.
-  - Flags: none.
+  - Flags: `-AllowNonLocalDb` / `--allow-non-local-db` to permit non-local DATABASE_URL targets.
   - Call graph: loads `scripts/lib/branch-env.*` and `scripts/lib/compose-utils.*`; PowerShell variant falls back to running pg_dump inside the container when the host CLI is unavailable.
+
+- `scripts/db/migrate.ps1` / `scripts/db/migrate.sh`
+  - Purpose: run `alembic upgrade head` as an explicit migration job.
+  - Flags: `-AllowNonLocalDb` / `--allow-non-local-db` to permit non-local DATABASE_URL targets.
+  - Call graph: loads `scripts/lib/branch-env.*` and `scripts/lib/compose-utils.*`, waits for Alembic availability in the backend container, then runs Alembic in `/app/Backend`.
 
 - `scripts/db/restore.ps1` / `scripts/db/restore.sh`
   - Purpose: restore a custom-format dump into the branch-local database and optionally upgrade afterward.
   - Flags:
-    - PowerShell: `-UpgradeAfter`, `-FailOnMismatch`, `-ResetSchema`, optional positional `DumpPath`.
-    - Bash: `--upgrade-after`, `--fail-on-mismatch`, `--reset-schema`, optional dump file argument, `-h|--help`.
-  - Behavior: auto-selects the newest dump for the current branch (falling back to `main` when necessary), refuses to touch non-localhost databases, can drop/recreate the `public` schema, and compares backup Alembic revision metadata against repo heads.
+    - PowerShell: `-UpgradeAfter`, `-FailOnMismatch`, `-ResetSchema`, `-AllowNonLocalDb`, optional positional `DumpPath`.
+    - Bash: `--upgrade-after`, `--fail-on-mismatch`, `--reset-schema`, `--allow-non-local-db`, optional dump file argument, `-h|--help`.
+  - Behavior: auto-selects the newest dump for the current branch (falling back to `main` when necessary), blocks non-localhost targets unless explicitly allowed, can drop/recreate the `public` schema, and compares backup Alembic revision metadata against repo heads.
 
 - `scripts/db/import-from-csv.ps1` / `scripts/db/import-from-csv.sh`
   - Purpose: load CSV fixtures into the running branch database.
-  - Flags: exactly one of `-production`/`--production` or `-test`/`--test`.
+  - Flags: exactly one of `-production`/`--production` or `-test`/`--test`; production requires `-AllowProductionSeed` / `--allow-production-seed`; non-local DATABASE_URL requires `-AllowNonLocalDb` / `--allow-non-local-db`.
   - Call graph: ensures venv activation and running containers before executing `python Database/import_from_csv.py` with the matching flag.
 
 - `scripts/db/export-to-csv.ps1` / `scripts/db/export-to-csv.sh`

--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ A full-stack nutrition planning and tracking app built with:
    ```pwsh
    pwsh ./scripts/docker/compose.ps1 up data -test
    ```
-  - Replace `-test` with `-prod` to restore the latest branch backup. The compose script calls
-    `restore.ps1` and exits if that step fails (for example, when no dump is available), so rerun the
-    command to relaunch the stack before importing data.
-    When no dump exists yet, reseed manually once the stack is running: `pwsh ./scripts/db/import-from-csv.ps1`
-    (or `./scripts/db/import-from-csv.sh`).
+  - Replace `-test` with `-prod` for production-like startup (no automatic seed or restore).
+    Run migrations explicitly before serving traffic: `pwsh ./scripts/db/migrate.ps1` (or `./scripts/db/migrate.sh`).
+    CSV fixture import remains available for local/test workflows and requires explicit confirmation for production mode.
    - Add `type -test` to run on the dedicated test ports (used by the end-to-end suite).
 
    The script prints the branch-specific ports and waits until the services are ready:
@@ -114,6 +112,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#docker-workflows) for detailed contributor
 - `pwsh ./scripts/switch-worktree-branch.ps1`: fetch remote refs, sync local tracking branches, and create or hop between branch-dedicated worktrees (`-CopyEnv` can copy the current `.env` into the target).
 - `pwsh ./scripts/env/check.ps1 -Fix`: ensure you are inside the correct worktree with an activated virtualenv (Bash variant available).
 - `pwsh ./scripts/docker/compose.ps1 <up|down|restart>`: manage the per-branch Docker stack.
+- `pwsh ./scripts/db/migrate.ps1` / `./scripts/db/migrate.sh`: explicit migration job for deploy pipelines (run before app traffic).
 - `pwsh ./scripts/run-tests.ps1 [-sync] [-e2e]`: run backend + frontend tests with optional API/migration sync and branch-isolated API/browser e2e suites. Bash variant: `./scripts/run-tests.sh`.
 - `pwsh ./scripts/db/backup.ps1` / `restore.ps1`: create or restore branch-local Postgres backups. Bash variants available in the same directory.
 - `pwsh ./scripts/db/export-to-csv.ps1` / `./scripts/db/export-to-csv.sh`: export the current database tables to CSV (production by default, `--test` or `--output-dir` available).

--- a/scripts/db/backup.ps1
+++ b/scripts/db/backup.ps1
@@ -4,7 +4,9 @@
   Falls back to running pg_dump inside the db container if client tools are not on PATH.
 #>
 [CmdletBinding()]
-param()
+param(
+  [switch]$AllowNonLocalDb
+)
 
 $ErrorActionPreference = 'Stop'
 
@@ -15,6 +17,10 @@ Set-Location $envInfo.RepoRoot
 
 # Ensure containers are running for this branch
 Ensure-BranchContainers | Out-Null
+
+if ($env:DATABASE_URL -notmatch 'localhost' -and -not $AllowNonLocalDb) {
+  throw "Refusing to back up non-local database without -AllowNonLocalDb."
+}
 
 $backupDir = Join-Path $envInfo.RepoRoot "Database/backups"
 New-Item -ItemType Directory -Path $backupDir -Force | Out-Null

--- a/scripts/db/backup.sh
+++ b/scripts/db/backup.sh
@@ -2,6 +2,23 @@
 # Create a timestamped PostgreSQL dump for the branch-local database.
 set -euo pipefail
 
+allow_non_local=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-non-local-db) allow_non_local=true ;;
+    -h|--help)
+      echo "Usage: $(basename "$0") [--allow-non-local-db]" >&2
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $(basename "$0") [--allow-non-local-db]" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/branch-env.sh"
 branch_env_load
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/compose-utils.sh"
@@ -9,6 +26,11 @@ cd "$REPO_ROOT"
 
 # Ensure containers are running for this branch
 require_branch_containers
+
+if [[ "$DATABASE_URL" != *"localhost"* && "$allow_non_local" != true ]]; then
+  echo "Refusing to back up non-local database without --allow-non-local-db." >&2
+  exit 1
+fi
 
 mkdir -p Database/backups
 timestamp=$(date +"%Y%m%d-%H%M%S")

--- a/scripts/db/import-from-csv.ps1
+++ b/scripts/db/import-from-csv.ps1
@@ -2,15 +2,22 @@
 [CmdletBinding()]
 param(
   [switch]$production,
-  [switch]$test
+  [switch]$test,
+  [switch]$AllowProductionSeed,
+  [switch]$AllowNonLocalDb
 )
 
 function Show-Usage {
-  Write-Host "Usage: pwsh ./scripts/db/import-from-csv.ps1 -production|-test" -ForegroundColor Yellow
+  Write-Host "Usage: pwsh ./scripts/db/import-from-csv.ps1 -production|-test [-AllowProductionSeed] [-AllowNonLocalDb]" -ForegroundColor Yellow
 }
 
 if (([int]$production + [int]$test) -ne 1) {
   Show-Usage
+  exit 1
+}
+
+if ($production -and -not $AllowProductionSeed) {
+  Write-Error "Refusing production CSV seed without -AllowProductionSeed."
   exit 1
 }
 
@@ -27,5 +34,10 @@ Ensure-Venv
 
 # Ensure containers are running for this branch
 Ensure-BranchContainers | Out-Null
+
+if ($env:DATABASE_URL -notmatch 'localhost' -and -not $AllowNonLocalDb) {
+  Write-Error "Refusing to target non-local database without -AllowNonLocalDb."
+  exit 1
+}
 
 python Database/import_from_csv.py $flag

--- a/scripts/db/import-from-csv.sh
+++ b/scripts/db/import-from-csv.sh
@@ -3,25 +3,39 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $(basename "$0") -production|-test" >&2
+  cat >&2 <<'USAGE'
+Usage: import-from-csv.sh -production|-test [--allow-production-seed] [--allow-non-local-db]
+
+Options:
+  --allow-production-seed  Required when using -production to avoid accidental reseeding.
+  --allow-non-local-db     Required when DATABASE_URL does not target localhost.
+USAGE
   exit 1
 }
 
-if [[ $# -ne 1 ]]; then
+mode=""
+allow_prod_seed=false
+allow_non_local=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -production|--production) mode="production" ;;
+    -test|--test) mode="test" ;;
+    --allow-production-seed) allow_prod_seed=true ;;
+    --allow-non-local-db) allow_non_local=true ;;
+    -h|--help) usage ;;
+    *) usage ;;
+  esac
+  shift
+done
+
+if [[ -z "$mode" ]]; then
   usage
 fi
 
-case "$1" in
-  -production|--production)
-    flag="--production"
-    ;;
-  -test|--test)
-    flag="--test"
-    ;;
-  *)
-    usage
-    ;;
-esac
+if [[ "$mode" == "production" && "$allow_prod_seed" != true ]]; then
+  echo "Refusing production CSV seed without --allow-production-seed." >&2
+  exit 1
+fi
 
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/branch-env.sh"
 branch_env_load
@@ -36,5 +50,14 @@ ensure_venv
 # Ensure containers are running for this branch
 require_branch_containers
 
+if [[ "$DATABASE_URL" != *"localhost"* && "$allow_non_local" != true ]]; then
+  echo "Refusing to target non-local database without --allow-non-local-db." >&2
+  exit 1
+fi
+
 export DEV_DB_PORT
-python Database/import_from_csv.py "$flag"
+if [[ "$mode" == "production" ]]; then
+  python Database/import_from_csv.py --production
+else
+  python Database/import_from_csv.py --test
+fi

--- a/scripts/db/migrate.ps1
+++ b/scripts/db/migrate.ps1
@@ -1,0 +1,40 @@
+<#
+  scripts/db/migrate.ps1
+  Applies Alembic migrations against the running branch-local database.
+#>
+[CmdletBinding()]
+param(
+  [switch]$AllowNonLocalDb
+)
+
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/../lib/branch-env.ps1"
+. "$PSScriptRoot/../lib/compose-utils.ps1"
+$envInfo = Set-BranchEnv
+Set-Location $envInfo.RepoRoot
+
+Ensure-BranchContainers | Out-Null
+
+if ($env:DATABASE_URL -notmatch 'localhost' -and -not $AllowNonLocalDb) {
+  throw "Refusing to migrate non-local database without -AllowNonLocalDb."
+}
+
+Write-Host "Waiting for backend dependencies (alembic) to be ready..."
+$project = $envInfo.Project
+$deadline = (Get-Date).AddMinutes(3)
+do {
+  Start-Sleep -Seconds 1
+  docker compose -p $project exec -T backend sh -lc "python -m pip show alembic >/dev/null 2>&1"
+} until ($LASTEXITCODE -eq 0 -or (Get-Date) -ge $deadline)
+if ($LASTEXITCODE -ne 0) {
+  throw "Backend did not finish installing dependencies (alembic not available) within timeout."
+}
+
+Write-Host "Applying database migrations..."
+docker compose -p $project exec -T backend sh -lc "cd /app/Backend && python -m alembic -c alembic.ini upgrade head"
+if ($LASTEXITCODE -ne 0) {
+  throw "Database migration failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Migrations complete."

--- a/scripts/db/migrate.sh
+++ b/scripts/db/migrate.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Apply Alembic migrations against the running branch-specific stack.
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: migrate.sh [--allow-non-local-db]
+
+Options:
+  --allow-non-local-db  Allow migrations when DATABASE_URL is not localhost.
+USAGE
+}
+
+allow_non_local=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-non-local-db) allow_non_local=true ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 1 ;;
+  esac
+  shift
+done
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/branch-env.sh"
+branch_env_load
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/compose-utils.sh"
+cd "$REPO_ROOT"
+
+require_branch_containers
+
+if [[ "$DATABASE_URL" != *"localhost"* && "$allow_non_local" != true ]]; then
+  echo "Refusing to migrate non-local database without --allow-non-local-db." >&2
+  exit 1
+fi
+
+echo "Waiting for backend dependencies (alembic) to be ready..."
+deadline=$((SECONDS + 180))
+until docker compose -p "$COMPOSE_PROJECT" exec -T backend sh -lc 'python -m pip show alembic >/dev/null 2>&1'; do
+  if (( SECONDS >= deadline )); then
+    echo "Backend did not finish installing dependencies (alembic not available) within timeout." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Applying database migrations..."
+docker compose -p "$COMPOSE_PROJECT" exec -T backend sh -lc "cd /app/Backend && python -m alembic -c alembic.ini upgrade head"
+echo "Migrations complete."

--- a/scripts/db/restore.ps1
+++ b/scripts/db/restore.ps1
@@ -11,7 +11,8 @@ param(
   [string]$DumpPath,
   [switch]$UpgradeAfter,
   [switch]$FailOnMismatch,
-  [switch]$ResetSchema
+  [switch]$ResetSchema,
+  [switch]$AllowNonLocalDb
 )
 
 $ErrorActionPreference = 'Stop'
@@ -98,8 +99,8 @@ if (-not (Test-Path $DumpPath)) {
   exit 1
 }
 
-if ($env:DATABASE_URL -notlike "postgresql://*localhost*") {
-  Write-Error "Refusing to restore to non-localhost database"
+if ($env:DATABASE_URL -notmatch "localhost" -and -not $AllowNonLocalDb) {
+  Write-Error "Refusing to restore to non-local database without -AllowNonLocalDb."
   exit 1
 }
 
@@ -188,4 +189,3 @@ if ($UpgradeAfter) {
     }
   }
 }
-

--- a/scripts/db/restore.sh
+++ b/scripts/db/restore.sh
@@ -4,12 +4,13 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<USAGE
-Usage: $(basename "$0") [--upgrade-after] [--fail-on-mismatch] [--reset-schema] [dump_file]
+Usage: $(basename "$0") [--upgrade-after] [--fail-on-mismatch] [--reset-schema] [--allow-non-local-db] [dump_file]
 
 Options:
   --upgrade-after      Run 'alembic -c Backend/alembic.ini upgrade head' after restore
   --fail-on-mismatch   Exit if backup Alembic revision doesn't match repo head(s)
   --reset-schema       Drop and recreate 'public' schema before restore (dev-safe)
+  --allow-non-local-db Allow restores when DATABASE_URL is not localhost
 
 Notes:
   When 'dump_file' is omitted, the script auto-selects the most recent backup for
@@ -21,12 +22,14 @@ USAGE
 upgrade_after=false
 fail_on_mismatch=false
 reset_schema=false
+allow_non_local=false
 args=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --upgrade-after) upgrade_after=true; shift;;
     --fail-on-mismatch) fail_on_mismatch=true; shift;;
     --reset-schema) reset_schema=true; shift;;
+    --allow-non-local-db) allow_non_local=true; shift;;
     -h|--help) usage;;
     --*) echo "Unknown option: $1" >&2; usage;;
     *) args+=("$1"); shift;;
@@ -107,14 +110,10 @@ else
   dump_file="$latest"
 fi
 
-case "$DATABASE_URL" in
-  postgresql://*localhost*|postgres://*localhost*)
-    ;;
-  *)
-    echo "Refusing to restore to non-localhost database" >&2
-    exit 1
-    ;;
-esac
+if [[ "$DATABASE_URL" != *"localhost"* && "$allow_non_local" != true ]]; then
+  echo "Refusing to restore to non-local database without --allow-non-local-db." >&2
+  exit 1
+fi
 
 # Ensure containers are running for this branch
 require_branch_containers

--- a/scripts/docker/compose.ps1
+++ b/scripts/docker/compose.ps1
@@ -94,11 +94,6 @@ function Invoke-Up {
       exit 1
     }
 
-  if ($empty) {
-    Write-Host "Starting with empty database."
-    return
-  }
-
   Write-Host "Waiting for database to be ready..."
   $deadline = (Get-Date).AddMinutes(2)
   do {
@@ -121,15 +116,15 @@ function Invoke-Up {
     exit 1
   }
 
-    & "$PSScriptRoot/../env/activate-venv.ps1"
     if ($dataMode -eq '-prod') {
-      Write-Host "Restoring latest backup dump..."
-      & "$PSScriptRoot/../db/restore.ps1" -UpgradeAfter
-      if ($LASTEXITCODE -ne 0) {
-        Write-Error "Database restore failed with exit code $LASTEXITCODE."
-        exit $LASTEXITCODE
-      }
+      Write-Host "Production-like startup selected."
+      Write-Host "Skipping automatic migrations and CSV seeding."
+      Write-Host "Run an explicit migration job before serving traffic:"
+      Write-Host "  pwsh ./scripts/db/migrate.ps1"
+      Write-Host "If you intentionally need CSV fixtures in production-like environments:"
+      Write-Host "  pwsh ./scripts/db/import-from-csv.ps1 -production -AllowProductionSeed"
     } else {
+      & "$PSScriptRoot/../env/activate-venv.ps1"
       Write-Host "Applying database migrations..."
       # Ensure Alembic resolves relative paths from Backend/ where alembic.ini lives
       docker compose -p $proj exec -T backend sh -lc "cd /app/Backend && python -m alembic -c alembic.ini upgrade head"

--- a/scripts/docker/compose.sh
+++ b/scripts/docker/compose.sh
@@ -99,13 +99,17 @@ compose_up() {
     sleep 1
   done
 
-  echo "Applying database migrations..."
-  docker compose -p "$proj" exec -T backend python -m alembic upgrade head
-  bash ./scripts/env/activate-venv.sh
   if [[ "$data_mode" == "prod" ]]; then
-    echo "Importing production data..."
-    python Database/import_from_csv.py --production
+    echo "Production-like startup selected."
+    echo "Skipping automatic migrations and CSV seeding."
+    echo "Run an explicit migration job before serving traffic:"
+    echo "  ./scripts/db/migrate.sh"
+    echo "If you intentionally need CSV fixtures in production-like environments:"
+    echo "  ./scripts/db/import-from-csv.sh -production --allow-production-seed"
   else
+    echo "Applying database migrations..."
+    docker compose -p "$proj" exec -T backend sh -lc "cd /app/Backend && python -m alembic -c alembic.ini upgrade head"
+    bash ./scripts/env/activate-venv.sh
     echo "Importing test data..."
     python Database/import_from_csv.py --test
   fi


### PR DESCRIPTION
### Motivation
- Prevent accidental data mutations during production startup by separating migrations from CSV seeding and requiring explicit deploy-time migration steps.
- Provide a deterministic, documented backup→migrate→deploy→rollback sequence for server deployments.
- Add safety guardrails to avoid operating on non-local databases or reseeding production fixtures without explicit confirmation.

### Description
- Split migration and seed behavior in the compose wrappers so `data -prod` now starts services but skips automatic migrations and CSV seeding, while `data -test` continues to run migrations and load test fixtures (changes to `scripts/docker/compose.sh` and `scripts/docker/compose.ps1`).
- Add explicit migration job scripts `scripts/db/migrate.sh` and `scripts/db/migrate.ps1` that wait for Alembic readiness and run `alembic upgrade head` inside the backend container for deploy-time execution.
- Harden CSV import and backup/restore scripts: require `--allow-production-seed`/`-AllowProductionSeed` to seed production CSVs, add `--allow-non-local-db`/`-AllowNonLocalDb` flags to opt into non-local `DATABASE_URL` targets, and refuse non-local targets by default (updates to `scripts/db/import-from-csv.*`, `scripts/db/backup.*`, `scripts/db/restore.*`).
- Document the safe deploy sequence and new commands in `README.md` and `CONTRIBUTING.md`, and update the script catalog to reflect the explicit migration job and guardrails.

### Testing
- Ran shell-syntax checks: `bash -n scripts/docker/compose.sh scripts/db/import-from-csv.sh scripts/db/backup.sh scripts/db/restore.sh scripts/db/migrate.sh` which completed successfully.
- Ran repository hygiene check `bash ./scripts/repo/check.sh`, which surfaced an unrelated local worktree mapping issue (branch `work` mapped to `/workspace/Nutrition`) causing that check to fail in this environment; scripts changes themselves validated via the syntax checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7369fa5f4832299c50615b4a2782a)