### PR TITLE
Include /api/health (liveness/readiness) in generated frontend API types

### DIFF
--- a/Frontend/src/api-types.ts
+++ b/Frontend/src/api-types.ts
@@ -186,6 +186,20 @@ export interface paths {
     /** Get Food Details */
     get: operations["get_food_details_api_usda_foods__fdc_id__get"];
   };
+  "/api/health/live": {
+    /**
+     * Liveness
+     * @description Report process liveness for container orchestrators.
+     */
+    get: operations["liveness_api_health_live_get"];
+  };
+  "/api/health/ready": {
+    /**
+     * Readiness
+     * @description Report readiness only when the API can reach the database.
+     */
+    get: operations["readiness_api_health_ready_get"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -1439,6 +1453,38 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Liveness
+   * @description Report process liveness for container orchestrators.
+   */
+  liveness_api_health_live_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: string;
+          };
+        };
+      };
+    };
+  };
+  /**
+   * Readiness
+   * @description Report readiness only when the API can reach the database.
+   */
+  readiness_api_health_ready_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": {
+            [key: string]: string;
+          };
         };
       };
     };


### PR DESCRIPTION
### Motivation
- Align frontend TypeScript API types with the backend OpenAPI which exposes `/api/health/live` and `/api/health/ready`.
- Provide type-safe client usage for the health endpoints used by orchestration and readiness checks.

### Description
- Added `paths` entries for `GET /api/health/live` and `GET /api/health/ready` in `Frontend/src/api-types.ts`.
- Added `operations` typings `liveness_api_health_live_get` and `readiness_api_health_ready_get` returning string-keyed JSON objects in `Frontend/src/api-types.ts`.
- This change updates the generated API types only and does not modify runtime behavior.

### Testing
- Ran `npm --prefix Frontend run lint`, which completed successfully.
- Ran `bash ./scripts/repo/check.sh`, which reported a worktree location mismatch and exited with an error (environment-specific) and is unrelated to the type changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c73ad0e204832287e12305bbd2087f)