### PR TITLE
Normalize shoppingUnitId to null for non-positive values in ingredient payload

### DIFF
--- a/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
+++ b/Frontend/src/components/data/ingredient/form/useIngredientForm.ts
@@ -186,13 +186,15 @@ const buildRequestPayload = (ingredient: IngredientFormState["ingredient"]): Ing
 
   const normalizeShoppingUnitId = (value: unknown): number | null => {
     if (value === null || value === undefined) return null;
-    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value > 0 ? value : null;
+    }
     if (typeof value === "string") {
       const trimmed = value.trim();
       if (trimmed === "") return null;
       const numeric = Number(trimmed);
       if (Number.isFinite(numeric)) {
-        return numeric;
+        return numeric > 0 ? numeric : null;
       }
     }
     return null;


### PR DESCRIPTION
### Motivation
- Prevent sending invalid non-positive shopping unit IDs (0 or negative) in the ingredient request payload by normalizing them to `null` during payload construction.

### Description
- Updated `normalizeShoppingUnitId` in `useIngredientForm.ts` to treat numeric values `<= 0` as `null` and to treat string values that parse to `<= 0` as `null` as well.
- Kept existing behavior of trimming empty strings and preserving positive numeric IDs, and left other payload sanitization logic unchanged.

### Testing
- Ran the TypeScript typecheck and project build (`yarn build`) with no errors.
- Executed unit tests (`yarn test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe63f1f7883228c4375001be215a7)