### PR TITLE
Escape env var expansion for backend gunicorn command in docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -104,7 +104,7 @@ services:
       [
         "sh",
         "-c",
-        "exec gunicorn Backend.backend:app -k uvicorn.workers.UvicornWorker --bind ${HOST}:${PORT} --workers ${WEB_CONCURRENCY} --timeout ${GUNICORN_TIMEOUT} --graceful-timeout ${GUNICORN_GRACEFUL_TIMEOUT} --keep-alive ${GUNICORN_KEEPALIVE} --access-logfile - --error-logfile - --access-logformat '{\"ts\":\"%(t)s\",\"remote\":\"%(h)s\",\"method\":\"%(m)s\",\"path\":\"%(U)s\",\"query\":\"%(q)s\",\"status\":%(s)s,\"size\":%(B)s,\"referer\":\"%(f)s\",\"agent\":\"%(a)s\",\"request_time_s\":%(D)s}' --log-level ${LOG_LEVEL}",
+        "exec gunicorn Backend.backend:app -k uvicorn.workers.UvicornWorker --bind $${HOST}:$${PORT} --workers $${WEB_CONCURRENCY} --timeout $${GUNICORN_TIMEOUT} --graceful-timeout $${GUNICORN_GRACEFUL_TIMEOUT} --keep-alive $${GUNICORN_KEEPALIVE} --access-logfile - --error-logfile - --access-logformat '{\"ts\":\"%(t)s\",\"remote\":\"%(h)s\",\"method\":\"%(m)s\",\"path\":\"%(U)s\",\"query\":\"%(q)s\",\"status\":%(s)s,\"size\":%(B)s,\"referer\":\"%(f)s\",\"agent\":\"%(a)s\",\"request_time_s\":%(D)s}' --log-level $${LOG_LEVEL}",
       ]
     depends_on:
       db:


### PR DESCRIPTION
### Motivation
- Ensure environment variables in the backend `command` are expanded at container runtime rather than by Compose by passing literal `$` into the container using `$$` escaping.

### Description
- Replaced instances of `${VAR}` with `$${VAR}` in the `backend` service `command` string in `docker-compose.prod.yml` so runtime shell/gunicorn receives the variables intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9dbfa9c4832288401a64b50b4eb8)